### PR TITLE
chore(deps): tilfoej Remotes for BFHtheme + BFHllm (v0.8.1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BFHcharts
 Title: SPC Visualization for Healthcare Quality Improvement
-Version: 0.8.0
+Version: 0.8.1
 Authors@R: c(
     person(
       "Johan", "Reventlow",
@@ -46,4 +46,7 @@ Suggests:
     BFHllm,
     digest,
     geomtextpath
+Remotes:
+    johanreventlow/BFHtheme,
+    johanreventlow/BFHllm
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# BFHcharts 0.8.1
+
+## Bug fixes
+
+* Tilføjet `Remotes:` til `DESCRIPTION` for `BFHtheme` og `BFHllm`. Downstream-
+  pakker (fx biSPCharts) kunne tidligere ikke installere `BFHcharts` via pak
+  uden eksplicit workaround, fordi pak ikke transitivt fandt `BFHtheme`.
+  Fra v0.8.1 er transitiv dep-resolution fixet.
+
 # BFHcharts 0.8.0
 
 ## Breaking changes


### PR DESCRIPTION
## Problem

pak kan ikke transitivt resolve BFHtheme/BFHllm naar BFHcharts selv mangler `Remotes:`-felt. Downstream-pakker (fx biSPCharts) maa arbejde rundt om det.

## Fix

Tilfoej `Remotes: johanreventlow/BFHtheme, johanreventlow/BFHllm` til DESCRIPTION. PATCH-bump (0.8.0 -> 0.8.1).