### PR TITLE
fix(tests): rette 2 pre-existing failures + fjern --no-tests workaround (v0.8.2)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,46 +45,11 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
-      # Pragmatisk konfiguration matcher biSPCharts pilot-pattern:
-      # - --no-tests: 2 kendte pre-existing test-failures (BFHtheme color
-      #   API mismatch + S3 dispatch issue) - haandteres separat
-      # - error-on "error": kun ERRORs blokerer; WARNINGs/NOTEs er synlige
-      #   men non-blocking
-      # CI validerer stadig: NAMESPACE, deps, kompilering, eksempler, vignetter.
+      # Full R CMD check med tests - BFHcharts har ingen kendte test-failures.
+      # error-on "error" lader WARNINGs/NOTEs vaere synlige men non-blocking
+      # (kan strammes til "warning" senere hvis oensket).
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
           error-on: '"error"'
-          args: 'c("--no-manual", "--no-tests")'
-
-  # Separat test-job - synligt men non-blocking indtil 2 test-failures er fixed.
-  testthat:
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      R_KEEP_PKG_SOURCE: yes
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: 'release'
-          use-public-rspm: true
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::testthat
-          needs: check
-
-      - name: Install local package
-        run: R CMD INSTALL .
-        shell: bash
-
-      - name: Run testthat
-        run: |
-          testthat::test_dir("tests/testthat", reporter = "summary", stop_on_failure = FALSE)
-        shell: Rscript {0}
+          args: 'c("--no-manual", "--as-cran")'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BFHcharts
 Title: SPC Visualization for Healthcare Quality Improvement
-Version: 0.8.1
+Version: 0.8.2
 Authors@R: c(
     person(
       "Johan", "Reventlow",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# BFHcharts 0.8.2
+
+## Interne ændringer
+
+* **CI: fuld R CMD check med tests.** Fjernede `--no-tests` workaround fra
+  `R-CMD-check.yaml` efter at to pre-existing test-failures blev rettet:
+  `test-smoke.R:10` brugte udfasede BFHtheme farvenavne
+  (`hospital_grey`/`hospital_dark_grey` → `grey`/`dark_grey`);
+  `test-export_pdf.R:423` forventede forældet fejlbesked-regex efter
+  `bfh_extract_spc_stats()` blev konverteret til S3 generic. CI fanger nu
+  nye test-regressioner.
+
 # BFHcharts 0.8.1
 
 ## Bug fixes

--- a/tests/testthat/test-export_pdf.R
+++ b/tests/testthat/test-export_pdf.R
@@ -419,20 +419,21 @@ test_that("bfh_extract_spc_stats handles missing columns gracefully", {
 })
 
 test_that("bfh_extract_spc_stats validates input type", {
-  # Should error for non-data frame input
+  # Should error for input that is not data.frame or bfh_qic_result
+  # (S3 dispatch via bfh_extract_spc_stats.default)
   expect_error(
     bfh_extract_spc_stats("not a data frame"),
-    "summary must be a data frame or NULL"
+    "must be a data\\.frame.*or a bfh_qic_result"
   )
 
   expect_error(
     bfh_extract_spc_stats(123),
-    "summary must be a data frame or NULL"
+    "must be a data\\.frame.*or a bfh_qic_result"
   )
 
   expect_error(
     bfh_extract_spc_stats(list(a = 1)),
-    "summary must be a data frame or NULL"
+    "must be a data\\.frame.*or a bfh_qic_result"
   )
 })
 

--- a/tests/testthat/test-smoke.R
+++ b/tests/testthat/test-smoke.R
@@ -7,7 +7,7 @@ test_that("Package loads without errors", {
 
 test_that("BFHtheme colors are accessible", {
   # Test that we can get colors from BFHtheme
-  colors <- BFHtheme::bfh_cols("hospital_blue", "hospital_grey", "hospital_dark_grey")
+  colors <- BFHtheme::bfh_cols("hospital_blue", "grey", "dark_grey")
 
   expect_type(colors, "character")
   expect_length(colors, 3)


### PR DESCRIPTION
## Aendringer

1. **Test fixes** (commit `70bb3c2`):
   - `test-smoke.R:10`: opdater `hospital_grey`/`hospital_dark_grey` → `grey`/`dark_grey` (BFHtheme har omdoebt)
   - `test-export_pdf.R:423`: opdater regex efter `bfh_extract_spc_stats` blev konverteret til S3-generic

2. **CI workaround fjernet** (commit `9faca18`):
   - Fjern `--no-tests` fra `R-CMD-check.yaml`
   - Fjern separat `testthat`-job (nu redundant)
   - CI fanger nu test-regressioner

3. **Version bump** (commit `ee2ad01`): 0.8.1 → 0.8.2 (PATCH)

## Verifikation

CI vil koere fuld R CMD check med tests. Hvis groen → de 2 fixes virker og CI er nu arkitektonisk korrekt.