### PR TITLE
docs(readme): add Codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # BFHcharts
 
+[![codecov](https://codecov.io/gh/johanreventlow/BFHcharts/branch/main/graph/badge.svg)](https://codecov.io/gh/johanreventlow/BFHcharts)
+
 > Modern SPC Visualization for Healthcare Quality Improvement
 
 **BFHcharts** is an R package for creating beautiful, publication-ready Statistical Process Control (SPC) charts tailored for healthcare settings. Built on `ggplot2` and `qicharts2`, it provides a consistent visual style inspired by BBC's data journalism approach.


### PR DESCRIPTION
## Summary
- Tilføjer Codecov coverage-badge i README.md, nu hvor `CODECOV_TOKEN` er konfigureret og upload verificeret (issue #151).

## Test plan
- [x] Lokal render — badge-link peger på https://codecov.io/gh/johanreventlow/BFHcharts
- [ ] Visuel verifikation efter merge (GitHub rendering)

Refs #151