### PR TITLE
[codex] Fix centerline details formatting for count values

### DIFF
--- a/R/export_pdf.R
+++ b/R/export_pdf.R
@@ -996,33 +996,63 @@ format_centerline_for_details <- function(cl_value, y_axis_unit) {
   formatted <- switch(y_axis_unit,
     "percent" = {
       # Percentage: multiply by 100 if needed, show 1 decimal
-      if (cl_value <= 1) {
-        sprintf("%.1f%%", cl_value * 100)
-      } else {
-        sprintf("%.1f%%", cl_value)
-      }
+      percent_value <- if (cl_value <= 1) cl_value * 100 else cl_value
+      paste0(
+        format(
+          round(percent_value, 1),
+          big.mark = ".",
+          decimal.mark = ",",
+          nsmall = 1,
+          trim = TRUE,
+          scientific = FALSE
+        ),
+        "%"
+      )
     },
     "rate" = {
       # Rate: typically per 1000 or similar, show 1 decimal
-      sprintf("%.1f", cl_value)
+      format(
+        round(cl_value, 1),
+        big.mark = ".",
+        decimal.mark = ",",
+        nsmall = 1,
+        trim = TRUE,
+        scientific = FALSE
+      )
     },
     "time" = {
       # Time: show as-is with 1 decimal
-      sprintf("%.1f", cl_value)
+      format(
+        round(cl_value, 1),
+        big.mark = ".",
+        decimal.mark = ",",
+        nsmall = 1,
+        trim = TRUE,
+        scientific = FALSE
+      )
     },
     # Default (count and others): show as integer or 1 decimal
     {
       if (cl_value == round(cl_value)) {
-        format(round(cl_value), big.mark = ".", decimal.mark = ",")
+        format(
+          round(cl_value),
+          big.mark = ".",
+          decimal.mark = ",",
+          trim = TRUE,
+          scientific = FALSE
+        )
       } else {
-        format(round(cl_value, 1), big.mark = ".", decimal.mark = ",", nsmall = 1)
+        format(
+          round(cl_value, 1),
+          big.mark = ".",
+          decimal.mark = ",",
+          nsmall = 1,
+          trim = TRUE,
+          scientific = FALSE
+        )
       }
     }
   )
 
-  # Replace . with , for Danish decimal notation (if not already done)
-  formatted <- gsub("\\.", ",", formatted)
-
   sprintf("Nuværende niveau: %s", formatted)
 }
-

--- a/tests/testthat/test-export_pdf.R
+++ b/tests/testthat/test-export_pdf.R
@@ -1319,6 +1319,10 @@ test_that("format_centerline_for_details handles different y_axis_units", {
 
   # Count (integer value)
   expect_match(BFHcharts:::format_centerline_for_details(127, "count"), "127")
+  expect_equal(
+    BFHcharts:::format_centerline_for_details(1234.5, "count"),
+    "Nuværende niveau: 1.234,5"
+  )
 
   # Rate (1 decimal)
   expect_match(BFHcharts:::format_centerline_for_details(5.5, "rate"), "5,5")


### PR DESCRIPTION
## Summary
Fixes the `format_centerline_for_details()` regression where count values with decimals lost their Danish thousands separator in the details text.

Closes #76.

## Root Cause
The formatter first produced count strings with `big.mark = "."` and `decimal.mark = ","`, but then applied a global `gsub("\\.", ",", ...)`. That replaced both decimal dots from `sprintf()` output and the already-correct thousands separator for count values.

## Changes
- removed the global punctuation replacement in `format_centerline_for_details()`
- formatted each `y_axis_unit` branch explicitly with Danish separators
- added a regression test covering `1234.5 -> 1.234,5` for count values

## Impact
Count-based details now preserve `.` as thousands separator while percent/rate/time values still render with Danish decimal commas.

## Validation
- `Rscript -e 'devtools::load_all(".", quiet = TRUE); stopifnot(BFHcharts:::format_centerline_for_details(1234.5, "count") == "Nuværende niveau: 1.234,5"); stopifnot(BFHcharts:::format_centerline_for_details(127, "count") == "Nuværende niveau: 127"); stopifnot(BFHcharts:::format_centerline_for_details(0.645, "percent") == "Nuværende niveau: 64,5%"); stopifnot(BFHcharts:::format_centerline_for_details(5.5, "rate") == "Nuværende niveau: 5,5")'`
- `Rscript -e 'devtools::test(filter = "export_pdf")'` still reports pre-existing unrelated failures in export-related tests due local environment issues around fonts/Quarto and broader test expectations; this fix does not introduce new failures in the targeted formatter checks.