### PR TITLE
[codex] Emit Typst datetime for export date parameter

### DIFF
--- a/R/utils_typst.R
+++ b/R/utils_typst.R
@@ -331,9 +331,13 @@ build_typst_content <- function(chart_image, metadata, spc_stats, template, temp
 
   # Date parameter - format for Typst template
   if (!is.null(metadata$date)) {
-    # Format date as ISO string for Typst
-    date_str <- format(as.Date(metadata$date), "%Y-%m-%d")
-    params$date <- sprintf('"%s"', date_str)
+    date_obj <- as.Date(metadata$date)
+    params$date <- sprintf(
+      "datetime(year: %d, month: %d, day: %d)",
+      as.integer(format(date_obj, "%Y")),
+      as.integer(format(date_obj, "%m")),
+      as.integer(format(date_obj, "%d"))
+    )
   }
 
   # SPC statistics — send "?" for NA (vises i tabel), udelad kun NULL

--- a/tests/testthat/test-export_pdf.R
+++ b/tests/testthat/test-export_pdf.R
@@ -849,7 +849,7 @@ test_that("generated Typst contains metadata and chart reference", {
   # Verify metadata appears in content
   expect_match(content, "My Test Title")
   expect_match(content, "Copenhagen Hospital")
-  expect_match(content, "2025-03-15")
+  expect_match(content, "datetime\\(year: 2025, month: 3, day: 15\\)")
 
   # Verify SPC stats appear
   expect_match(content, "runs_expected: 7")

--- a/tests/testthat/test-export_pdf.R
+++ b/tests/testthat/test-export_pdf.R
@@ -631,7 +631,8 @@ test_that("build_typst_content includes date parameter", {
   # Content should include date parameter
   content_str <- paste(content, collapse = "\n")
   expect_true(grepl("date:", content_str))
-  expect_true(grepl("2025-01-15", content_str))
+  expect_true(grepl("datetime\\(year: 2025, month: 1, day: 15\\)", content_str))
+  expect_false(grepl('date:\\s*"2025-01-15"', content_str))
 })
 
 test_that("build_typst_content escapes file paths", {


### PR DESCRIPTION
## Summary
Fixes the Typst export date parameter so `build_typst_content()` sends a real `datetime(...)` value instead of a quoted ISO string.

Closes #77.

## Root Cause
The Typst template declares `date` as a datetime-valued parameter, but the R side serialized it as a string like `"2025-01-15"`. That leaves Typst with the wrong type for the parameter.

## Changes
- convert `metadata$date` to a `Date`
- emit `datetime(year: ..., month: ..., day: ...)` in `build_typst_content()`
- tighten the test to require a Typst datetime constructor and reject the old quoted string form

## Impact
Date values passed to the Typst template now match the template's expected type and can be formatted as real Typst datetimes.

## Validation
- `Rscript -e 'devtools::load_all(".", quiet = TRUE); metadata <- list(hospital = "Test Hospital", title = "Test Chart", date = as.Date("2025-01-15")); content <- BFHcharts:::build_typst_content(chart_image = "/tmp/chart.png", metadata = metadata, spc_stats = list(), template = "bfh-diagram", template_file = system.file("templates/typst/bfh-template/bfh-template.typ", package = "BFHcharts")); content_str <- paste(content, collapse = "\n"); stopifnot(grepl("date:", content_str, fixed = TRUE)); stopifnot(grepl("datetime(year: 2025, month: 1, day: 15)", content_str, fixed = TRUE)); stopifnot(!grepl("date: \"2025-01-15\"", content_str, fixed = TRUE))'`
- broader export tests were not rerun here because the package currently has unrelated existing export/Quarto environment failures.