### PR TITLE
[codex] Escape Typst special chars in content blocks

### DIFF
--- a/R/utils_typst.R
+++ b/R/utils_typst.R
@@ -448,6 +448,8 @@ markdown_to_typst <- function(text) {
   result <- gsub("<", "\\\\<", result)
   result <- gsub(">", "\\\\>", result)
   result <- gsub("@", "\\\\@", result)
+  result <- gsub("\\$", "\\\\$", result)
+  result <- gsub("_", "\\\\_", result)
   result <- gsub("\\[", "\\\\[", result)  # Bracket injection prevention
   result <- gsub("\\]", "\\\\]", result)
   result <- gsub("(?<!\\*)#", "\\\\#", result, perl = TRUE)

--- a/tests/testthat/test-export_pdf.R
+++ b/tests/testthat/test-export_pdf.R
@@ -1006,6 +1006,18 @@ test_that("markdown_to_typst preserves plain text without formatting", {
   expect_equal(BFHcharts:::markdown_to_typst(plain_text), plain_text)
 })
 
+test_that("markdown_to_typst escapes Typst special characters in content blocks", {
+  result <- BFHcharts:::markdown_to_typst(
+    "Afd. #3 @akut koster $100 for kode_navn <Akut>"
+  )
+
+  expect_match(result, "\\\\#3")
+  expect_match(result, "\\\\@akut")
+  expect_match(result, "\\\\\\$100")
+  expect_match(result, "kode\\\\_navn")
+  expect_match(result, "\\\\<Akut\\\\>")
+})
+
 test_that("build_typst_content uses content blocks for title and analysis", {
   # Create minimal test setup
   test_metadata <- list(


### PR DESCRIPTION
## Summary
Fixes Typst content-block escaping for user text passed through `markdown_to_typst()`, covering special characters that were still leaking into `[...]` content.

Closes #79.

## Root Cause
`markdown_to_typst()` already escaped `#`, `@`, `<`, `>`, and brackets, but it still left `$` and `_` untouched. Those characters are special in Typst content blocks and could alter rendering or break compilation for user-provided metadata.

## Changes
- escape `$` in content-block text
- escape `_` in content-block text
- add a regression test covering `#`, `@`, `$`, `_`, `<`, `>` in one string
- verify existing markdown bold/italic conversion still works after the escaping change

## Impact
Rich-text metadata rendered through Typst content blocks is safer and more predictable for plain user text containing Typst control characters.

## Validation
- inline R validation script:
```r
devtools::load_all('.', quiet = TRUE)
result <- BFHcharts:::markdown_to_typst('Afd. #3 @akut koster $100 for kode_navn <Akut>')
stopifnot(grepl(paste0('\\', '#3'), result, fixed = TRUE))
stopifnot(grepl(paste0('\\', '@akut'), result, fixed = TRUE))
stopifnot(grepl(paste0('\\', '$100'), result, fixed = TRUE))
stopifnot(grepl(paste0('kode', '\\', '_navn'), result, fixed = TRUE))
stopifnot(grepl(paste0('\\', '<Akut', '\\', '>'), result, fixed = TRUE))
stopifnot(identical(
  BFHcharts:::markdown_to_typst('This is **bold** and *italic*'),
  'This is #strong[bold] and #emph[italic]'
))
```
- broader export tests were not rerun here because the package currently has unrelated existing export/Quarto environment failures.