### PR TITLE
[codex] Make Typst analysis row height dynamic

### DIFF
--- a/inst/templates/typst/bfh-template/bfh-template.typ
+++ b/inst/templates/typst/bfh-template/bfh-template.typ
@@ -81,7 +81,7 @@ show table.cell: it => {
     grid(
       //rows: (51.33mm, 22.66mm, 1fr),
       //rows: (59.4mm, 22.1mm, 1fr),
-      rows: (52.8mm, 26.4mm, 1fr),
+      rows: (52.8mm, auto, 1fr),
         block(
           //fill: rgb("DCF1FC"),
           fill: rgb("007dbb"),

--- a/tests/testthat/test-export_pdf.R
+++ b/tests/testthat/test-export_pdf.R
@@ -686,6 +686,20 @@ test_that("bfh template uses none for optional metadata and SPC defaults", {
   expect_no_match(template, "outliers_actual: 0", fixed = TRUE)
 })
 
+test_that("bfh template uses auto height for analysis row", {
+  template_file <- system.file(
+    "templates/typst/bfh-template/bfh-template.typ",
+    package = "BFHcharts"
+  )
+
+  skip_if(!file.exists(template_file), "Template file not found")
+
+  template <- paste(readLines(template_file), collapse = "\n")
+
+  expect_match(template, "rows: (52.8mm, auto, 1fr)", fixed = TRUE)
+  expect_no_match(template, "rows: (52.8mm, 26.4mm, 1fr)", fixed = TRUE)
+})
+
 test_that("bfh_export_pdf validates custom template_path", {
   data <- data.frame(
     month = seq(as.Date("2024-01-01"), by = "month", length.out = 12),


### PR DESCRIPTION
## Summary
Changes the Typst template layout so the analysis row uses dynamic height instead of a fixed 26.4mm slot.

Closes #81.

## Root Cause
The template hardcoded the second grid row to `26.4mm`. That always reserved whitespace when `analysis == none` and could still be too small for longer analysis text.

## Changes
- changed the main content grid from `rows: (52.8mm, 26.4mm, 1fr)` to `rows: (52.8mm, auto, 1fr)`
- added a regression test that reads the packaged template and requires the new `auto` row height

## Impact
PDF exports no longer reserve a fixed empty analysis band when no analysis text is present, and long analysis text can grow the row naturally.

## Validation
- `Rscript` check reading the packaged template and asserting `rows: (52.8mm, auto, 1fr)` is present
- no broader export rendering tests were rerun here because the package currently has unrelated existing export/Quarto environment failures.