### PR TITLE
[codex] Expose outlier stats from summary data

### DIFF
--- a/R/export_pdf.R
+++ b/R/export_pdf.R
@@ -582,8 +582,14 @@ bfh_extract_spc_stats.bfh_qic_result <- function(x) {
   is_run_chart <- identical(x$config$chart_type, "run")
   stats$is_run_chart <- is_run_chart
 
-  # Run charts har ingen kontrolgrænser → outlier-felter forbliver NULL
-  if (is_run_chart) return(stats)
+  # Run charts har ingen kontrolgrænser → outlier-felter skal være NULL,
+  # selvom format_qic_summary() har tilføjet aggregerede outlier-kolonner.
+  if (is_run_chart) {
+    stats$outliers_expected <- NULL
+    stats$outliers_actual <- NULL
+    stats$outliers_recent_count <- NULL
+    return(stats)
+  }
 
   if (is.null(x$qic_data) || !"sigma.signal" %in% names(x$qic_data)) {
     # Uden sigma.signal kan vi ikke tælle outliers; lad felterne forblive NULL

--- a/R/export_pdf.R
+++ b/R/export_pdf.R
@@ -557,8 +557,18 @@ bfh_extract_spc_stats.data.frame <- function(x) {
     stats$crossings_actual <- clean_spc_value(row$antal_kryds)
   }
 
-  # Outliers kan ikke udledes af summary alene (kræver sigma.signal fra qic_data).
-  # Brug bfh_extract_spc_stats(bfh_qic_result) hvis outliers skal udfyldes.
+  # Outliers kan udledes fra summary, hvis summary-generatoren har tilføjet
+  # aggregerede outlier-kolonner.
+  if ("forventede_outliers" %in% names(row)) {
+    stats$outliers_expected <- clean_spc_value(row$forventede_outliers)
+  } else if ("outliers_expected" %in% names(row)) {
+    stats$outliers_expected <- clean_spc_value(row$outliers_expected)
+  }
+  if ("antal_outliers" %in% names(row)) {
+    stats$outliers_actual <- clean_spc_value(row$antal_outliers)
+  } else if ("outliers_actual" %in% names(row)) {
+    stats$outliers_actual <- clean_spc_value(row$outliers_actual)
+  }
 
   stats
 }
@@ -1025,4 +1035,3 @@ format_centerline_for_details <- function(cl_value, y_axis_unit) {
 
   sprintf("Nuværende niveau: %s", formatted)
 }
-

--- a/R/utils_qic_summary.R
+++ b/R/utils_qic_summary.R
@@ -108,6 +108,26 @@ format_qic_summary <- function(qic_data, y_axis_unit = "count") {
   formatted$løbelængde_signal <- as.logical(raw_summary$runs.signal)
   formatted$sigma_signal <- as.logical(raw_summary$sigma.signal)
 
+  # Add aggregated outlier counts per part when sigma.signal is available.
+  has_sigma_signal <- "sigma.signal" %in% names(qic_data) &&
+    any(!is.na(qic_data$sigma.signal))
+
+  if (has_sigma_signal) {
+    if ("part" %in% names(qic_data)) {
+      outliers_by_part <- vapply(
+        split(qic_data$sigma.signal, qic_data$part),
+        function(x) sum(x, na.rm = TRUE),
+        integer(1)
+      )
+      part_key <- as.character(raw_summary$part)
+      formatted$forventede_outliers <- unname(as.integer(rep(0L, length(part_key))))
+      formatted$antal_outliers <- unname(as.integer(outliers_by_part[part_key]))
+    } else {
+      formatted$forventede_outliers <- 0L
+      formatted$antal_outliers <- as.integer(sum(qic_data$sigma.signal, na.rm = TRUE))
+    }
+  }
+
   # Add control limits with appropriate rounding (if they exist)
   if ("cl" %in% names(raw_summary)) {
     formatted$centerlinje <- round(raw_summary$cl, decimal_places)

--- a/tests/testthat/test-export_pdf.R
+++ b/tests/testthat/test-export_pdf.R
@@ -378,6 +378,22 @@ test_that("bfh_extract_spc_stats extracts statistics from valid summary", {
   expect_null(stats$outliers_actual)
 })
 
+test_that("bfh_extract_spc_stats extracts outliers from summary when present", {
+  summary <- data.frame(
+    længste_løb_max = 8,
+    længste_løb = 6,
+    antal_kryds_min = 10,
+    antal_kryds = 12,
+    forventede_outliers = 0,
+    antal_outliers = 2
+  )
+
+  stats <- bfh_extract_spc_stats(summary)
+
+  expect_equal(stats$outliers_expected, 0)
+  expect_equal(stats$outliers_actual, 2)
+})
+
 test_that("bfh_extract_spc_stats handles NULL summary gracefully", {
   stats <- bfh_extract_spc_stats(NULL)
 

--- a/tests/testthat/test-utils_qic_summary.R
+++ b/tests/testthat/test-utils_qic_summary.R
@@ -82,6 +82,18 @@ test_that("format_qic_summary kombinerer signals korrekt med any()", {
   expect_false(result$løbelængde_signal[2])
 })
 
+test_that("format_qic_summary inkluderer aggregerede outlier-kolonner per fase", {
+  qic_data <- fixture_qicharts_summary_data(n = 24, parts = 2)
+  qic_data$sigma.signal[c(2, 14, 15)] <- TRUE
+
+  result <- format_qic_summary(qic_data, y_axis_unit = "count")
+
+  expect_true("forventede_outliers" %in% names(result))
+  expect_true("antal_outliers" %in% names(result))
+  expect_equal(result$forventede_outliers, c(0L, 0L))
+  expect_equal(result$antal_outliers, c(1L, 2L))
+})
+
 # =============================================================================
 # AFRUNDING OG UNIT-SPECIFIK FORMATERING
 # =============================================================================


### PR DESCRIPTION
## Summary
Adds aggregated outlier data to formatted summary output and teaches `bfh_extract_spc_stats.data.frame()` to read it.

Closes #82.

## Root Cause
The public `data.frame` method for `bfh_extract_spc_stats()` only read runs and crossings. Even when downstream callers only had `summary`, outlier fields always stayed `NULL` because summary contained no aggregated outlier columns and the extractor never looked for them.

## Changes
- `format_qic_summary()` now adds per-phase `forventede_outliers` and `antal_outliers` when `sigma.signal` data is available
- `bfh_extract_spc_stats.data.frame()` now reads those summary columns
- kept compatibility with explicit `outliers_expected` / `outliers_actual` column names if a caller already provides them
- added regression tests for both summary generation and public summary-based stats extraction

## Impact
Downstream packages that only receive `summary` can now still recover outlier counts through the public `bfh_extract_spc_stats()` API.

## Validation
- focused inline end-to-end check from summary generation to `bfh_extract_spc_stats(summary)`
- `Rscript -e 'devtools::test(filter = "utils_qic_summary|extract-spc-stats-dispatch")'` → passing (`75` tests, `0` failures)