### PR TITLE
[codex] Reduce default y-axis expansion around SPC labels

### DIFF
--- a/R/globals.R
+++ b/R/globals.R
@@ -26,6 +26,10 @@ utils::globalVariables(c(
 # Line extension factor — hvor langt CL/target forlænges forbi sidste datapunkt
 LINE_EXTENSION_FACTOR <- 0.20
 
+# Default y-axis expansion for chart scales — holdes lav for at minimere
+# tom whitespace. Boundary labels kan stadig udvide skalaen dynamisk.
+Y_AXIS_BASE_EXPANSION_MULT <- 0.05
+
 # Y-axis expansion multiplier — matcher ggplot2 expansion(mult = ...)
 Y_AXIS_EXPANSION_MULT <- 0.25
 

--- a/R/utils_y_axis_formatting.R
+++ b/R/utils_y_axis_formatting.R
@@ -144,7 +144,7 @@ format_y_axis_percent <- function(y_range = NULL) {
   }
 
   BFHtheme::scale_y_continuous_bfh(
-    expand = ggplot2::expansion(mult = c(.20, .20)),
+    expand = ggplot2::expansion(mult = c(Y_AXIS_BASE_EXPANSION_MULT, Y_AXIS_BASE_EXPANSION_MULT)),
     breaks = percent_breaks,
     labels = percent_labels
   )
@@ -163,7 +163,7 @@ format_y_axis_percent <- function(y_range = NULL) {
 #' @noRd
 format_y_axis_count <- function() {
   BFHtheme::scale_y_continuous_bfh(
-    expand = ggplot2::expansion(mult = c(.20, .20)),
+    expand = ggplot2::expansion(mult = c(Y_AXIS_BASE_EXPANSION_MULT, Y_AXIS_BASE_EXPANSION_MULT)),
     labels = function(x, ...) {
       # Uses canonical format_count_danish() from utils_number_formatting.R
       purrr::map_chr(x, format_count_danish)
@@ -178,7 +178,7 @@ format_y_axis_count <- function() {
 #' @noRd
 format_y_axis_rate <- function() {
   BFHtheme::scale_y_continuous_bfh(
-    expand = ggplot2::expansion(mult = c(.20, .20)),
+    expand = ggplot2::expansion(mult = c(Y_AXIS_BASE_EXPANSION_MULT, Y_AXIS_BASE_EXPANSION_MULT)),
     labels = function(x, ...) {
       # Uses canonical format_rate_danish() from utils_number_formatting.R
       purrr::map_chr(x, format_rate_danish)
@@ -205,14 +205,16 @@ format_y_axis_rate <- function() {
 format_y_axis_time <- function(qic_data) {
   if (is.null(qic_data) || !"y" %in% names(qic_data)) {
     warning("format_y_axis_time: missing qic_data or y column, using default")
-    return(BFHtheme::scale_y_continuous_bfh(expand = ggplot2::expansion(mult = c(.20, .20))))
+    return(BFHtheme::scale_y_continuous_bfh(
+      expand = ggplot2::expansion(mult = c(Y_AXIS_BASE_EXPANSION_MULT, Y_AXIS_BASE_EXPANSION_MULT))
+    ))
   }
 
   # Tids-naturlige tick-breaks baseret på data-range (target_n = 5 som default)
   breaks <- time_breaks(qic_data$y)
 
   BFHtheme::scale_y_continuous_bfh(
-    expand = ggplot2::expansion(mult = c(.20, .20)),
+    expand = ggplot2::expansion(mult = c(Y_AXIS_BASE_EXPANSION_MULT, Y_AXIS_BASE_EXPANSION_MULT)),
     breaks = breaks,
     labels = function(x, ...) {
       # Defensiv: ggplot2 kan passere waiver-objekter under layout

--- a/tests/testthat/test-fct_add_spc_labels.R
+++ b/tests/testthat/test-fct_add_spc_labels.R
@@ -221,6 +221,45 @@ test_that("CL at zero with target above does not crash and returns ggplot", {
   expect_true(inherits(result, "gg"))
 })
 
+test_that("boundary labels avoid adding excess whitespace when minimal expansion is enough", {
+  qic_data <- data.frame(
+    x = as.Date("2024-01-01") + 0:11 * 30,
+    y = c(0, 0, 0, 0.06, 0, 0.04, 0, 0, 0, 0, 0, 0),
+    cl = rep(0, 12),
+    target = rep(0.01, 12)
+  )
+  p <- ggplot2::ggplot(qic_data, ggplot2::aes(x = x, y = y)) +
+    ggplot2::geom_line()
+
+  plot_before_labels <- apply_y_axis_formatting(p, "percent", qic_data)
+  range_before <- ggplot2::ggplot_build(plot_before_labels)$layout$panel_params[[1]]$y.range
+
+  result <- suppressWarnings(add_spc_labels(plot_before_labels, qic_data, y_axis_unit = "percent"))
+  range_after <- ggplot2::ggplot_build(result)$layout$panel_params[[1]]$y.range
+
+  expect_equal(range_before, c(-0.003, 0.063), tolerance = 1e-8)
+  expect_equal(range_after, range_before, tolerance = 1e-8)
+})
+
+test_that("non-boundary labels keep the minimal default y expansion", {
+  qic_data <- data.frame(
+    x = as.Date("2024-01-01") + 0:11 * 30,
+    y = c(40, 52, 48, 55, 47, 51, 49, 53, 50, 48, 52, 60),
+    cl = rep(50.5, 12),
+    target = rep(48, 12)
+  )
+  p <- ggplot2::ggplot(qic_data, ggplot2::aes(x = x, y = y)) +
+    ggplot2::geom_line()
+
+  plot_before_labels <- apply_y_axis_formatting(p, "count", qic_data)
+  range_before <- ggplot2::ggplot_build(plot_before_labels)$layout$panel_params[[1]]$y.range
+
+  result <- suppressWarnings(add_spc_labels(plot_before_labels, qic_data, y_axis_unit = "count"))
+  range_after <- ggplot2::ggplot_build(result)$layout$panel_params[[1]]$y.range
+
+  expect_equal(range_after, range_before, tolerance = 1e-8)
+})
+
 test_that("CL at data maximum with target below does not crash", {
   # Spejlvendt scenarie: CL nær toppen
   qic_data <- data.frame(

--- a/tests/testthat/test-y_axis_formatting.R
+++ b/tests/testthat/test-y_axis_formatting.R
@@ -51,6 +51,16 @@ test_that("apply_y_axis_formatting applies count formatting", {
   expect_true(length(result$scales$scales) > 0)
 })
 
+test_that("apply_y_axis_formatting uses minimal default y expansion", {
+  qic_data <- data.frame(x = 1:3, y = c(40, 50, 60))
+  plot <- ggplot2::ggplot(qic_data, ggplot2::aes(x = x, y = y)) + ggplot2::geom_point()
+
+  result <- apply_y_axis_formatting(plot, "count", qic_data)
+  y_range <- ggplot2::ggplot_build(result)$layout$panel_params[[1]]$y.range
+
+  expect_equal(y_range, c(39, 61), tolerance = 1e-8)
+})
+
 test_that("apply_y_axis_formatting applies rate formatting", {
   data <- data.frame(x = 1:10, y = rnorm(10, 5, 1))
   plot <- ggplot2::ggplot(data, ggplot2::aes(x = x, y = y)) + ggplot2::geom_point()


### PR DESCRIPTION
## Summary
Reduces the default y-axis expansion from 20% to 5% and adds regression coverage showing that label placement no longer creates unnecessary whitespace in normal and boundary cases.

Closes #113.

## Rationale
The current fixed 20% y-axis expansion was doing most of the work, which left too much empty space even when labels were nowhere near the plot boundaries. In practice, the right-label layer already has enough information to keep boundary labels inside the visible range when needed, so the simpler fix is to lower the baseline expansion and verify the resulting ranges directly.

## Changes
- introduced `Y_AXIS_BASE_EXPANSION_MULT <- 0.05`
- switched count/percent/rate/time y-axis formatters to use the new 5% default expansion
- added tests asserting:
  - default y-axis expansion is now minimal (`39..61` for data `40..60`)
  - non-boundary label scenarios keep that minimal expansion
  - boundary label scenarios do not add new excess whitespace when the minimal expansion is already sufficient

## Validation
- `Rscript -e 'devtools::test(filter = "y_axis_formatting|fct_add_spc_labels")'` → passing (`165` tests, `0` failures)
- the focused run still emits pre-existing font fallback and deprecated-warning noise in unrelated expectations, but no test failures