### PR TITLE
docs(openspec): propose split of export_pdf.R (#116)

### DIFF
--- a/openspec/changes/refactor-split-export-pdf/design.md
+++ b/openspec/changes/refactor-split-export-pdf/design.md
@@ -1,0 +1,58 @@
+# Design Notes
+
+## Goal
+
+Splitte `R/export_pdf.R` efter ansvar uden at ændre den offentlige API
+eller PDF-renderingens adfærd.
+
+## Proposed Module Boundaries
+
+### `R/export_pdf.R`
+
+Beholder kun PDF-exportspecifik orchestration:
+
+- input- og miljøvalidering
+- plot-forberedelse og label-recalculation
+- Typst-dokumentoprettelse
+- compile/invoke pipeline
+
+### `R/utils_spc_stats.R`
+
+Canonical hjem for SPC-statistik-API:
+
+- `bfh_extract_spc_stats()`
+- `bfh_extract_spc_stats.default()`
+- `bfh_extract_spc_stats.data.frame()`
+- `bfh_extract_spc_stats.bfh_qic_result()`
+- tilhørende interne helpers (`empty_spc_stats()`, `clean_spc_value()`)
+
+### `R/utils_metadata.R`
+
+Canonical hjem for metadata utilities:
+
+- `bfh_merge_metadata()`
+
+### `R/export_details.R`
+
+Hjem for details-tekst og tilhørende formattering:
+
+- `bfh_generate_details()`
+- `format_centerline_for_details()`
+
+## Alias Strategy
+
+De tidligere interne aliaser `extract_spc_stats()` og `merge_metadata()`
+fjernes i implementeringen. Rationalet er:
+
+- `bfh_*`-navnene er allerede den etablerede public API
+- aliaserne giver ikke længere migrationsværdi internt i BFHcharts
+- tests og interne call sites skal bruge de kanoniske navne direkte
+
+Hvis der under implementering opdages eksterne downstream-kald til disse
+interne aliaser, skal ændringen stoppes og revurderes som potentiel
+breaking change.
+
+## Test Impact
+
+Der forventes ingen ændring i assertions om output, men tests skal flyttes
+væk fra interne aliaser og gerne organiseres nærmere de nye modulgrænser.

--- a/openspec/changes/refactor-split-export-pdf/proposal.md
+++ b/openspec/changes/refactor-split-export-pdf/proposal.md
@@ -1,0 +1,80 @@
+# refactor-split-export-pdf
+
+## Why
+
+`R/export_pdf.R` er vokset til en monolit, som blander flere adskilte
+ansvarsområder:
+
+- input- og sikkerhedsvalidering for eksport
+- PDF-pipeline og orchestration
+- offentlig SPC-statistik-API (`bfh_extract_spc_stats()`)
+- offentlig metadata-API (`bfh_merge_metadata()`)
+- details-generering og label-relaterede eksporthelpers
+
+Det gør filen sværere at navigere i, øger risikoen ved ændringer, og
+slører hvilke funktioner der er generelle utilities versus PDF-specifik
+orchestration.
+
+Issue `#116` peger specifikt på, at `bfh_extract_spc_stats()` og
+`bfh_merge_metadata()` ikke hører hjemme i en eksportfil, og at de gamle
+interne aliaser (`extract_spc_stats()`, `merge_metadata()`) bør fjernes nu,
+hvor de navngivne `bfh_*` APIs allerede er etableret.
+
+## What Changes
+
+Denne change opdeler eksportkoden efter ansvar uden at ændre den
+offentlige adfærd:
+
+1. Flyt SPC-statistik-API til `R/utils_spc_stats.R`
+2. Flyt metadata-merge-API til `R/utils_metadata.R`
+3. Flyt details-generering til en dedikeret eksport-helperfil
+4. Lad `R/export_pdf.R` fokusere på validering, plotting, Typst/Quarto og
+   orchestration
+5. Fjern de interne aliaser `extract_spc_stats()` og `merge_metadata()` og
+   opdater interne tests/call sites til direkte `bfh_*`-kald
+
+## Impact
+
+**Affected specs:**
+- `code-organization`
+
+**Affected code:**
+- `R/export_pdf.R`
+- `R/utils_spc_stats.R` (ny)
+- `R/utils_metadata.R` (ny)
+- `R/export_details.R` eller tilsvarende helperfil (ny)
+- relevante tests og generated docs
+
+**User-visible changes:**
+- Ingen planlagte adfærdsændringer i `bfh_export_pdf()`
+- Ingen planlagte signaturændringer i `bfh_extract_spc_stats()`,
+  `bfh_merge_metadata()` eller `bfh_generate_details()`
+
+**Internal changes:**
+- Utility-funktioner får canonical hjem uden for `R/export_pdf.R`
+- `R/export_pdf.R` bliver en orchestration-fil frem for en catch-all modulfil
+- Tests kan spejle den nye modulopdeling i stedet for at samle alt under
+  `test-export_pdf.R`
+
+## Alternatives Considered
+
+### Beholde alt i `R/export_pdf.R`
+
+Afvist, fordi issue `#116` netop dokumenterer at den nuværende fil bryder
+med projektets separation-of-concerns princip og gør fremtidige ændringer
+dyrere.
+
+### Splitte filen men beholde de interne aliaser
+
+Afvist, fordi aliaserne nu kun vedligeholder dobbelt navneflade internt.
+Den offentlige `bfh_*` API findes allerede og bør være den eneste
+kanoniske adgangsvej.
+
+### Flytte utilities uden OpenSpec-change
+
+Afvist, fordi dette er en arkitekturændring med flere filer og intern API-
+oprydning. Den bør godkendes eksplicit før implementering.
+
+## Related
+
+- GitHub Issue: [#116](https://github.com/johanreventlow/BFHcharts/issues/116)

--- a/openspec/changes/refactor-split-export-pdf/specs/code-organization/spec.md
+++ b/openspec/changes/refactor-split-export-pdf/specs/code-organization/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: PDF export code SHALL be split by responsibility into dedicated modules
+
+The PDF export implementation SHALL separate orchestration from reusable
+utility APIs so that each module has a single primary responsibility.
+
+**Rationale:**
+- Reduces navigation and review cost in export-related code
+- Makes public utility APIs discoverable outside the export pipeline
+- Lowers regression risk when changing PDF orchestration versus shared helpers
+
+#### Scenario: Shared utility APIs live outside export_pdf.R
+
+**Given** the package source is inspected
+**When** the implementations of `bfh_extract_spc_stats()` and
+`bfh_merge_metadata()` are located
+**Then** they SHALL live in dedicated `R/utils_*.R` files
+**And** `R/export_pdf.R` SHALL NOT be the canonical implementation home for
+those functions
+
+#### Scenario: Details generation is isolated from PDF orchestration
+
+**Given** the package source is inspected
+**When** `bfh_generate_details()` and its helper formatting functions are
+located
+**Then** they SHALL live in a dedicated helper module separate from the main
+PDF orchestration file
+
+#### Scenario: Export pipeline calls canonical public utility names
+
+**Given** `bfh_export_pdf()` needs SPC stats or merged metadata
+**When** the orchestration code invokes those utilities
+**Then** it SHALL call `bfh_extract_spc_stats()` and
+`bfh_merge_metadata()` directly
+**And** duplicate internal alias wrappers SHALL NOT remain

--- a/openspec/changes/refactor-split-export-pdf/tasks.md
+++ b/openspec/changes/refactor-split-export-pdf/tasks.md
@@ -1,0 +1,30 @@
+## 1. Specification
+
+- [ ] 1.1 Beskriv den nye ansvarsopdeling for PDF-export og relaterede
+  utilities i `code-organization` spec
+- [ ] 1.2 Beskriv alias-oprydningen og canonical `bfh_*` call pattern i
+  design-noten
+
+## 2. Implementation
+
+- [ ] 2.1 Opret `R/utils_spc_stats.R` og flyt
+  `bfh_extract_spc_stats()`-generic, methods og helpers
+- [ ] 2.2 Opret `R/utils_metadata.R` og flyt `bfh_merge_metadata()`
+- [ ] 2.3 Opret dedikeret helperfil til `bfh_generate_details()` og
+  relaterede interne formatteringshelpers
+- [ ] 2.4 Reducer `R/export_pdf.R` til eksportvalidering, plot-prep,
+  Typst-dokumentoprettelse og compile orchestration
+- [ ] 2.5 Fjern `extract_spc_stats()` og `merge_metadata()` og opdater alle
+  interne call sites til `bfh_*` funktioner
+
+## 3. Verification
+
+- [ ] 3.1 Opdater tests så de ikke bruger `BFHcharts:::extract_spc_stats()`
+  eller `BFHcharts:::merge_metadata()`
+- [ ] 3.2 Kør målrettede tests for SPC-statistik, metadata og details-
+  generering
+- [ ] 3.3 Kør `devtools::document()` og verificér at NAMESPACE/man forbliver
+  korrekt
+- [ ] 3.4 Kør `openspec validate refactor-split-export-pdf --strict`
+
+Tracking: GitHub Issue #116


### PR DESCRIPTION
## Summary
- add an OpenSpec change proposal for issue #116
- define the target module split for `R/export_pdf.R`
- document removal of the internal `extract_spc_stats()` and `merge_metadata()` aliases in the planned implementation

## Why
`R/export_pdf.R` currently mixes PDF orchestration, public utility APIs, and details-generation helpers. This PR captures the proposed refactor boundaries before implementation, as required by OpenSpec for architecture changes.

## Scope
This PR contains proposal artifacts only:
- `proposal.md`
- `tasks.md`
- `design.md`
- `code-organization` spec delta

No production R code changes are included yet.

## Validation
- `openspec validate refactor-split-export-pdf --strict`

Closes #116