### PR TITLE
docs(openspec): propose bfh_qic helper split (#117)

### DIFF
--- a/openspec/changes/refactor-extract-bfh-qic-helpers/design.md
+++ b/openspec/changes/refactor-extract-bfh-qic-helpers/design.md
@@ -1,0 +1,43 @@
+# Design Notes
+
+## Goal
+
+Reducere kompleksiteten i `bfh_qic()` ved at flytte to klart afgrænsede
+ansvarsområder ud i interne helpers, uden at ændre public API eller legacy
+returadfærd.
+
+## Proposed Helpers
+
+### `add_anhoej_signal(qic_data)`
+
+Ansvar:
+
+- normalisere `runs.signal`
+- beregne crossings-signal per part når de nødvendige kolonner findes
+- producere en altid-boolean `anhoej.signal`
+- rydde midlertidige kolonner op
+
+Returnerer det muterede `qic_data`-data frame.
+
+### `build_bfh_qic_return(...)`
+
+Ansvar:
+
+- håndtere `return.data` / `print.summary` kombinationer
+- bevare warnings for deprecated legacy paths
+- returnere enten raw `qic_data`, legacy lister eller `bfh_qic_result`
+
+Denne helper skal være eneste sted, hvor de legacy branches ligger.
+
+## Refactor Boundary
+
+`bfh_qic()` skal fortsat eje:
+
+- input validation
+- `qicharts2::qic()` invocation
+- unit conversion og viewport-beregning
+- plot generation
+- config- og summary-opbygning
+
+Helperne skal kun overtage de klart afgrænsede dele, som issue `#117`
+peger på, så refaktoren forbliver lille og lav-risiko.

--- a/openspec/changes/refactor-extract-bfh-qic-helpers/proposal.md
+++ b/openspec/changes/refactor-extract-bfh-qic-helpers/proposal.md
@@ -1,0 +1,71 @@
+# refactor-extract-bfh-qic-helpers
+
+## Why
+
+`bfh_qic()` i `R/create_spc_chart.R` har en lang funktionskrop, som i dag
+blander flere forskellige lag af ansvar:
+
+- input- og parameter-validering
+- opbygning af `qicharts2::qic()`-kaldet
+- Anhøj signal-postprocessering
+- viewport- og labelrelateret plotopbygning
+- summary-beregning og config-opbygning
+- return-routing mellem nyt resultatobjekt og legacy formater
+
+Issue `#117` peger specifikt på to områder, der bør skilles ud som
+selvstændige interne funktioner:
+
+- postprocessering af `anhoej.signal`
+- return-routing for `return.data` / `print.summary`
+
+Det vil gøre `bfh_qic()` lettere at læse, reducere regressionsrisiko ved
+ændringer i legacy-returadfærd og gøre de mest komplekse grene testbare i
+isolation.
+
+## What Changes
+
+Denne change foreslår en intern refaktorering uden adfærdsændringer:
+
+1. Ekstraher Anhøj signal-postprocessering til en intern helper
+2. Ekstraher return-routing til en intern helper, der ejer legacy-
+   kompatibilitet
+3. Lad `bfh_qic()` blive en kortere orchestration-funktion, der kalder de
+   dedikerede helpers
+4. Tilføj målrettede tests for de nye helpers og for bevaret returadfærd
+
+## Impact
+
+**Affected specs:**
+- `code-organization`
+
+**Affected code:**
+- `R/create_spc_chart.R`
+- evt. ny helperfil for interne `bfh_qic()`-helpers
+- relevante tests for `bfh_qic()` og legacy return modes
+
+**User-visible changes:**
+- Ingen planlagte ændringer i `bfh_qic()` signatur
+- Ingen planlagte ændringer i default `bfh_qic_result` output
+- Ingen planlagte ændringer i deprecated `return.data` / `print.summary`
+  adfærd ud over bevaret kompatibilitet
+
+## Alternatives Considered
+
+### Kun ekstrahere `add_anhoej_signal()`
+
+Afvist, fordi return-routing er den anden store kompleksitetskilde i
+`bfh_qic()` og samtidig den mest følsomme del ift. backward compatibility.
+
+### Kun ekstrahere `build_bfh_qic_return()`
+
+Afvist, fordi signal-postprocesseringen er et separat ansvar med sin egen
+datamutation og derfor også bør kunne testes isoleret.
+
+### Lade `bfh_qic()` være som den er
+
+Afvist, fordi issue `#117` dokumenterer en reel læsbarheds- og
+vedligeholdelsesomkostning i en central public entrypoint.
+
+## Related
+
+- GitHub Issue: [#117](https://github.com/johanreventlow/BFHcharts/issues/117)

--- a/openspec/changes/refactor-extract-bfh-qic-helpers/specs/code-organization/spec.md
+++ b/openspec/changes/refactor-extract-bfh-qic-helpers/specs/code-organization/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: bfh_qic SHALL delegate distinct post-processing responsibilities to internal helpers
+
+The implementation of `bfh_qic()` SHALL isolate data post-processing and
+return-routing in dedicated internal helpers so the public entrypoint can
+focus on orchestration.
+
+**Rationale:**
+- Keeps the package's main chart-construction API readable
+- Makes legacy return behavior testable in isolation
+- Reduces regression risk in Anhøj signal computation
+
+#### Scenario: Anhøj signal post-processing has a canonical helper
+
+**Given** a `qicharts2::qic()` result data frame
+**When** BFHcharts needs to derive `anhoej.signal`
+**Then** that logic SHALL live in a dedicated internal helper
+**And** `bfh_qic()` SHALL call that helper instead of inlining the full
+mutation block
+
+#### Scenario: Return routing has a canonical helper
+
+**Given** `bfh_qic()` has produced `plot`, `summary`, `qic_data`, and
+`config`
+**When** it must return output for combinations of `return.data` and
+`print.summary`
+**Then** the routing logic SHALL live in a dedicated internal helper
+**And** the helper SHALL preserve the documented legacy return formats and
+warnings

--- a/openspec/changes/refactor-extract-bfh-qic-helpers/tasks.md
+++ b/openspec/changes/refactor-extract-bfh-qic-helpers/tasks.md
@@ -1,0 +1,22 @@
+## 1. Specification
+
+- [ ] 1.1 Beskriv helper-opdelingen for `bfh_qic()` i `code-organization`
+- [ ] 1.2 Dokumentér ansvar og input/output for signal-helper og
+  return-helper i design-noten
+
+## 2. Implementation
+
+- [ ] 2.1 Ekstraher Anhøj signal-postprocessering til en intern helper
+- [ ] 2.2 Ekstraher legacy return-routing til en intern helper
+- [ ] 2.3 Opdater `bfh_qic()` til at orkestrere kald til helpers uden
+  adfærdsændring
+
+## 3. Verification
+
+- [ ] 3.1 Tilføj målrettede tests for signal-helperen
+- [ ] 3.2 Tilføj målrettede tests for `return.data` / `print.summary`
+  kombinationerne via return-helperen
+- [ ] 3.3 Kør relevante `bfh_qic()` tests
+- [ ] 3.4 Kør `openspec validate refactor-extract-bfh-qic-helpers --strict`
+
+Tracking: GitHub Issue #117


### PR DESCRIPTION
## Summary
- add an OpenSpec change proposal for issue #117
- define the internal helper split for `bfh_qic()`
- preserve the current public API and legacy return compatibility in the proposed design

## Why
`bfh_qic()` currently mixes orchestration, Anhøj signal post-processing, and legacy return routing in one long function body. This PR captures the intended helper boundaries before implementation, which is required for this architecture refactor.

## Scope
This PR contains proposal artifacts only:
- `proposal.md`
- `tasks.md`
- `design.md`
- `code-organization` spec delta

No production R code changes are included yet.

## Validation
- `openspec validate refactor-extract-bfh-qic-helpers --strict`

Closes #117