### PR TITLE
fix(nse): support quoted symbols in bfh_qic programmatic calls

### DIFF
--- a/R/create_spc_chart.R
+++ b/R/create_spc_chart.R
@@ -504,21 +504,32 @@ bfh_qic <- function(data,
   # SECURITY: Validate column names are simple identifiers
   # Prevents NSE injection attacks where malicious code could be passed
   validate_column_name <- function(col_expr, param_name) {
+    # Understøt både direkte symboler (month) og quoted symboler (quote(month))
+    # til programmatisk brug via do.call/list-argumenter.
+    normalized_expr <- col_expr
+    if (is.call(col_expr) &&
+      identical(col_expr[[1]], as.name("quote")) &&
+      length(col_expr) == 2) {
+      normalized_expr <- col_expr[[2]]
+    }
+
     col_str <- deparse(col_expr)
     # Allow only simple identifiers: letters, numbers, dots, underscores
     # No parentheses, operators, or function calls
     valid_pattern <- "^[a-zA-Z][a-zA-Z0-9._]*$"
-    if (!grepl(valid_pattern, col_str)) {
+    if (!is.symbol(normalized_expr) || !grepl(valid_pattern, as.character(normalized_expr))) {
       stop(sprintf(
         "%s must be a simple column name, got: %s\nAvoid special characters, spaces, or expressions",
         param_name, col_str
       ), call. = FALSE)
     }
+
+    as.name(as.character(normalized_expr))
   }
 
   # Validate x and y column names
-  validate_column_name(substitute(x), "x")
-  validate_column_name(substitute(y), "y")
+  x_expr <- validate_column_name(substitute(x), "x")
+  y_expr <- validate_column_name(substitute(y), "y")
 
   # SECURITY: Validate numeric parameters for bounds and sanity
   # Prevents DoS attacks via memory exhaustion or crashes
@@ -636,16 +647,15 @@ bfh_qic <- function(data,
   # Build qicharts2::qic() arguments using NSE
   qic_args <- list(
     data = data,
-    x = substitute(x),
-    y = substitute(y),
+    x = x_expr,
+    y = y_expr,
     chart = chart_type,
     return.data = TRUE
   )
 
   # Add optional arguments
   if (!missing(n) && !is.null(substitute(n))) {
-    validate_column_name(substitute(n), "n")
-    qic_args$n <- substitute(n)
+    qic_args$n <- validate_column_name(substitute(n), "n")
   }
 
   if (!is.null(part)) {

--- a/tests/testthat/test-security-nse-validation.R
+++ b/tests/testthat/test-security-nse-validation.R
@@ -104,6 +104,36 @@ test_that("bfh_qic validates n parameter for ratio charts", {
   )
 })
 
+test_that("bfh_qic accepts quoted symbols for programmatic NSE calls", {
+  data <- data.frame(
+    month = 1:12,
+    events = rpois(12, 5),
+    total = rpois(12, 100)
+  )
+
+  expect_no_error({
+    suppressWarnings(
+      bfh_qic(
+        data = data,
+        x = quote(month),
+        y = quote(events),
+        n = quote(total),
+        chart_type = "p"
+      )
+    )
+  })
+
+  expect_error(
+    bfh_qic(
+      data = data,
+      x = quote(month),
+      y = quote(events + 1),
+      chart_type = "run"
+    ),
+    "y must be a simple column name"
+  )
+})
+
 test_that("NSE validation prevents code injection patterns", {
   # The validation happens at the NSE layer where expressions are parsed
   # Our regex validates the deparsed form, catching malicious patterns


### PR DESCRIPTION
### Motivation
- Fix a regression where programmatic NSE calls (e.g. via `do.call()` with `quote(...)`) caused `bfh_qic()` to reject otherwise-valid column references and fail downstream when passing arguments to `qicharts2::qic()`.
- Preserve the strict NSE security model so malicious expressions (function calls, operators, or quoted expressions that are not plain symbols) remain rejected.

### Description
- Update `validate_column_name` in `R/create_spc_chart.R` to accept both direct symbols (e.g. `month`) and quoted symbols (e.g. `quote(month)`), normalize them to a symbol and return an `as.name(...)` for safe use.
- Replace direct uses of `substitute(x)`/`substitute(y)` with normalized `x_expr`/`y_expr` and pass those into `qicharts2::qic()` via `qic_args` to avoid downstream NSE issues.
- Apply the same normalization/validation to the `n` argument so ratio charts accept quoted symbols programmatically while still rejecting expressions.
- Add a unit test in `tests/testthat/test-security-nse-validation.R` that covers acceptance of quoted symbols and verifies that quoted expressions are still rejected.

### Testing
- Added automated tests: extended `tests/testthat/test-security-nse-validation.R` to include positive and negative cases for quoted-symbol inputs (test file modified). These tests are included in the repository for CI.
- Attempted to run the test suite locally with `devtools::test()` but it could not be executed in this environment because `R` is not installed (`/bin/bash: R: command not found`).
- Performed repository checks such as `git diff --check` which passed locally after changes. CI will run the full R test matrix and must be used to verify all tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6061514ac833093d46adebecb8e87)