### PR TITLE
test(visual): align vdiffr scenarios for issues #118 and #150

### DIFF
--- a/tests/testthat/test-visual-regression.R
+++ b/tests/testthat/test-visual-regression.R
@@ -170,19 +170,44 @@ test_that("vdiffr: chart med target line", {
 # NOTES / ANNOTATIONS
 # ============================================================================
 
-test_that("vdiffr: chart med notes-annotationer", {
+test_that("vdiffr: p-chart med notes-annotationer", {
+  data <- data.frame(
+    month = seq(as.Date("2024-01-01"), by = "month", length.out = 12),
+    events = c(5, 8, 12, 10, 15, 11, 9, 14, 13, 16, 12, 10),
+    total = c(100, 120, 150, 110, 180, 130, 115, 160, 145, 170, 135, 125),
+    notes = c(
+      NA, NA, "Intervention", NA, NA, NA,
+      "Audit", NA, NA, NA, NA, "Follow-up"
+    )
+  )
+
+  result <- suppressWarnings(
+    bfh_qic(
+      data,
+      x = month,
+      y = events,
+      n = total,
+      notes = notes,
+      chart_type = "p",
+      y_axis_unit = "percent",
+      chart_title = "P-Chart with Notes"
+    )
+  )
+  vdiffr::expect_doppelganger("p-chart-with-notes", result$plot)
+})
+
+test_that("vdiffr: chart med custom labels", {
   data <- fixture_deterministic_chart_data()
-  data$notes <- c(NA, NA, NA, "Intervention", NA, NA,
-                  NA, NA, NA, NA, NA, "Follow-up")
 
   result <- bfh_qic(
     data,
     x = month,
     y = infections,
-    notes = notes,
-    chart_type = "i",
+    chart_type = "run",
     y_axis_unit = "count",
-    chart_title = "Chart with Notes"
+    chart_title = "Chart with Custom Labels",
+    xlab = "Måned",
+    ylab = "Infektioner pr. måned"
   )
-  vdiffr::expect_doppelganger("i-chart-with-notes", result$plot)
+  vdiffr::expect_doppelganger("run-chart-with-custom-labels", result$plot)
 })


### PR DESCRIPTION
### Motivation
- Add/adjust visual-regression coverage requested by issues #118 and #150 so baseline snapshots exercise notes handling and custom label output.
- Ensure the vdiffr suite includes a representative p-chart notes case and an explicit run-chart custom-labels case for future snapshot acceptance.

### Description
- Updated `tests/testthat/test-visual-regression.R` to replace the previous i-chart notes scenario with a `p-chart-with-notes` test that supplies `events`, `total` (denominator) and `notes` columns.
- Added a new vdiffr scenario `run-chart-with-custom-labels` that renders a run chart with explicit `xlab` and `ylab` to cover custom axis-label visuals.
- This is a test-only change and does not alter exported package APIs or runtime code.

### Testing
- Attempted to run the package test suite with `R -q -e "devtools::test()"`, but the run failed because `R` is not available in the environment (`/bin/bash: R: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e60652d2a483308b70161e50f6bedc)