### PR TITLE
chore(deps): bump BFHtheme lower-bound to >= 0.5.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ BugReports: https://github.com/johanreventlow/BFHcharts/issues
 Depends:
     R (>= 4.0.0)
 Imports:
-    BFHtheme (>= 0.1.0),
+    BFHtheme (>= 0.5.0),
     ggplot2 (>= 3.4.0),
     qicharts2 (>= 0.7.0),
     scales (>= 1.2.0),


### PR DESCRIPTION
Bumps `BFHtheme (>= 0.1.0)` → `(>= 0.5.0)` in DESCRIPTION.

BFHtheme 0.5.0 breaking changes:
- `add_bfh_logo()` now hard-errors when `cowplot` missing (was warning)
- `library(BFHtheme)` no longer sets knitr options automatically

No code changes needed: `add_bfh_logo()` only appears in `@examples`,
no vignettes depend on implicit ragg/knitr defaults.

Closes #180