### PR TITLE
feat!: validate denominator content for ratio charts (#205)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ covr::package_coverage()
 
 ```r
 # Eksempel: Input validation pattern
-create_spc_chart <- function(data, x, y, chart_type = "run", ...) {
+bfh_qic <- function(data, x, y, chart_type = "run", ...) {
   # Input validation
   stopifnot(
     "data must be a data.frame" = is.data.frame(data),
@@ -108,7 +108,7 @@ Undtagelse: Simple operationer (`git status`, `git diff`, `git log`)
 ### 3.1 R Package Structure
 
 **File organization i `/R/`:**
-* `plot_core.R` – Core plotting functions (bfh_spc_plot, create_spc_chart)
+* `plot_core.R` – Core plotting functions (bfh_spc_plot)
 * `plot_enhancements.R` – Plot enhancement layers (target lines, labels, etc.)
 * `themes.R` – ggplot2 theme functions (bfh_theme)
 * `chart_types.R` – Chart type definitions og mappings
@@ -135,9 +135,9 @@ Undtagelse: Simple operationer (`git status`, `git diff`, `git log`)
 #'
 #' @examples
 #' \dontrun{
-#' create_spc_chart(data = my_data, x = date, y = count, chart_type = "run")
+#' bfh_qic(data = my_data, x = date, y = count, chart_type = "run")
 #' }
-create_spc_chart <- function(data, x, y, chart_type = "run", ...) {
+bfh_qic <- function(data, x, y, chart_type = "run", ...) {
   # Implementation
 }
 ```
@@ -252,26 +252,26 @@ devtools::document()
 
 **Unit tests:**
 ```r
-test_that("create_spc_chart validates input data", {
+test_that("bfh_qic validates input data", {
   # Arrange
   invalid_data <- list(not = "a dataframe")
 
   # Act & Assert
   expect_error(
-    create_spc_chart(data = invalid_data, x = date, y = count),
+    bfh_qic(data = invalid_data, x = date, y = count),
     "data must be a data.frame"
   )
 })
 
-test_that("create_spc_chart returns ggplot object", {
+test_that("bfh_qic returns bfh_qic_result object", {
   # Arrange
   data <- data.frame(date = 1:10, count = rnorm(10))
 
   # Act
-  result <- create_spc_chart(data = data, x = date, y = count)
+  result <- bfh_qic(data = data, x = date, y = count)
 
   # Assert
-  expect_s3_class(result, "ggplot")
+  expect_s3_class(result, "bfh_qic_result")
 })
 ```
 
@@ -579,7 +579,8 @@ vdiffr::expect_doppelganger("name", plot, writer = "svg")
 
 | Fil | Ansvar | Vigtige funktioner |
 |-----|--------|-------------------|
-| **plot_core.R** | Core plotting logic | `create_spc_chart()`, `bfh_spc_plot()` |
+| **create_spc_chart.R** | Public API | `bfh_qic()` |
+| **plot_core.R** | Core plotting logic | `bfh_spc_plot()` |
 | **plot_enhancements.R** | Plot enhancements | Target lines, labels, annotations |
 | **themes.R** | ggplot2 themes | `bfh_theme()`, color palettes |
 | **chart_types.R** | Chart type definitions | Chart type mappings, validering |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@
 ```
 BFHcharts/
 ├── R/
-│   ├── create_spc_chart.R     # Main chart function
+│   ├── create_spc_chart.R     # bfh_qic() — main public API
 │   ├── spc_*.R                # Chart type implementations
 │   ├── anhoej_*.R             # Anhøj rules
 │   ├── utils_*.R              # Utilities
@@ -80,9 +80,9 @@ Følgende funktioner er markeret som `@keywords internal` og tilgængelige via `
 ### Chart Generation Pattern
 
 ```r
-create_spc_chart <- function(data, x, y, chart_type = NULL,
-                             notes_column = NULL, target = NULL,
-                             freeze_period = NULL, ...) {
+bfh_qic <- function(data, x, y, chart_type = NULL,
+                    notes_column = NULL, target = NULL,
+                    freeze_period = NULL, ...) {
   # 1. Input validation
   validate_chart_inputs(data, x, y)
 
@@ -185,7 +185,7 @@ Kræver:
 **Consistent Interface:**
 
 ```r
-create_spc_chart(
+bfh_qic(
   data,              # Data frame
   x,                 # X-axis variable name
   y,                 # Y-axis variable name
@@ -201,7 +201,7 @@ create_spc_chart(
 
 ```r
 # Charts returnerer ggplot objects som kan modificeres
-p <- create_spc_chart(data, "date", "value", "p")
+p <- bfh_qic(data, "date", "value", "p")
 
 # Add custom layers
 p <- p +
@@ -218,7 +218,7 @@ p <- p +
 
 ```r
 # Charts skal bruge BFHtheme som default
-create_spc_chart <- function(..., theme = BFHtheme::theme_bfh()) {
+bfh_qic <- function(..., theme = BFHtheme::theme_bfh()) {
   p <- base_plot + theme
 
   # Tilføj hospital branding hvis ønsket
@@ -316,7 +316,7 @@ LCL <- max(0, u_bar - 3 * sqrt(u_bar / n))
 ```r
 test_that("p-chart calculates correct control limits", {
   data <- data.frame(x = 1:10, y = c(0.1, 0.15, 0.12, ...))
-  chart <- create_spc_chart(data, "x", "y", chart_type = "p")
+  chart <- bfh_qic(data, "x", "y", chart_type = "p")
 
   # Verify UCL/LCL calculations
   expect_equal(chart$ucl, expected_ucl, tolerance = 0.001)

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,28 @@
   ```
   (#203)
 
+* **`bfh_qic()` validerer nu indholdet af denominator-kolonnen `n` for
+  ratio-charts (`p`, `pp`, `u`, `up`).** Tidligere blev kun kolonnenavnet
+  syntakstjekket; rækker med `n = 0`, `n < 0`, `n = Inf` eller `y > n`
+  (P-charts) gled igennem og producerede stille misvisende rate-plots
+  (NaN/Inf-værdier, proportioner > 1). Nu rejses en hård fejl med
+  rækkenumre, så brugeren kan inspicere kildedataene.
+  **Kontrakt:**
+  - Ratio-charts (`p`, `pp`, `u`, `up`) kræver `n` ikke-NULL.
+  - `n` skal være numerisk og endelig (ingen `Inf`/`-Inf`).
+  - Alle ikke-`NA` værdier af `n` skal være `> 0`.
+  - For proportion-charts (`p`, `pp`): hver række skal opfylde `y <= n`.
+  - `NA` i enkelt-rækker af `n` er tilladt (qicharts2 dropper dem).
+  - Andre chart-typer (`run`, `i`, `mr`, `c`, `g`, `t`, `xbar`, `s`)
+    valideres ikke.
+
+  **Migration:** Pre-filtrér data inden `bfh_qic()`:
+  ```r
+  data_clean <- data[!is.na(data$denominator) & data$denominator > 0, ]
+  bfh_qic(data_clean, ...)
+  ```
+  (#205)
+
 * **`bfh_generate_analysis()` kræver nu eksplicit `use_ai = TRUE` for
   AI-analyse.** Defaulten er ændret fra `NULL` (auto-detektér BFHllm) til
   `FALSE` (brug altid standardtekster). I healthcare-kontekst er implicit

--- a/R/create_spc_chart.R
+++ b/R/create_spc_chart.R
@@ -80,6 +80,22 @@ NULL
 #' - `part`: Vector of positions where phase splits occur (e.g., `c(12, 24)`)
 #' - `freeze`: Position to freeze baseline calculation
 #'
+#' **Denominator Contract (ratio charts):**
+#' Ratio chart types (`p`, `pp`, `u`, `up`) require a denominator column
+#' supplied via `n`. The content of `n` is validated to prevent silently
+#' misleading rate plots:
+#' - `n` must be numeric and finite (no `Inf`/`-Inf`).
+#' - All non-`NA` values of `n` must be `> 0` (zero/negative denominators
+#'   produce meaningless rates).
+#' - For proportion charts (`p`, `pp`): every row with both `y` and `n`
+#'   present must satisfy `y <= n` (proportion <= 1).
+#' - `NA` in individual rows of `n` is allowed (qicharts2 drops them).
+#' - Violations raise an error identifying the offending row number(s) so
+#'   the source data can be inspected. Pre-filter or correct invalid rows
+#'   before calling `bfh_qic()`.
+#' Other chart types (`run`, `i`, `mr`, `c`, `g`, `t`, `xbar`, `s`) are not
+#' subject to denominator validation.
+#'
 #' **Unit Support (Danish-friendly):**
 #' Width and height support multiple units for convenience:
 #' - **Smart auto-detection** (default, `units = NULL`):
@@ -670,9 +686,21 @@ bfh_qic <- function(data,
   )
 
   # Add optional arguments
+  n_expr <- NULL
   if (!missing(n) && !is.null(substitute(n))) {
-    qic_args$n <- validate_column_name(substitute(n), "n")
+    n_expr <- validate_column_name(substitute(n), "n")
+    qic_args$n <- n_expr
   }
+
+  # Validate denominator content for ratio charts (p/pp/u/up).
+  # Catches n <= 0, Inf, non-numeric, missing-but-required n, and
+  # y > n (proportion contract). Other chart types are skipped.
+  validate_denominator_data(
+    chart_type = chart_type,
+    data = data,
+    y_col = as.character(y_expr),
+    n_col = if (!is.null(n_expr)) as.character(n_expr) else NULL
+  )
 
   if (!is.null(part)) {
     qic_args$part <- part

--- a/R/utils_helpers.R
+++ b/R/utils_helpers.R
@@ -235,6 +235,113 @@ validate_target_for_unit <- function(target_value, y_axis_unit, multiply) {
 }
 
 # ============================================================================
+# DENOMINATOR CONTENT VALIDATION
+# ============================================================================
+
+#' Validate denominator column content for ratio charts
+#'
+#' Validates the content of the denominator column (`n`) for ratio chart types
+#' (`p`, `pp`, `u`, `up`). Prevents silently misleading rate plots when input
+#' data contains zero, negative, infinite, or proportion-violating denominators.
+#'
+#' **Contract:**
+#' - Ratio charts (`p`, `pp`, `u`, `up`) require `n_col` non-NULL.
+#' - `n` must be numeric.
+#' - `n` must be finite (no `Inf`/`-Inf`).
+#' - All non-`NA` values must satisfy `n > 0`.
+#' - For proportion charts (`p`, `pp`): every row with both `y` and `n` present
+#'   must satisfy `y <= n`.
+#' - `NA` in individual rows of `n` is permitted (qicharts2 drops them).
+#' - All other chart types skip validation.
+#'
+#' **Error format:** Violation messages identify offending row numbers
+#' (1-indexed) so users can locate problematic rows in the source data.
+#'
+#' @param chart_type Character. SPC chart type (e.g., "p", "u", "i").
+#' @param data Data frame passed to `bfh_qic()`.
+#' @param y_col Character. Name of y-axis column in `data`.
+#' @param n_col Character or NULL. Name of denominator column in `data`,
+#'   or NULL if not supplied.
+#'
+#' @return Invisibly NULL on success. Stops with error on violation.
+#' @keywords internal
+#' @noRd
+validate_denominator_data <- function(chart_type, data, y_col, n_col) {
+  RATIO_CHARTS <- c("p", "pp", "u", "up")
+  PROPORTION_CHARTS <- c("p", "pp")
+
+  if (!chart_type %in% RATIO_CHARTS) {
+    return(invisible(NULL))
+  }
+
+  if (is.null(n_col)) {
+    stop(sprintf(
+      "chart_type = \"%s\" requires denominator column `n`. Ratio charts (%s) need n.",
+      chart_type, paste(RATIO_CHARTS, collapse = ", ")
+    ), call. = FALSE)
+  }
+
+  if (!n_col %in% names(data)) {
+    stop(sprintf(
+      "denominator column `%s` not found in data",
+      n_col
+    ), call. = FALSE)
+  }
+  n_data <- data[[n_col]]
+
+  if (!is.numeric(n_data)) {
+    stop(sprintf(
+      "denominator column `%s` must be numeric, got: %s",
+      n_col, class(n_data)[1]
+    ), call. = FALSE)
+  }
+
+  non_na <- !is.na(n_data)
+
+  inf_rows <- which(non_na & is.infinite(n_data))
+  if (length(inf_rows) > 0) {
+    stop(sprintf(
+      "denominator column `%s` contains Inf/-Inf at row(s): %s. Denominators must be finite.",
+      n_col, paste(inf_rows, collapse = ", ")
+    ), call. = FALSE)
+  }
+
+  zero_neg_rows <- which(non_na & is.finite(n_data) & n_data <= 0)
+  if (length(zero_neg_rows) > 0) {
+    stop(sprintf(
+      "denominator column `%s` must be > 0, got %s at row(s): %s",
+      n_col,
+      paste(n_data[zero_neg_rows], collapse = ", "),
+      paste(zero_neg_rows, collapse = ", ")
+    ), call. = FALSE)
+  }
+
+  if (chart_type %in% PROPORTION_CHARTS) {
+    if (!y_col %in% names(data)) {
+      return(invisible(NULL))
+    }
+    y_data <- data[[y_col]]
+    if (!is.numeric(y_data)) {
+      return(invisible(NULL))
+    }
+
+    both_present <- !is.na(y_data) & !is.na(n_data)
+    violation_rows <- which(both_present & y_data > n_data)
+    if (length(violation_rows) > 0) {
+      stop(sprintf(
+        "Proportion chart \"%s\" requires y <= n. Violation at row(s): %s (y = %s, n = %s)",
+        chart_type,
+        paste(violation_rows, collapse = ", "),
+        paste(y_data[violation_rows], collapse = ", "),
+        paste(n_data[violation_rows], collapse = ", ")
+      ), call. = FALSE)
+    }
+  }
+
+  invisible(NULL)
+}
+
+# ============================================================================
 # COMMENT DATA EXTRACTION
 # ============================================================================
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ data <- data.frame(
 )
 
 # Example 1: Simple run chart
-create_spc_chart(
+bfh_qic(
   data = data,
   x = month,
   y = infections,
@@ -78,7 +78,7 @@ create_spc_chart(
 )
 
 # Example 2: P-chart with target line
-create_spc_chart(
+bfh_qic(
   data = data,
   x = month,
   y = infections,
@@ -91,7 +91,7 @@ create_spc_chart(
 )
 
 # Example 3: I-chart with intervention (phase split)
-create_spc_chart(
+bfh_qic(
   data = data,
   x = month,
   y = infections,
@@ -144,7 +144,7 @@ BFHcharts integrates with the **BFHtheme** package for consistent hospital brand
 library(BFHtheme)
 
 # Example 1: Use default BFHtheme
-plot <- create_spc_chart(
+plot <- bfh_qic(
   data = data,
   x = month,
   y = infections,
@@ -157,7 +157,7 @@ plot <- create_spc_chart(
 plot <- plot |> BFHtheme::add_bfh_logo()
 
 # Example 3: Apply alternative BFHtheme variants
-plot <- create_spc_chart(
+plot <- bfh_qic(
   data = data,
   x = month,
   y = infections,
@@ -167,7 +167,7 @@ plot <- create_spc_chart(
 ) + BFHtheme::theme_bfh_dark()
 
 # Example 4: Use BFHtheme color palettes
-plot <- create_spc_chart(
+plot <- bfh_qic(
   data = data,
   x = month,
   y = infections,
@@ -233,7 +233,7 @@ See `TRANSLATORS.md` for instructions on adding a new language.
 
 ## Documentation
 
-- Roxygen reference topics, e.g. `?create_spc_chart` or `help(package = "BFHcharts")`
+- Roxygen reference topics, e.g. `?bfh_qic` or `help(package = "BFHcharts")`
 - Architecture notes in [`docs/`](docs/DOCUMENTATION_OVERVIEW.md)
 - Vignettes are planned; links will be added once the articles ship
 

--- a/man/bfh_qic.Rd
+++ b/man/bfh_qic.Rd
@@ -145,6 +145,24 @@ entire workflow from raw data to finished plot with intelligent labels.
 \item \code{freeze}: Position to freeze baseline calculation
 }
 
+\strong{Denominator Contract (ratio charts):}
+Ratio chart types (\code{p}, \code{pp}, \code{u}, \code{up}) require a denominator column
+supplied via \code{n}. The content of \code{n} is validated to prevent silently
+misleading rate plots:
+\itemize{
+\item \code{n} must be numeric and finite (no \code{Inf}/\code{-Inf}).
+\item All non-\code{NA} values of \code{n} must be \verb{> 0} (zero/negative denominators
+produce meaningless rates).
+\item For proportion charts (\code{p}, \code{pp}): every row with both \code{y} and \code{n}
+present must satisfy \code{y <= n} (proportion <= 1).
+\item \code{NA} in individual rows of \code{n} is allowed (qicharts2 drops them).
+\item Violations raise an error identifying the offending row number(s) so
+the source data can be inspected. Pre-filter or correct invalid rows
+before calling \code{bfh_qic()}.
+Other chart types (\code{run}, \code{i}, \code{mr}, \code{c}, \code{g}, \code{t}, \code{xbar}, \code{s}) are not
+subject to denominator validation.
+}
+
 \strong{Unit Support (Danish-friendly):}
 Width and height support multiple units for convenience:
 \itemize{

--- a/openspec/changes/add-denominator-validator/proposal.md
+++ b/openspec/changes/add-denominator-validator/proposal.md
@@ -1,0 +1,70 @@
+## Why
+
+`bfh_qic()` validates the `n` argument only as a syntactically valid column name (`R/create_spc_chart.R:661`). It does not validate the *content* of the denominator column. Users with `n = 0`, `n = NA`, `n = Inf`, or `y > n` for P/PP-charts pass validation and produce silently misleading charts (NaN/Inf rates, illegal proportions > 1, or empty points where users expect signals).
+
+Codex code review 2026-04-27 (finding #3) flagged this as HIGH severity. Clinical impact: false-clean reports when underlying data is invalid.
+
+## What Changes
+
+- **BREAKING**: `bfh_qic()` validates denominator column content for ratio charts (`p`, `pp`, `u`, `up`).
+- New internal helper `validate_denominator_data()` in `R/utils_helpers.R`:
+  - Requires `n` for ratio chart types (`p`, `pp`, `u`, `up`); errors if missing
+  - Rejects non-numeric `n` column
+  - Rejects `Inf` / `-Inf` in `n`
+  - Rejects `n <= 0` (zero/negative denominator gives meaningless rate)
+  - Allows `NA` in individual rows (qicharts2 drops them)
+  - For `p` / `pp` charts: rejects rows where `y > n` (proportion > 1)
+  - Reports row numbers in violation messages
+- xbar/s/i/run/c/g/t charts: not subject to denominator validation (no `n` semantics or `n` is subgroup grouping)
+- Add 10 new tests covering all chart types and violation modes
+- Update `bfh_qic()` Roxygen `@details` with denominator contract section
+- NEWS entry under `## Breaking changes`, version bump 0.8.3 → 0.9.0 (combined release with #203 percent-target proposal)
+
+## Impact
+
+**Affected specs:**
+- `public-api` — ADDED requirement: denominator validation contract for ratio charts
+
+**Affected code:**
+- `R/utils_helpers.R` — new internal helper `validate_denominator_data()`
+- `R/create_spc_chart.R` — wire validation call before `do.call(qicharts2::qic, ...)`
+- `tests/testthat/test-denominator-validator.R` — new file
+- `NEWS.md` — breaking change entry
+
+**Breaking change scope:**
+- Existing callers passing `n = 0`, `n = Inf`, `y > n` (P-chart), or omitting `n` for ratio charts will receive hard errors instead of silent NaN/Inf or kryptisk qicharts2-fejl
+- Pre-1.0 → MINOR bump
+
+## Cross-repo impact (biSPCharts)
+
+**Verification before BFHcharts 0.9.0 release:**
+```bash
+# I biSPCharts:
+grep -rn "n\s*=" R/ | grep -E "bfh_qic|create_spc_chart"
+```
+
+**Likely affected:** any biSPCharts data flow that may include rows with `n = 0` (e.g., a month with no patients, missing denominator data).
+
+**Migration pattern for biSPCharts:**
+```r
+# Pre-filter data before bfh_qic call:
+data_clean <- data[!is.na(data$denominator) & data$denominator > 0, ]
+n_dropped <- nrow(data) - nrow(data_clean)
+if (n_dropped > 0) {
+  showNotification(
+    sprintf("Dropped %d rows with invalid denominator", n_dropped),
+    type = "warning"
+  )
+}
+bfh_qic(data_clean, ...)
+```
+
+**biSPCharts version bump:** PATCH (input cleaning) or MINOR (if UI surfaces validation feedback).
+
+**Lower-bound in biSPCharts/DESCRIPTION:** `BFHcharts (>= 0.9.0)`
+
+## Related
+
+- GitHub Issue: #205
+- Combined release with #203 (`fix-percent-target-scale-contract`) — both are clinical-correctness fixes targeting v0.9.0
+- Source: BFHcharts code review 2026-04-27, Codex finding #3

--- a/openspec/changes/add-denominator-validator/specs/public-api/spec.md
+++ b/openspec/changes/add-denominator-validator/specs/public-api/spec.md
@@ -1,0 +1,129 @@
+## ADDED Requirements
+
+### Requirement: Public API SHALL validate denominator column content for ratio charts
+
+The package SHALL validate the content of the denominator column (`n` argument) for ratio chart types (`p`, `pp`, `u`, `up`) to prevent silently misleading rate plots from invalid denominator data.
+
+**Rationale:**
+- Healthcare data routinely contain rows with missing or zero denominators (e.g., months with no patients, missing data ingest)
+- Without content validation, qicharts2 produces NaN/Inf rates that render as silent gaps or out-of-range points
+- For P-charts, `y > n` violates the proportion contract (proportion ≤ 1) but qicharts2 plots it anyway
+- Strict failure with row-numbered messages makes invalid data visible to users instead of hidden
+
+**Contract:**
+
+| Chart type | `n` required | Validations on `n` content |
+|---|---|---|
+| `p`, `pp` | yes | `n > 0`, finite, `y <= n` per row |
+| `u`, `up` | yes | `n > 0`, finite |
+| `c`, `g`, `t` | no | n/a |
+| `i`, `mr`, `run` | no | n/a |
+| `xbar`, `s` | no (uses duplicated x as subgrouping) | n/a |
+
+`NA` in individual rows of `n` is permitted (qicharts2 drops them as missing data).
+
+#### Scenario: ratio chart without n rejected
+
+- **GIVEN** `chart_type = "p"` and no `n` argument
+- **WHEN** `bfh_qic(...)` is called
+- **THEN** an error SHALL be raised
+- **AND** the message SHALL identify which chart types require `n`
+
+```r
+data <- data.frame(period = 1:8, events = rep(5L, 8))
+expect_error(
+  bfh_qic(data, x = period, y = events, chart_type = "p"),
+  "requires denominator"
+)
+```
+
+#### Scenario: zero denominator rejected
+
+- **GIVEN** `chart_type = "p"`, `n = c(100, 0, 100, 100)`
+- **WHEN** `bfh_qic(...)` is called
+- **THEN** an error SHALL be raised
+- **AND** the message SHALL state that `n` must be > 0
+
+```r
+data <- data.frame(
+  period = 1:4,
+  events = c(5L, 0L, 5L, 5L),
+  total = c(100L, 0L, 100L, 100L)
+)
+expect_error(
+  bfh_qic(data, x = period, y = events, n = total, chart_type = "p"),
+  "must be > 0"
+)
+```
+
+#### Scenario: negative denominator rejected
+
+- **GIVEN** `chart_type = "u"`, `n = c(100, -5, 100, 100)`
+- **WHEN** `bfh_qic(...)` is called
+- **THEN** an error SHALL be raised
+
+#### Scenario: infinite denominator rejected
+
+- **GIVEN** `n` column contains `Inf`
+- **WHEN** `bfh_qic(...)` is called
+- **THEN** an error SHALL be raised mentioning Inf/-Inf
+
+#### Scenario: NA in individual rows of n permitted
+
+- **GIVEN** `chart_type = "p"`, `n = c(100, NA, 100, 100)`, `y` valid otherwise
+- **WHEN** `bfh_qic(...)` is called
+- **THEN** the function SHALL succeed
+- **AND** qicharts2 SHALL drop the NA row from calculations
+
+```r
+data <- data.frame(
+  period = 1:4,
+  events = c(5L, 5L, 5L, 5L),
+  total = c(100L, NA_integer_, 100L, 100L)
+)
+result <- bfh_qic(data, x = period, y = events, n = total, chart_type = "p")
+expect_s3_class(result, "bfh_qic_result")
+```
+
+#### Scenario: y greater than n on P-chart rejected with row numbers
+
+- **GIVEN** `chart_type = "p"`, `y = c(5, 6, 200, 8)`, `n = c(100, 100, 100, 100)`
+- **WHEN** `bfh_qic(...)` is called
+- **THEN** an error SHALL be raised
+- **AND** the message SHALL identify the violation row(s) (row 3 in this example)
+
+```r
+data <- data.frame(
+  period = 1:4,
+  events = c(5L, 6L, 200L, 8L),
+  total = rep(100L, 4)
+)
+expect_error(
+  bfh_qic(data, x = period, y = events, n = total, chart_type = "p"),
+  "y <= n"
+)
+```
+
+#### Scenario: u-chart allows y > n
+
+- **GIVEN** `chart_type = "u"`, `y = c(50, 60, 200)`, `n = c(100, 100, 100)`
+- **WHEN** `bfh_qic(...)` is called
+- **THEN** the function SHALL succeed
+- **AND** rates can exceed 1 (events per unit, not proportion)
+
+```r
+data <- data.frame(
+  period = 1:3,
+  events = c(50L, 60L, 200L),
+  exposure = rep(100L, 3)
+)
+result <- bfh_qic(data, x = period, y = events, n = exposure, chart_type = "u")
+expect_s3_class(result, "bfh_qic_result")
+```
+
+#### Scenario: xbar chart skips n validation
+
+- **GIVEN** `chart_type = "xbar"` with subgroup data (duplicated x values, no n)
+- **WHEN** `bfh_qic(...)` is called
+- **THEN** the function SHALL NOT validate denominator content
+- **AND** the function SHALL succeed

--- a/openspec/changes/add-denominator-validator/tasks.md
+++ b/openspec/changes/add-denominator-validator/tasks.md
@@ -1,0 +1,42 @@
+## 1. Validation infrastructure
+
+- [ ] 1.1 Add `validate_denominator_data()` in `R/utils_helpers.R`
+- [ ] 1.2 Wire call into `bfh_qic()` after column-name validation, before `do.call(qicharts2::qic, ...)`
+- [ ] 1.3 Resolve y_data and n_data from `data` for content checks
+- [ ] 1.4 Roxygen documentation for helper
+
+## 2. Tests
+
+- [ ] 2.1 Create `tests/testthat/test-denominator-validator.R`
+- [ ] 2.2 Test: p-chart without `n` → error
+- [ ] 2.3 Test: i-chart without `n` → succeeds (n not required)
+- [ ] 2.4 Test: p-chart with `n = c(100, 0, 100)` → error mentions ">0"
+- [ ] 2.5 Test: p-chart with `n = c(100, -5, 100)` → error
+- [ ] 2.6 Test: p-chart with `n = c(100, Inf, 100)` → error
+- [ ] 2.7 Test: p-chart with `n = c(100, NA, 100)` → succeeds (NA allowed)
+- [ ] 2.8 Test: p-chart with `y = c(5, 6, 200)` and `n = c(100, 100, 100)` → error mentions row 3
+- [ ] 2.9 Test: p-chart with `y <= n` → succeeds
+- [ ] 2.10 Test: u-chart with `n = 0` → error (same rule)
+- [ ] 2.11 Test: pp-chart with `y > n` → error (proportion percent variant)
+- [ ] 2.12 Test: xbar-chart no n-validation (subgroup mechanism via duplicated x)
+
+## 3. Documentation
+
+- [ ] 3.1 Add `@details` "Denominator Contract" section to `bfh_qic()` Roxygen
+- [ ] 3.2 NEWS.md entry under `## Breaking changes` for v0.9.0
+- [ ] 3.3 Document the row-number reporting format in helper Roxygen
+
+## 4. Cross-repo coordination (biSPCharts)
+
+- [ ] 4.1 Grep biSPCharts for affected callsites
+- [ ] 4.2 Open companion issue in biSPCharts with migration snippet
+- [ ] 4.3 Coordinate release timing with #203 (same v0.9.0 bump)
+
+## 5. Release
+
+- [ ] 5.1 Bump `DESCRIPTION` 0.8.3 → 0.9.0 (combined with #203)
+- [ ] 5.2 `devtools::test()` passes
+- [ ] 5.3 `devtools::check()` no new WARN/ERROR
+- [ ] 5.4 Tag v0.9.0 after merge
+
+Tracking: GitHub Issue #205

--- a/openspec/changes/add-denominator-validator/tasks.md
+++ b/openspec/changes/add-denominator-validator/tasks.md
@@ -1,42 +1,42 @@
 ## 1. Validation infrastructure
 
-- [ ] 1.1 Add `validate_denominator_data()` in `R/utils_helpers.R`
-- [ ] 1.2 Wire call into `bfh_qic()` after column-name validation, before `do.call(qicharts2::qic, ...)`
-- [ ] 1.3 Resolve y_data and n_data from `data` for content checks
-- [ ] 1.4 Roxygen documentation for helper
+- [x] 1.1 Add `validate_denominator_data()` in `R/utils_helpers.R`
+- [x] 1.2 Wire call into `bfh_qic()` after column-name validation, before `do.call(qicharts2::qic, ...)`
+- [x] 1.3 Resolve y_data and n_data from `data` for content checks
+- [x] 1.4 Roxygen documentation for helper
 
 ## 2. Tests
 
-- [ ] 2.1 Create `tests/testthat/test-denominator-validator.R`
-- [ ] 2.2 Test: p-chart without `n` → error
-- [ ] 2.3 Test: i-chart without `n` → succeeds (n not required)
-- [ ] 2.4 Test: p-chart with `n = c(100, 0, 100)` → error mentions ">0"
-- [ ] 2.5 Test: p-chart with `n = c(100, -5, 100)` → error
-- [ ] 2.6 Test: p-chart with `n = c(100, Inf, 100)` → error
-- [ ] 2.7 Test: p-chart with `n = c(100, NA, 100)` → succeeds (NA allowed)
-- [ ] 2.8 Test: p-chart with `y = c(5, 6, 200)` and `n = c(100, 100, 100)` → error mentions row 3
-- [ ] 2.9 Test: p-chart with `y <= n` → succeeds
-- [ ] 2.10 Test: u-chart with `n = 0` → error (same rule)
-- [ ] 2.11 Test: pp-chart with `y > n` → error (proportion percent variant)
-- [ ] 2.12 Test: xbar-chart no n-validation (subgroup mechanism via duplicated x)
+- [x] 2.1 Create `tests/testthat/test-denominator-validator.R`
+- [x] 2.2 Test: p-chart without `n` → error
+- [x] 2.3 Test: i-chart without `n` → succeeds (n not required)
+- [x] 2.4 Test: p-chart with `n = c(100, 0, 100)` → error mentions ">0"
+- [x] 2.5 Test: p-chart with `n = c(100, -5, 100)` → error
+- [x] 2.6 Test: p-chart with `n = c(100, Inf, 100)` → error
+- [x] 2.7 Test: p-chart with `n = c(100, NA, 100)` → succeeds (NA allowed)
+- [x] 2.8 Test: p-chart with `y = c(5, 6, 200)` and `n = c(100, 100, 100)` → error mentions row 3
+- [x] 2.9 Test: p-chart with `y <= n` → succeeds
+- [x] 2.10 Test: u-chart with `n = 0` → error (same rule)
+- [x] 2.11 Test: pp-chart with `y > n` → error (proportion percent variant)
+- [x] 2.12 Test: xbar-chart no n-validation (subgroup mechanism via duplicated x)
 
 ## 3. Documentation
 
-- [ ] 3.1 Add `@details` "Denominator Contract" section to `bfh_qic()` Roxygen
-- [ ] 3.2 NEWS.md entry under `## Breaking changes` for v0.9.0
-- [ ] 3.3 Document the row-number reporting format in helper Roxygen
+- [x] 3.1 Add `@details` "Denominator Contract" section to `bfh_qic()` Roxygen
+- [x] 3.2 NEWS.md entry under `## Breaking changes` for v0.9.0
+- [x] 3.3 Document the row-number reporting format in helper Roxygen
 
 ## 4. Cross-repo coordination (biSPCharts)
 
-- [ ] 4.1 Grep biSPCharts for affected callsites
+- [x] 4.1 Grep biSPCharts for affected callsites (call site: `R/fct_spc_bfh_invocation.R:113` via `do.call`; data flows from upstream prep — runtime impact only, no static n=0 literals)
 - [ ] 4.2 Open companion issue in biSPCharts with migration snippet
-- [ ] 4.3 Coordinate release timing with #203 (same v0.9.0 bump)
+- [x] 4.3 Coordinate release timing with #203 (same v0.9.0 bump — already combined in DESCRIPTION/NEWS)
 
 ## 5. Release
 
-- [ ] 5.1 Bump `DESCRIPTION` 0.8.3 → 0.9.0 (combined with #203)
-- [ ] 5.2 `devtools::test()` passes
-- [ ] 5.3 `devtools::check()` no new WARN/ERROR
+- [x] 5.1 Bump `DESCRIPTION` 0.8.3 → 0.9.0 (already at 0.9.0 from #203)
+- [x] 5.2 `devtools::test()` passes
+- [x] 5.3 `devtools::check()` no new WARN/ERROR (0 errors; 4 warnings + 4 notes all pre-existing)
 - [ ] 5.4 Tag v0.9.0 after merge
 
 Tracking: GitHub Issue #205

--- a/openspec/changes/expose-variable-control-limits-in-summary/proposal.md
+++ b/openspec/changes/expose-variable-control-limits-in-summary/proposal.md
@@ -1,0 +1,71 @@
+## Why
+
+`format_qic_summary()` (`R/utils_qic_summary.R:139-154`) silently drops `nedre_kontrolgrænse`/`øvre_kontrolgrænse` from the summary when control limits are non-constant per part:
+
+```r
+if (lcl_constant && ucl_constant) {
+  formatted$nedre_kontrolgrænse <- round(raw_summary$lcl, decimal_places)
+  formatted$øvre_kontrolgrænse <- round(raw_summary$ucl, decimal_places)
+}
+# If not constant, don't include them in summary
+```
+
+For P/U-charts with variable denominators (the **clinically most common case**), control limits vary per observation. The summary then contains no limits at all — without warning. Downstream callers (biSPCharts dashboards, manual reports) get summaries that look complete but lack control bounds.
+
+Both reviews flagged this. Codex called it "correct defensive behavior". I disagree: in healthcare, *invisible omission* is more dangerous than visible imprecision. A summary without limits can be misread as "no signal" rather than "limits vary".
+
+## What Changes
+
+- **NON-BREAKING addition**: When control limits are not constant per part, summary SHALL include four new columns:
+  - `nedre_kontrolgrænse_min` — minimum LCL across the part
+  - `nedre_kontrolgrænse_max` — maximum LCL across the part
+  - `øvre_kontrolgrænse_min` — minimum UCL across the part
+  - `øvre_kontrolgrænse_max` — maximum UCL across the part
+- **NON-BREAKING addition**: New logical column `kontrolgrænser_konstante` indicating whether limits are constant within the part (TRUE = single value, FALSE = varying)
+- **PRESERVED behavior**: When limits are constant, `nedre_kontrolgrænse`/`øvre_kontrolgrænse` columns continue to populate as before. `kontrolgrænser_konstante = TRUE` in this case
+- New tests covering both constant and variable-limit cases
+- Update `bfh_qic()` Roxygen `@return` to describe new columns
+- NEWS entry under `## Nye features` for v0.9.x (additive, no breaking change)
+
+## Impact
+
+**Affected specs:**
+- `public-api` — ADDED requirement: control limits exposure for variable denominator charts
+
+**Affected code:**
+- `R/utils_qic_summary.R:139-154` — replace silent drop with min/max + constant-flag columns
+- `tests/testthat/test-utils_qic_summary.R` — extend with variable-limit tests
+- `R/create_spc_chart.R` — update Roxygen `@return` description for `result$summary`
+
+**Non-breaking:** existing callers reading `nedre_kontrolgrænse`/`øvre_kontrolgrænse` continue to work for constant cases. New columns are additive. Pre-1.0 → MINOR bump (safe additive).
+
+## Cross-repo impact (biSPCharts)
+
+**Verification:**
+```bash
+# I biSPCharts:
+grep -rn "nedre_kontrolgrænse\|øvre_kontrolgrænse\|centerlinje" R/
+```
+
+**Expected impact:** Low. biSPCharts code reading constant-limit summaries continues to work. New variable-limit summaries can be ignored or surfaced in UI.
+
+**Optional enhancement for biSPCharts:**
+```r
+# Detect variable-limit case and surface in UI:
+if (!summary$kontrolgrænser_konstante[i]) {
+  showNotification(
+    "Control limits vary per observation; see chart for individual bounds.",
+    type = "info"
+  )
+}
+```
+
+**biSPCharts version bump:** PATCH (no required changes; optional enhancement)
+
+**Lower-bound:** can wait until biSPCharts wants to use the new columns.
+
+## Related
+
+- GitHub Issue: #206
+- Source: BFHcharts code review 2026-04-27, Claude finding #1 (CRITICAL in initial review)
+- Codex finding: noted but classified as "correct defensive" — disagreement resolved by exposing the data instead of hiding it

--- a/openspec/changes/expose-variable-control-limits-in-summary/specs/public-api/spec.md
+++ b/openspec/changes/expose-variable-control-limits-in-summary/specs/public-api/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: Summary SHALL expose variable control limits via min/max columns
+
+When control limits vary across observations within a part (typical for P-charts and U-charts with varying denominators), the summary returned by `bfh_qic()$summary` SHALL include explicit per-part minimum and maximum bounds plus a flag indicating whether limits are constant.
+
+**Rationale:**
+- Healthcare-typical P/U charts have variable denominators per period
+- Without exposed bounds, downstream consumers cannot distinguish "no limits available" from "limits vary"
+- Silent omission can be misread as a stable process when limits actually fluctuated
+- Exposing min/max preserves correctness while keeping summary actionable for reports
+
+**Contract:**
+
+| Limit constancy in part | `kontrolgrænser_konstante` | `nedre_/øvre_kontrolgrænse` (scalar) | `*_min`/`*_max` columns |
+|---|---|---|---|
+| Constant | `TRUE` | populated with single value | absent or NA |
+| Variable | `FALSE` | absent or NA | populated with min/max across part |
+
+#### Scenario: constant limits expose scalar columns and TRUE flag
+
+- **GIVEN** an i-chart with constant control limits within a single part
+- **WHEN** `format_qic_summary(...)` is called
+- **THEN** the summary SHALL contain `nedre_kontrolgrænse` and `øvre_kontrolgrænse` as scalar columns
+- **AND** `kontrolgrænser_konstante` SHALL be `TRUE`
+
+```r
+data <- data.frame(period = 1:10, value = c(10, 11, 10, 11, 10, 11, 10, 11, 10, 11))
+result <- bfh_qic(data, x = period, y = value, chart_type = "i")
+expect_true(result$summary$kontrolgrænser_konstante[1])
+expect_true("nedre_kontrolgrænse" %in% names(result$summary))
+expect_false(is.na(result$summary$nedre_kontrolgrænse[1]))
+```
+
+#### Scenario: variable limits expose min/max columns and FALSE flag
+
+- **GIVEN** a P-chart with varying denominators within a part (e.g., `n = c(100, 200, 50)`)
+- **WHEN** `format_qic_summary(...)` is called
+- **THEN** the summary SHALL contain `nedre_kontrolgrænse_min`, `nedre_kontrolgrænse_max`, `øvre_kontrolgrænse_min`, `øvre_kontrolgrænse_max` columns
+- **AND** `kontrolgrænser_konstante` SHALL be `FALSE`
+- **AND** the min ≤ max relationship SHALL hold
+
+```r
+data <- data.frame(
+  period = 1:6,
+  events = c(5, 10, 5, 10, 5, 10),
+  total = c(100, 200, 50, 200, 100, 50)  # varying n
+)
+result <- bfh_qic(data, x = period, y = events, n = total,
+                  chart_type = "p", y_axis_unit = "percent")
+expect_false(result$summary$kontrolgrænser_konstante[1])
+expect_true("nedre_kontrolgrænse_min" %in% names(result$summary))
+expect_lte(result$summary$nedre_kontrolgrænse_min[1],
+           result$summary$nedre_kontrolgrænse_max[1])
+```
+
+#### Scenario: backward-compatible reads on constant-limit summaries
+
+- **GIVEN** existing downstream code that reads `summary$nedre_kontrolgrænse` for a constant-limit chart
+- **WHEN** `format_qic_summary(...)` is called
+- **THEN** the column SHALL be present and populated as before
+- **AND** existing tests SHALL pass without modification
+
+#### Scenario: mixed constancy across multi-part summary
+
+- **GIVEN** a multi-part chart where part 1 has constant limits and part 2 has variable limits
+- **WHEN** `format_qic_summary(...)` is called
+- **THEN** `kontrolgrænser_konstante` SHALL be `TRUE` for part 1 and `FALSE` for part 2
+- **AND** scalar columns SHALL be populated for part 1 (NA or absent for part 2)
+- **AND** min/max columns SHALL be populated for part 2 (NA for part 1)

--- a/openspec/changes/expose-variable-control-limits-in-summary/tasks.md
+++ b/openspec/changes/expose-variable-control-limits-in-summary/tasks.md
@@ -1,0 +1,38 @@
+## 1. Implementation
+
+- [ ] 1.1 In `R/utils_qic_summary.R:139-154`, replace silent drop with:
+  - Compute `lcl_min`, `lcl_max`, `ucl_min`, `ucl_max` per part
+  - Add `kontrolgrænser_konstante` logical column
+  - Populate `nedre_kontrolgrænse_min`/`max` and `øvre_kontrolgrænse_min`/`max` columns when limits vary
+  - Continue to populate scalar `nedre_kontrolgrænse`/`øvre_kontrolgrænse` when constant (preserve backward compat)
+- [ ] 1.2 Verify column ordering preserved per existing tests
+
+## 2. Tests
+
+- [ ] 2.1 Extend `tests/testthat/test-utils_qic_summary.R`
+- [ ] 2.2 Test: constant limits → `kontrolgrænser_konstante = TRUE`, scalar columns populated, min/max columns absent or NA
+- [ ] 2.3 Test: variable limits (P-chart, varying n) → `kontrolgrænser_konstante = FALSE`, min/max columns populated with sensible values
+- [ ] 2.4 Test: per-part with mixed constant/variable → flag correctly per row
+- [ ] 2.5 Test: backward compat — existing assertions on scalar `nedre_kontrolgrænse` for constant cases still pass
+- [ ] 2.6 Test: P-chart with constant n → constant limits → scalar columns
+- [ ] 2.7 Test: P-chart with varying n → variable limits → min/max columns
+
+## 3. Documentation
+
+- [ ] 3.1 Update `bfh_qic()` Roxygen `@return` describing new columns
+- [ ] 3.2 Document `kontrolgrænser_konstante` semantics in `format_qic_summary` Roxygen
+- [ ] 3.3 NEWS.md entry under `## Nye features` for v0.9.x
+
+## 4. Cross-repo coordination (biSPCharts)
+
+- [ ] 4.1 Grep biSPCharts for `nedre_kontrolgrænse|øvre_kontrolgrænse` usage
+- [ ] 4.2 Verify backward compat (constant-limit reads still work)
+- [ ] 4.3 Optionally: open biSPCharts enhancement issue for surfacing variable-limit info
+
+## 5. Release
+
+- [ ] 5.1 Bump version (combine with 0.9.0 or follow as 0.9.1)
+- [ ] 5.2 Tests pass
+- [ ] 5.3 `devtools::check()` clean
+
+Tracking: GitHub Issue #206

--- a/openspec/changes/harden-batch-session-race-safety/proposal.md
+++ b/openspec/changes/harden-batch-session-race-safety/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+Codex finding #7: `bfh_create_export_session()` shares a single `temp_dir` across all `bfh_export_pdf()` calls in batch mode. Each export writes fixed filenames `chart.svg` and `document.typ` to the same directory:
+
+```r
+# R/export_pdf.R:367
+on.exit(
+  {
+    unlink(file.path(temp_dir, "chart.svg"))
+    unlink(file.path(temp_dir, "document.typ"))
+  },
+  add = TRUE
+)
+```
+
+**Documented limitation:** "Sessions are single-threaded sequential only — do not share across parallel workers" (`R/export_session.R:32`).
+
+**Risks:**
+1. **Parallel race**: if user violates the documentation and calls `bfh_export_pdf()` from `future_lapply()`, two exports overwrite each other's `chart.svg`/`document.typ` → corrupt PDFs
+2. **Sequential ambiguity**: even sequential reuse risks orphan cleanup if one export crashes mid-render
+3. **No enforcement**: nothing prevents parallel use; documentation alone is insufficient
+
+Sequential safety is also weaker than it could be — adding per-export unique filenames eliminates the race entirely without adding overhead.
+
+## What Changes
+
+- **NON-BREAKING**: replace fixed `chart.svg` / `document.typ` filenames with per-export unique names (`chart-<rand>.svg`, `document-<rand>.typ`) using `tempfile(tmpdir = temp_dir, fileext = ".svg")`
+- Update cleanup logic to reference the actual generated filenames (track via local variables, not hardcoded names)
+- Add lock file mechanism (optional, defer to discussion): `flock`-style PID-based lock on `temp_dir` prevents accidental parallel use
+- Add `reg.finalizer()` on session object as backup cleanup if user forgets `close()`
+- New tests:
+  - Sequential 5x batch → all PDFs unique and valid
+  - Concurrent (intentional) batch via `future`/`parallel` → either succeeds with isolated artifacts OR fails fast with clear error
+  - Crash mid-export → cleanup correctly removes only that export's files
+- Document race-safety guarantees explicitly in `bfh_create_export_session()` Roxygen
+
+## Impact
+
+**Affected specs:**
+- `pdf-export` — MODIFIED requirement: batch session SHALL use per-export unique filenames
+
+**Affected code:**
+- `R/export_pdf.R:367-371, 431, 461` — replace fixed filenames with unique
+- `R/export_session.R` — add `reg.finalizer()`, expand Roxygen on safety guarantees
+- `tests/testthat/test-export-session.R` — extend with concurrency tests (using parallel package or simulated)
+- NEWS entry under `## Bug fixes` or `## Forbedringer`
+
+**Non-breaking:**
+- Public API unchanged
+- Sequential semantics unchanged
+- Just removes possibility of fixed-name collision
+
+## Cross-repo impact (biSPCharts)
+
+biSPCharts likely uses `bfh_create_export_session()` in dashboard batch flows. No code change required — but biSPCharts can now safely consider parallelism if needed.
+
+## Related
+
+- GitHub Issue: #213
+- Source: BFHcharts code review 2026-04-27 (Codex #7)

--- a/openspec/changes/harden-batch-session-race-safety/specs/pdf-export/spec.md
+++ b/openspec/changes/harden-batch-session-race-safety/specs/pdf-export/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: Batch session SHALL use per-export unique intermediate filenames
+
+The package SHALL generate per-export unique filenames for intermediate artifacts (`chart.svg`, `document.typ`) within a shared `batch_session` tmpdir to eliminate filename collisions between exports and to make race conditions impossible by construction.
+
+**Rationale:**
+- Fixed filenames create a guaranteed collision if any caller violates the documented sequential-only contract (e.g., calling from `future_lapply()`)
+- Even sequential semantics benefit: a crashed export leaves orphan files only for its own filenames, preventing pollution of subsequent exports
+- Unique names cost only one `tempfile()` call per export — negligible overhead
+
+**Filename pattern:**
+```r
+chart_svg <- tempfile(pattern = "chart-", tmpdir = temp_dir, fileext = ".svg")
+typst_file <- tempfile(pattern = "document-", tmpdir = temp_dir, fileext = ".typ")
+```
+
+The Typst document SHALL reference the chart by relative basename (already the case in `build_typst_content()`), so unique filenames cause no document-content changes.
+
+#### Scenario: sequential batch produces unique intermediates per export
+
+- **GIVEN** a batch session and 10 sequential `bfh_export_pdf()` calls
+- **WHEN** all calls complete
+- **THEN** no two intermediate filenames SHALL have collided
+- **AND** all 10 final PDFs SHALL be valid
+
+```r
+session <- bfh_create_export_session()
+on.exit(close(session))
+for (i in 1:10) {
+  out <- tempfile(fileext = ".pdf")
+  bfh_export_pdf(result, out, batch_session = session)
+  expect_true(file.exists(out))
+}
+```
+
+#### Scenario: crash mid-export leaves only its own intermediates
+
+- **GIVEN** an export that crashes after writing `chart-XYZ.svg` but before completing
+- **WHEN** the next export runs in the same session
+- **THEN** the next export SHALL use a different chart filename (`chart-ABC.svg`)
+- **AND** the crashed export's orphan SHALL be removable independently
+
+#### Scenario: parallel batch isolation by construction
+
+- **GIVEN** two `bfh_export_pdf()` calls run concurrently against the same session (violating documented contract)
+- **WHEN** both write intermediates
+- **THEN** unique filenames SHALL prevent overwrite
+- **AND** both PDFs SHALL be valid OR fail with clear error (not silently corrupted)
+
+> Note: Parallel use is still not officially supported. This requirement removes a class of failure modes but does not promote parallel as a recommended pattern.
+
+### Requirement: Batch session SHALL register a finalizer for orphan tmpdir cleanup
+
+`bfh_create_export_session()` SHALL register a finalizer on the returned session object that calls `close()` if the user drops the reference without explicitly closing.
+
+**Rationale:**
+- R has no implicit RAII; users frequently forget `close()` in dashboards or scripts
+- Without finalizer, abandoned sessions leave tmpdirs until R session ends
+- Finalizer is a backup, not a substitute for `close()` — explicit cleanup is still preferred
+
+#### Scenario: dropped session reference triggers cleanup on GC
+
+- **GIVEN** a session created and reference dropped without `close()`
+- **WHEN** garbage collection runs
+- **THEN** the session tmpdir SHALL be removed
+- **AND** no error SHALL be raised even if `close()` was never called
+
+```r
+local({
+  session <- bfh_create_export_session()
+  tmpdir_path <- session$tmpdir
+  rm(session)
+  gc()
+  expect_false(dir.exists(tmpdir_path))
+})
+```

--- a/openspec/changes/harden-batch-session-race-safety/tasks.md
+++ b/openspec/changes/harden-batch-session-race-safety/tasks.md
@@ -1,0 +1,34 @@
+## 1. Per-export unique filenames
+
+- [ ] 1.1 Replace `file.path(temp_dir, "chart.svg")` with `tempfile(pattern = "chart-", tmpdir = temp_dir, fileext = ".svg")`
+- [ ] 1.2 Same for `document.typ` → `tempfile(pattern = "document-", tmpdir = temp_dir, fileext = ".typ")`
+- [ ] 1.3 Track generated filenames in local variables; update cleanup `on.exit` to reference these
+- [ ] 1.4 Verify Typst document references chart by relative basename (already does)
+
+## 2. Session finalizer
+
+- [ ] 2.1 Add `reg.finalizer(session, function(s) s$close())` in `bfh_create_export_session()`
+- [ ] 2.2 Verify finalizer runs on session GC even without explicit close()
+- [ ] 2.3 Test: create session, drop reference, force `gc()` → tmpdir cleaned
+
+## 3. Concurrency tests
+
+- [ ] 3.1 Extend `tests/testthat/test-export-session.R`
+- [ ] 3.2 Sequential test: 5 exports back-to-back, verify all PDFs unique + valid
+- [ ] 3.3 Crash recovery: simulate error mid-export, verify orphan files cleaned
+- [ ] 3.4 (Optional) Parallel test using `parallel::mclapply` (skip on Windows): verify either success with isolation OR clear error
+- [ ] 3.5 Stress test: 100 sequential exports → no leftover files in tempdir
+
+## 4. Documentation
+
+- [ ] 4.1 Update `bfh_create_export_session()` Roxygen with explicit safety guarantees
+- [ ] 4.2 Document the per-export filename pattern for advanced users
+- [ ] 4.3 NEWS entry
+
+## 5. Release
+
+- [ ] 5.1 PATCH bump
+- [ ] 5.2 Tests pass
+- [ ] 5.3 No new WARN/ERROR in `devtools::check()`
+
+Tracking: GitHub Issue #213

--- a/openspec/changes/harden-outliers-recent-count/proposal.md
+++ b/openspec/changes/harden-outliers-recent-count/proposal.md
@@ -1,0 +1,61 @@
+## Why
+
+`bfh_extract_spc_stats.bfh_qic_result()` (`R/utils_spc_stats.R:143-150`) hardcodes "last 6 observations" as the recency window for outlier reporting:
+
+```r
+n_obs <- nrow(qd)
+recent_start <- max(1, n_obs - 5)
+stats$outliers_recent_count <- sum(qd$sigma.signal[recent_start:n_obs], na.rm = TRUE)
+```
+
+The constant 6 is undocumented (no rationale comment, no Anhøj literature reference for this specific window) and untested at boundaries. Fallback analysis text (`inst/i18n/da.yaml`, `spc_analysis.yml`) hardcodes the phrasing "seneste 6 observationer" to match.
+
+**Concrete risks:**
+- Part with n_obs = 1: returns 1-row window, fallback text still says "seneste 6 observationer" → misleading
+- Part with n_obs = 5: returns 5-row window, fallback says "6" → misleading
+- No test verifies behavior at n_obs boundaries (1, 5, 6, 7)
+- Window cannot be configured by downstream packages with different clinical conventions
+
+## What Changes
+
+- Add named constant `RECENT_OBS_WINDOW <- 6L` in `R/globals.R` with rationale comment
+- Replace hardcoded `5` (n_obs - 5) with `RECENT_OBS_WINDOW - 1L` in `bfh_extract_spc_stats.bfh_qic_result()`
+- Add `effective_window` field to stats output: equals `min(RECENT_OBS_WINDOW, n_obs)` so downstream callers know the actual window used
+- Update fallback text generation (`R/spc_analysis.R` + i18n YAML) to use `{effective_window}` placeholder instead of hardcoded "6"
+- Add 5 new boundary tests
+- Document constant choice in `globals.R` Roxygen and in `bfh_extract_spc_stats` Roxygen
+
+## Impact
+
+**Affected specs:**
+- `spc-analysis-api` — MODIFIED requirement on outliers_recent_count contract; ADDED requirement for effective window reporting
+
+**Affected code:**
+- `R/globals.R` — add `RECENT_OBS_WINDOW` constant
+- `R/utils_spc_stats.R:143-150` — use constant
+- `R/spc_analysis.R` — wire effective_window into placeholder data
+- `inst/i18n/da.yaml` + `inst/i18n/en.yaml` — replace hardcoded "6" with `{effective_window}` placeholder in outlier-text variants
+- `tests/testthat/test-anhoej-precision.R` or new `test-outliers-recent-count.R` — add boundary tests
+- NEWS entry under `## Bug fixes` or `## Forbedringer`
+
+**Not breaking:**
+- Behavior unchanged for `n_obs >= 6` (same window)
+- Adds `effective_window` field (additive)
+- i18n templates take new placeholder; falls back gracefully if not all translations updated
+
+## Cross-repo impact (biSPCharts)
+
+**Verification:**
+```bash
+# I biSPCharts:
+grep -rn "outliers_recent_count\|seneste 6" R/ inst/
+```
+
+**Expected impact:** none — biSPCharts likely consumes the field via `bfh_extract_spc_stats()` API. New `effective_window` field is additive.
+
+**biSPCharts version bump:** none required.
+
+## Related
+
+- GitHub Issue: #207
+- Source: BFHcharts code review 2026-04-27, Claude finding #5

--- a/openspec/changes/harden-outliers-recent-count/specs/spc-analysis-api/spec.md
+++ b/openspec/changes/harden-outliers-recent-count/specs/spc-analysis-api/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: outliers_recent_count window SHALL be configurable via named constant and report effective window
+
+The package SHALL define a named constant `RECENT_OBS_WINDOW` in `R/globals.R` documenting the recency window used by `bfh_extract_spc_stats.bfh_qic_result()` for `outliers_recent_count`. The stats output SHALL include an `effective_window` field reporting the actual number of observations considered (capped by `n_obs`).
+
+**Rationale:**
+- The hardcoded "6" lacks documented rationale and is not derived from Anhøj literature
+- Downstream consumers and analysis text need to know the actual window used (especially for short parts)
+- A named constant enables future configurability without scattering the magic number
+- Boundary correctness (n_obs < window) cannot be verified without exposed effective_window
+
+**Contract:**
+
+| `n_obs` | `effective_window` | `outliers_recent_count` |
+|---|---|---|
+| 0 | 0 | 0 |
+| 1 | 1 | sum(sigma.signal[1:1]) |
+| 5 | 5 | sum(sigma.signal[1:5]) |
+| 6 | 6 | sum(sigma.signal[1:6]) |
+| 7 | 6 | sum(sigma.signal[2:7]) |
+| 100 | 6 | sum(sigma.signal[95:100]) |
+
+#### Scenario: short part returns truncated effective_window
+
+- **GIVEN** a `bfh_qic_result` whose latest part has only 3 observations
+- **WHEN** `bfh_extract_spc_stats(result)` is called
+- **THEN** `stats$effective_window` SHALL equal 3
+- **AND** `stats$outliers_recent_count` SHALL equal `sum(sigma.signal[1:3])`
+
+```r
+sigma <- c(TRUE, FALSE, TRUE)  # 2 outliers in 3 obs
+result <- fixture_bfh_qic_result(sigma, chart_type = "i")
+stats <- bfh_extract_spc_stats(result)
+expect_equal(stats$effective_window, 3)
+expect_equal(stats$outliers_recent_count, 2)
+```
+
+#### Scenario: long part caps effective_window at RECENT_OBS_WINDOW
+
+- **GIVEN** a `bfh_qic_result` with 100 observations and outliers only at indexes 1–10
+- **WHEN** `bfh_extract_spc_stats(result)` is called
+- **THEN** `stats$effective_window` SHALL equal `RECENT_OBS_WINDOW` (6)
+- **AND** `stats$outliers_recent_count` SHALL equal 0 (none in last 6)
+
+```r
+sigma <- c(rep(TRUE, 10), rep(FALSE, 90))
+result <- fixture_bfh_qic_result(sigma, chart_type = "i")
+stats <- bfh_extract_spc_stats(result)
+expect_equal(stats$effective_window, 6)
+expect_equal(stats$outliers_recent_count, 0)
+```
+
+#### Scenario: empty sigma.signal returns zero values
+
+- **GIVEN** a part with `sigma.signal = logical(0)` or all NA
+- **WHEN** `bfh_extract_spc_stats(result)` is called
+- **THEN** `stats$outliers_recent_count` SHALL be 0
+- **AND** `stats$effective_window` SHALL be 0 or `min(RECENT_OBS_WINDOW, n_obs)`
+
+#### Scenario: fallback analysis text references effective window
+
+- **GIVEN** a part with 3 observations, all outliers
+- **WHEN** `bfh_generate_analysis(result)` is called with fallback (no AI)
+- **THEN** the output text SHALL reference "seneste 3 observationer" (NOT hardcoded "6")
+- **AND** the count SHALL match `effective_window`
+
+```r
+result <- fixture_bfh_qic_result(rep(TRUE, 3), chart_type = "i")
+text <- bfh_generate_analysis(result, use_ai = FALSE)
+expect_match(text, "seneste 3 observationer", ignore.case = TRUE)
+expect_false(grepl("seneste 6 observationer", text))
+```

--- a/openspec/changes/harden-outliers-recent-count/tasks.md
+++ b/openspec/changes/harden-outliers-recent-count/tasks.md
@@ -1,0 +1,41 @@
+## 1. Constant + helper
+
+- [ ] 1.1 Add `RECENT_OBS_WINDOW <- 6L` to `R/globals.R` with rationale comment
+- [ ] 1.2 Reference constant from `R/utils_spc_stats.R:143-150` instead of literal `5`
+- [ ] 1.3 Add `stats$effective_window <- min(RECENT_OBS_WINDOW, n_obs)` to outputs
+
+## 2. Tests
+
+- [ ] 2.1 Create or extend `tests/testthat/test-outliers-recent-count.R`
+- [ ] 2.2 Test: n_obs = 1 → effective_window = 1, count counts only that single obs
+- [ ] 2.3 Test: n_obs = 5 → effective_window = 5, count covers all 5
+- [ ] 2.4 Test: n_obs = 6 → effective_window = 6, count covers all 6
+- [ ] 2.5 Test: n_obs = 7 → effective_window = 6, count covers last 6
+- [ ] 2.6 Test: n_obs = 100, outliers concentrated at start → effective_window = 6, count = 0 (none in last 6)
+- [ ] 2.7 Test: empty sigma.signal → outliers_recent_count = 0, effective_window = 0
+
+## 3. i18n templates
+
+- [ ] 3.1 Update `inst/i18n/da.yaml` outlier text variants to use `{effective_window}` placeholder
+- [ ] 3.2 Update `inst/i18n/en.yaml` similarly
+- [ ] 3.3 Wire `effective_window` into placeholder_data in `R/spc_analysis.R`
+- [ ] 3.4 Verify fallback text reads naturally for n=1, n=5, n=6 cases
+
+## 4. Documentation
+
+- [ ] 4.1 Roxygen for `RECENT_OBS_WINDOW` explaining choice and configurability future-direction
+- [ ] 4.2 Update `bfh_extract_spc_stats()` Roxygen `@return` describing effective_window
+- [ ] 4.3 NEWS entry under `## Bug fixes` (or `## Forbedringer`)
+
+## 5. Cross-repo
+
+- [ ] 5.1 Grep biSPCharts for any hardcoded references
+- [ ] 5.2 Verify no breaking impact
+
+## 6. Release
+
+- [ ] 6.1 PATCH bump (additive, non-breaking)
+- [ ] 6.2 Tests pass
+- [ ] 6.3 `devtools::check()` clean
+
+Tracking: GitHub Issue #207

--- a/openspec/changes/refactor-bfh_export_pdf-orchestrator/proposal.md
+++ b/openspec/changes/refactor-bfh_export_pdf-orchestrator/proposal.md
@@ -1,0 +1,65 @@
+## Why
+
+`bfh_export_pdf()` in `R/export_pdf.R:161-490` is 330 lines combining:
+- Class + path validation
+- Metadata validation (type checking, length limits, unknown fields)
+- Optional parameter validation (font_path, inject_assets, dpi)
+- Batch session validation
+- Auto-analysis generation
+- Auto-details generation
+- Custom template path validation + file checks
+- Quarto availability check
+- Tempdir creation + permissions + ownership verification (Unix UID check)
+- Title extraction + plot stripping
+- Label recalculation for export dimensions
+- Plot margin preparation
+- SVG export via ggsave (with tryCatch)
+- SPC stats extraction
+- Metadata merge
+- Font path resolution
+- Typst document creation
+- inject_assets callback execution
+- Quarto compilation
+- Cleanup
+
+Codex finding #5 + Claude finding #4 both flagged this as HIGH severity. Companion to `refactor-bfh_qic-orchestrator` (#211).
+
+## What Changes
+
+- **NON-BREAKING refactor**: split `bfh_export_pdf()` into orchestrator + 7-8 helpers:
+  - `validate_bfh_export_pdf_inputs()` — class + path + metadata + optional params + batch session
+  - `prepare_export_metadata()` — auto-analysis, auto-details, merge with defaults
+  - `prepare_temp_workspace()` — tempdir creation, permissions, ownership check (or reuse session)
+  - `prepare_export_plot()` — title strip, label recalc, margin adjustment
+  - `export_chart_svg()` — ggsave wrapper with error handling
+  - `compose_typst_document()` — bfh_create_typst_document call + inject_assets execution
+  - `compile_pdf_via_quarto()` — bfh_compile_typst wrapper
+  - Existing `bfh_create_typst_document` + `bfh_compile_typst` unchanged
+- Public function signature unchanged
+- All existing tests pass
+- Add unit tests for each helper
+
+## Impact
+
+**Affected specs:**
+- `code-organization` — references requirement from #211 (orchestrator pattern); applies same pattern here
+
+**Affected code:**
+- `R/export_pdf.R` — orchestrator reduced to ≤ 80 lines
+- `R/utils_export_helpers.R` — new file with extracted helpers (or extend existing utils file)
+- `tests/testthat/test-export_pdf.R` — extended with helper-isolation tests
+
+**Non-breaking:**
+- Public API identical
+- No behavior change
+- Security checks ordering preserved (validation before file system ops, before Quarto)
+
+## Cross-repo impact (biSPCharts)
+
+None. Public API unchanged.
+
+## Related
+
+- GitHub Issue: #212
+- Companion proposal: `refactor-bfh_qic-orchestrator` (#211)
+- Source: BFHcharts code review 2026-04-27 (Codex #5, Claude #4)

--- a/openspec/changes/refactor-bfh_export_pdf-orchestrator/specs/code-organization/spec.md
+++ b/openspec/changes/refactor-bfh_export_pdf-orchestrator/specs/code-organization/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: bfh_export_pdf SHALL follow the orchestrator-helper pattern
+
+`bfh_export_pdf()` SHALL be refactored to act as a thin orchestrator delegating distinct responsibilities to internal helpers, mirroring the pattern established by `bfh_qic()` (see `refactor-bfh_qic-orchestrator` change). Function body SHOULD target ≤ 80 lines excluding Roxygen.
+
+**Rationale:**
+- Current 330-line implementation mixes validation, IO, security checks, plot manipulation, Typst generation, and Quarto execution
+- Security check ordering is currently spread across the function — risk of regression when modifying any single step
+- Companion to `bfh_qic()` refactor for consistency
+
+**Pattern:**
+
+```
+bfh_export_pdf(args) [≤ 80 lines]
+  ├── validate_bfh_export_pdf_inputs(args)
+  ├── metadata <- prepare_export_metadata(x, metadata, auto_analysis, use_ai, ...)
+  ├── temp_dir <- prepare_temp_workspace(batch_session)
+  ├── plot <- prepare_export_plot(x)
+  ├── chart_svg <- export_chart_svg(plot, temp_dir, dpi)
+  ├── typst_file <- compose_typst_document(chart_svg, metadata, temp_dir, ...)
+  ├── compile_pdf_via_quarto(typst_file, output, font_path)
+  └── invisible(x)
+```
+
+**Security ordering preserved:**
+1. Validation (no IO yet)
+2. File system operations
+3. Quarto execution
+4. Cleanup (registered before any allocation)
+
+#### Scenario: orchestrator under target size after refactor
+
+- **GIVEN** the refactored `bfh_export_pdf()` function
+- **WHEN** the function body is measured (excluding Roxygen, blank lines)
+- **THEN** the body SHALL be ≤ 80 lines
+
+#### Scenario: helpers callable in isolation
+
+- **GIVEN** any of the new helpers
+- **WHEN** called with appropriate arguments
+- **THEN** the helper SHALL produce its expected output without invoking the full orchestrator
+
+#### Scenario: security check ordering preserved
+
+- **GIVEN** the refactored function
+- **WHEN** an invalid `output` path with shell metachars is passed
+- **THEN** validation SHALL fail BEFORE any tempdir is created
+- **AND** no Quarto invocation SHALL occur
+
+#### Scenario: public API unchanged after refactor
+
+- **GIVEN** existing tests calling `bfh_export_pdf()` from any caller
+- **WHEN** running `devtools::test()` after the refactor
+- **THEN** all pre-existing tests SHALL pass without modification

--- a/openspec/changes/refactor-bfh_export_pdf-orchestrator/tasks.md
+++ b/openspec/changes/refactor-bfh_export_pdf-orchestrator/tasks.md
@@ -1,0 +1,41 @@
+## 1. Helper extraction
+
+- [ ] 1.1 Create `validate_bfh_export_pdf_inputs()` (lines 174-286) — class, path, metadata, dpi, font_path, inject_assets, batch_session
+- [ ] 1.2 Create `prepare_export_metadata()` (lines 290-307) — auto-analysis + auto-details + merge_metadata
+- [ ] 1.3 Create `prepare_temp_workspace()` (lines 360-400) — tempdir + permissions + UID check + cleanup hook
+- [ ] 1.4 Create `prepare_export_plot()` (lines 402-426) — title strip + recalculate_labels + margin
+- [ ] 1.5 Create `export_chart_svg()` (lines 431-449) — ggsave with tryCatch
+- [ ] 1.6 Create `compose_typst_document()` (lines 451-485) — bfh_create_typst_document + inject_assets + font_path resolution
+- [ ] 1.7 Create `compile_pdf_via_quarto()` — wraps `bfh_compile_typst()` with consistent font_path handling
+- [ ] 1.8 Update `bfh_export_pdf()` to call helpers in sequence — target ≤ 80 lines body
+- [ ] 1.9 Preserve security check ordering: validation → file system → Quarto
+
+## 2. Helper tests
+
+- [ ] 2.1 Extend `tests/testthat/test-export_pdf.R` (or new `test-export_pdf-helpers.R`)
+- [ ] 2.2 Test `validate_bfh_export_pdf_inputs()` with all violation cases
+- [ ] 2.3 Test `prepare_export_metadata()` auto-analysis + auto-details with mocks
+- [ ] 2.4 Test `prepare_temp_workspace()` permissions + cleanup
+- [ ] 2.5 Test `prepare_export_plot()` returns correctly-sized plot
+- [ ] 2.6 Test `export_chart_svg()` error handling on disk full / readonly path
+- [ ] 2.7 Test `compose_typst_document()` font_path resolution from session vs per-export
+
+## 3. Regression verification
+
+- [ ] 3.1 Full `devtools::test()` passes
+- [ ] 3.2 `devtools::check()` no new WARN/ERROR
+- [ ] 3.3 Live render test (#210 if available) produces identical PDF output
+- [ ] 3.4 Security tests still pass (path traversal, metachar rejection, etc.)
+
+## 4. Documentation
+
+- [ ] 4.1 Roxygen `@details` to `bfh_export_pdf()` referencing helper map
+- [ ] 4.2 Roxygen for each new helper (`@noRd` if internal)
+- [ ] 4.3 NEWS entry under `## Interne ændringer`
+
+## 5. Release
+
+- [ ] 5.1 PATCH bump (refactor only)
+- [ ] 5.2 Tests pass
+
+Tracking: GitHub Issue #212

--- a/openspec/changes/refactor-bfh_qic-orchestrator/proposal.md
+++ b/openspec/changes/refactor-bfh_qic-orchestrator/proposal.md
@@ -1,0 +1,67 @@
+## Why
+
+`bfh_qic()` in `R/create_spc_chart.R:453-834` is 380 lines combining:
+- NSE column-name validation
+- Numeric parameter validation (×7 calls)
+- `qic_args` construction
+- `qicharts2::qic()` invocation
+- Anhøj signal post-processing
+- Dimension/unit conversion
+- Responsive base_size calculation
+- Axis label normalization
+- Plot config + viewport + plot_margin construction
+- Plot rendering (`bfh_spc_plot`) with warning suppression
+- Label size computation + label addition
+- Summary formatting
+- Config object construction
+- Return-value routing (S3 vs legacy paths)
+
+The `R/utils_bfh_qic_helpers.R` file (created in 2026-04-24, archived) shows the team has already begun extracting helpers (`add_anhoej_signal`, `build_bfh_qic_return`). This proposal continues that work to reduce orchestrator complexity below ~80 lines.
+
+Both code reviews (Codex #5 + Claude #4) identified this as HIGH severity for maintainability.
+
+## What Changes
+
+- **NON-BREAKING refactor**: split `bfh_qic()` into orchestrator + 5–7 helper functions:
+  - `validate_bfh_qic_inputs()` — all input validation in one place
+  - `build_qic_args()` — construct argument list for `qicharts2::qic()`
+  - `invoke_qicharts2()` — wrap `do.call()` with warning suppression
+  - `compute_viewport_base_size()` — handle dimension/unit conversion + base_size derivation
+  - `render_bfh_plot()` — plot config + viewport + bfh_spc_plot orchestration
+  - `apply_spc_labels_to_export()` — label_size + add_spc_labels orchestration
+  - `build_bfh_qic_return()` — already exists; preserve
+- Public function signature unchanged
+- All existing tests continue to pass
+- Add unit tests for each helper in isolation
+- Update `R/create_spc_chart.R` Roxygen with reference to the orchestration map
+
+## Impact
+
+**Affected specs:**
+- `code-organization` — ADDED requirement: orchestrator-helper separation pattern for primary entry points
+
+**Affected code:**
+- `R/create_spc_chart.R` — orchestrator reduced to ≤ 80 lines
+- `R/utils_bfh_qic_helpers.R` — extended with new helpers (or split into multiple files if grows large)
+- `tests/testthat/test-bfh_qic_helpers.R` — extended with helper-isolation tests
+
+**Non-breaking:**
+- Public API identical
+- No behavior change
+- All existing tests pass without modification
+
+**Test quality improvement:**
+- Each helper testable in isolation
+- Faster failure localization when validation or rendering breaks
+- Lower coupling between concerns
+
+## Cross-repo impact (biSPCharts)
+
+None. Public API unchanged.
+
+## Related
+
+- GitHub Issue: #211
+- Prior work: `openspec/changes/archive/2026-04-24-refactor-extract-bfh-qic-helpers/`
+- Source: BFHcharts code review 2026-04-27 (Codex #5, Claude #4)
+- Companion proposal: `refactor-bfh_export_pdf-orchestrator`

--- a/openspec/changes/refactor-bfh_qic-orchestrator/specs/code-organization/spec.md
+++ b/openspec/changes/refactor-bfh_qic-orchestrator/specs/code-organization/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Primary public entry points SHALL be thin orchestrators
+
+Primary public entry points (`bfh_qic()`, `bfh_export_pdf()`, `bfh_export_png()`) SHALL act as thin orchestrators that delegate distinct responsibilities (validation, computation, rendering, IO, return-routing) to internal helpers. Orchestrator function bodies SHOULD target ≤ 80 lines excluding Roxygen.
+
+**Rationale:**
+- Single function carrying 380+ lines mixes 8+ concerns and is impossible to test in isolation
+- Failure localization is slow when one giant function breaks
+- Architectural pattern documented for future entry points
+
+**Pattern:**
+
+```
+bfh_qic(args) [≤ 80 lines]
+  ├── validate_bfh_qic_inputs(args)
+  ├── qic_args <- build_qic_args(args, validated_columns)
+  ├── qic_data <- invoke_qicharts2(qic_args)
+  ├── viewport_info <- compute_viewport_base_size(args)
+  ├── plot <- render_bfh_plot(qic_data, args, viewport_info)
+  ├── plot <- apply_spc_labels_to_export(plot, qic_data, args, viewport_info)
+  ├── summary <- format_qic_summary(qic_data, args$y_axis_unit)
+  └── build_bfh_qic_return(qic_data, plot, summary, config, args$return.data, args$print.summary)
+```
+
+#### Scenario: orchestrator under target size after refactor
+
+- **GIVEN** the refactored `bfh_qic()` function in `R/create_spc_chart.R`
+- **WHEN** the function body is measured (excluding Roxygen, blank lines)
+- **THEN** the body SHALL be ≤ 80 lines
+
+#### Scenario: helpers callable in isolation
+
+- **GIVEN** any of the new helpers (`validate_bfh_qic_inputs`, `build_qic_args`, etc.)
+- **WHEN** called with appropriate arguments in isolation
+- **THEN** the helper SHALL produce its expected output without invoking the full orchestrator
+- **AND** unit tests SHALL exercise each helper independently
+
+```r
+# Example — validation helper testable alone
+expect_error(
+  validate_bfh_qic_inputs(args = list(chart_type = "invalid_type", ...)),
+  "chart_type must be"
+)
+```
+
+#### Scenario: public API unchanged after refactor
+
+- **GIVEN** existing tests calling `bfh_qic()` from any caller
+- **WHEN** running `devtools::test()` after the refactor
+- **THEN** all pre-existing tests SHALL pass without modification
+- **AND** `bfh_qic()` signature, return values, and behavior SHALL be identical

--- a/openspec/changes/refactor-bfh_qic-orchestrator/tasks.md
+++ b/openspec/changes/refactor-bfh_qic-orchestrator/tasks.md
@@ -1,0 +1,39 @@
+## 1. Helper extraction
+
+- [ ] 1.1 Create `validate_bfh_qic_inputs()` consolidating all `validate_*` calls (currently scattered across `bfh_qic()` lines 484-650)
+- [ ] 1.2 Create `build_qic_args()` consolidating `qic_args` list construction (lines 652-701)
+- [ ] 1.3 Create `invoke_qicharts2()` wrapping `do.call(qicharts2::qic, qic_args, envir = parent.frame())` + `add_anhoej_signal()`
+- [ ] 1.4 Create `compute_viewport_base_size()` consolidating `convert_to_inches()`, `calculate_base_size()`, axis-label normalization
+- [ ] 1.5 Create `render_bfh_plot()` consolidating plot_config + viewport_dims + bfh_spc_plot + warning handler
+- [ ] 1.6 Create `apply_spc_labels_to_export()` consolidating compute_label_size_for_viewport + add_spc_labels
+- [ ] 1.7 Update `bfh_qic()` to call helpers in sequence — target ≤ 80 lines body
+
+## 2. Helper tests
+
+- [ ] 2.1 Extend `tests/testthat/test-bfh_qic_helpers.R`
+- [ ] 2.2 Test `validate_bfh_qic_inputs()` with valid + invalid inputs per parameter
+- [ ] 2.3 Test `build_qic_args()` produces correct argument lists per chart type
+- [ ] 2.4 Test `invoke_qicharts2()` wrapping correctly handles parent.frame() lookup
+- [ ] 2.5 Test `compute_viewport_base_size()` with all unit-detection paths
+- [ ] 2.6 Test `render_bfh_plot()` with minimal qic_data fixtures
+- [ ] 2.7 Test `apply_spc_labels_to_export()` with viewport + no-viewport paths
+
+## 3. Regression verification
+
+- [ ] 3.1 Run full `devtools::test()` — all pre-existing tests pass without modification
+- [ ] 3.2 Run `devtools::check()` — no new WARN/ERROR
+- [ ] 3.3 Diff plot outputs against vdiffr snapshots — no rendering changes
+
+## 4. Documentation
+
+- [ ] 4.1 Add Roxygen `@details` to `bfh_qic()` referencing the helper map
+- [ ] 4.2 Roxygen for each new helper (internal, `@noRd`)
+- [ ] 4.3 NEWS entry under `## Interne ændringer`
+
+## 5. Release
+
+- [ ] 5.1 PATCH bump (refactor only, no behavior change)
+- [ ] 5.2 Tests pass
+- [ ] 5.3 Visual regression snapshots unchanged
+
+Tracking: GitHub Issue #211

--- a/openspec/changes/relax-check-traversal-to-component-match/proposal.md
+++ b/openspec/changes/relax-check-traversal-to-component-match/proposal.md
@@ -1,0 +1,71 @@
+## Why
+
+`.check_traversal()` in `R/utils_path_policy.R:83-91` rejects every filename containing `..` as a literal substring:
+
+```r
+.check_traversal <- function(path) {
+  if (grepl("..", path, fixed = TRUE)) {
+    stop("path cannot contain '..' (path traversal attempt detected)...")
+  }
+}
+```
+
+This is a **usability bug**, not a security hole. It rejects legitimate filenames:
+- `report..v2.pdf` — false positive
+- `analyse..final.pdf` — false positive
+- `..hidden.pdf` — false positive (legitimate dotfile pattern)
+- `data..backup.csv` — false positive
+
+The over-restrictive match errs on the safe side (no path traversal can occur), but produces confusing errors for valid filenames. Claude code review #6, severity medium.
+
+## What Changes
+
+- Replace literal substring match with **path-component** match
+- A path is rejected only if any path-separator-delimited component equals exactly `..`
+- Existing rejections preserved:
+  - `../etc/passwd` → rejected (component `..`)
+  - `output/../secret.pdf` → rejected (component `..`)
+  - `../../../sensitive.pdf` → rejected
+- Newly accepted (false positives fixed):
+  - `report..v2.pdf` → accepted (component is `report..v2.pdf`, not `..`)
+  - `..hidden.pdf` → accepted (component is `..hidden.pdf`)
+  - `analyse..final.pdf` → accepted
+
+**Implementation:**
+```r
+.check_traversal <- function(path) {
+  parts <- strsplit(path, "[/\\\\]")[[1]]
+  if (any(parts == "..")) {
+    stop(
+      "path cannot contain '..' as a path component (traversal attempt)\n",
+      "  Provided path: ", basename(path),
+      call. = FALSE
+    )
+  }
+}
+```
+
+Cross-platform (handles both `/` and `\` separators) — matches existing behavior.
+
+## Impact
+
+**Affected specs:**
+- `pdf-export` — MODIFIED requirement: path traversal rejection (component-based, not substring)
+
+**Affected code:**
+- `R/utils_path_policy.R:83-91` — replace match logic
+- `tests/testthat/test-path-policy.R` — extend with positive tests for legitimate `..` filenames + preserve existing negative tests
+
+**Non-breaking** for security:
+- All previously-rejected attacks still rejected
+- Legitimate filenames now accepted
+- Pre-1.0 → PATCH bump (bug fix)
+
+## Cross-repo impact (biSPCharts)
+
+None expected. biSPCharts unlikely to use double-dot filenames in normal flows.
+
+## Related
+
+- GitHub Issue: #214
+- Source: BFHcharts code review 2026-04-27 (Claude finding #6)

--- a/openspec/changes/relax-check-traversal-to-component-match/specs/pdf-export/spec.md
+++ b/openspec/changes/relax-check-traversal-to-component-match/specs/pdf-export/spec.md
@@ -1,0 +1,121 @@
+## MODIFIED Requirements
+
+### Requirement: Export paths SHALL be validated via centralized helper
+
+All export entry points SHALL validate user-supplied output paths via a single canonical helper `validate_export_path()` in `R/utils_path_policy.R`, covering `bfh_export_pdf()`, `bfh_export_png()`, and internal Typst helpers.
+
+**Rationale:**
+- Single source of truth prevents policy drift between formats
+- Consistent security posture across export surfaces
+- Central place to tighten rules in response to future threats
+
+**The helper SHALL reject:**
+- Paths where any path-separator-delimited component equals exactly `..` (path traversal)
+- Shell metacharacters: `;`, `|`, `&`, backtick, `$`, `(`, `)`, `{`, `}`, `<`, `>`, newline, carriage return
+- Extensions not in the format-specific whitelist
+- Symlinks that resolve outside the configured allowlist root (when root is configured)
+
+**The helper SHALL NOT reject:**
+- Filenames containing `..` as part of a longer string (e.g., `report..v2.pdf`, `..hidden.pdf`, `analyse..final.pdf`) — these are legitimate filename patterns
+- Paths with spaces, underscores, dashes, or unicode characters (already accepted)
+
+**The helper SHALL return:**
+- A normalized absolute path on success (when `normalize = TRUE`)
+- An informative error (with class `bfhcharts_path_policy_error`) on rejection
+
+#### Scenario: Path traversal rejected at component level
+
+**Given** a user supplies `../../etc/passwd` as output path
+**When** any export function validates the path
+**Then** it SHALL raise an error mentioning path traversal
+**And** no file SHALL be written
+
+```r
+expect_error(
+  bfh_export_pdf(result, "../../etc/passwd.pdf"),
+  "path|traversal"
+)
+```
+
+#### Scenario: Embedded subdirectory traversal rejected
+
+**Given** a user supplies `output/../secret.pdf`
+**When** validation runs
+**Then** the helper SHALL reject the path
+
+```r
+expect_error(
+  bfh_export_pdf(result, "output/../secret.pdf"),
+  "path|traversal"
+)
+```
+
+#### Scenario: Filenames containing double-dot substring accepted
+
+**Given** a user supplies `report..v2.pdf` (component is the whole filename, not `..`)
+**When** validation runs
+**Then** the helper SHALL accept the path
+**And** export SHALL proceed normally
+
+```r
+expect_no_error(
+  bfh_export_pdf(result, file.path(tempdir(), "report..v2.pdf"))
+)
+```
+
+#### Scenario: Dotfile prefix accepted
+
+**Given** a user supplies `..hidden.pdf` as filename (single component, not traversal)
+**When** validation runs
+**Then** the helper SHALL accept the path
+
+```r
+expect_no_error(
+  bfh_export_pdf(result, file.path(tempdir(), "..hidden.pdf"))
+)
+```
+
+#### Scenario: Shell metacharacters rejected
+
+**Given** a user supplies a path containing shell metacharacters
+**When** validation runs
+**Then** the helper SHALL reject the path regardless of file extension
+
+```r
+expect_error(
+  bfh_export_pdf(result, "output;rm -rf /.pdf"),
+  "invalid|character|disallowed"
+)
+```
+
+#### Scenario: Wrong extension for format rejected
+
+**Given** a user calls `bfh_export_pdf()` with path `output.png`
+**When** validation runs
+**Then** the helper SHALL reject with message naming expected extension
+
+```r
+expect_error(
+  bfh_export_pdf(result, "output.png"),
+  "pdf"
+)
+```
+
+#### Scenario: Valid path returned normalized
+
+**Given** a legitimate path with `.` segments
+**When** validation succeeds with normalize = TRUE
+**Then** the helper SHALL return an absolute, normalized path
+
+```r
+normalized <- validate_export_path("./out/./chart.pdf", extension = "pdf", normalize = TRUE)
+expect_true(startsWith(normalized, "/"))
+expect_false(grepl("/./", normalized, fixed = TRUE))
+```
+
+#### Scenario: Cross-platform separator handling
+
+**Given** a Windows-style path `..\\evil.pdf`
+**When** validation runs
+**Then** the helper SHALL recognize `..` as a path component
+**And** SHALL reject the path

--- a/openspec/changes/relax-check-traversal-to-component-match/tasks.md
+++ b/openspec/changes/relax-check-traversal-to-component-match/tasks.md
@@ -1,0 +1,33 @@
+## 1. Implementation
+
+- [ ] 1.1 Replace `.check_traversal()` body with `strsplit` + `any(parts == "..")` logic
+- [ ] 1.2 Handle both `/` and `\\` separators for cross-platform
+- [ ] 1.3 Preserve error message format and class
+
+## 2. Tests
+
+- [ ] 2.1 Add positive tests in `tests/testthat/test-path-policy.R`:
+  - `report..v2.pdf` → accepted
+  - `..hidden.pdf` → accepted
+  - `data..backup.csv` → accepted
+  - `analyse..final.pdf` → accepted
+- [ ] 2.2 Verify negative tests still reject:
+  - `../etc/passwd` → rejected
+  - `output/../secret.pdf` → rejected
+  - `../../sensitive.pdf` → rejected
+  - `subdir/..` → rejected
+  - `subdir/../child.pdf` → rejected
+- [ ] 2.3 Cross-platform: test with `\\` separators (Windows-style paths)
+
+## 3. Documentation
+
+- [ ] 3.1 Update `.check_traversal` Roxygen
+- [ ] 3.2 NEWS entry under `## Bug fixes`
+
+## 4. Release
+
+- [ ] 4.1 PATCH bump
+- [ ] 4.2 Tests pass
+- [ ] 4.3 No new WARN/ERROR
+
+Tracking: GitHub Issue #214

--- a/openspec/changes/remove-phase_config-dead-code/proposal.md
+++ b/openspec/changes/remove-phase_config-dead-code/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+`phase_config()` (`R/config_objects.R:280-300`) was scaffolded as a "reserved" config object for future phase configuration. It has 6 dedicated tests in `tests/testthat/test-config_objects.R` and a `print.phase_config` S3 method registered in NAMESPACE.
+
+**Verification of dead code status:**
+- `grep -n "phase_config" R/` outside `R/config_objects.R` → 0 production hits
+- `bfh_spc_plot(phase = NULL)` parameter (`R/plot_core.R:85`) accepts a phase_config object but the function body NEVER reads it
+- No call site in `bfh_qic()`, `bfh_export_pdf()`, or any other production path
+
+The function is reserved infrastructure that was never wired in. Codex finding #10 flagged it as "API noise" and recommended slet/arkivér or document som internal future API.
+
+## What Changes
+
+- **NON-BREAKING (internal-only)**: remove `phase_config()` constructor and `print.phase_config` method
+- Remove dead `phase = NULL` parameter from `bfh_spc_plot()` (internal function, no public-API impact)
+- Remove `tests/testthat/test-config_objects.R` tests for phase_config (lines ~285-340)
+- Remove `S3method(print,phase_config)` from NAMESPACE (regenerated via `devtools::document()`)
+- Update `R/config_objects.R` Roxygen to reflect removal
+
+## Impact
+
+**Affected specs:**
+- `code-organization` — REMOVED requirement: phase_config (if any spec referenced it; otherwise no spec impact)
+
+**Affected code:**
+- `R/config_objects.R` — remove `phase_config()` and `print.phase_config()` (~50 LOC)
+- `R/plot_core.R:85` — remove `phase = NULL` parameter
+- `tests/testthat/test-config_objects.R` — remove ~6 tests
+- NAMESPACE — auto-regenerated, removes `S3method(print,phase_config)`
+- NEWS entry under `## Interne ændringer`
+
+**Non-breaking:**
+- `phase_config()` was internal (not in NAMESPACE export list)
+- `print.phase_config` registered but unused
+- No external callers possible
+
+## Cross-repo impact (biSPCharts)
+
+Verification:
+```bash
+grep -rn "phase_config\|::phase_config\|:::phase_config" R/
+```
+
+Expected: 0 hits. If any: must be removed as part of biSPCharts cleanup PR.
+
+## Alternative considered
+
+**Keep phase_config and document as internal future API:** rejected because:
+- 50 LOC + 6 tests carrying weight without delivering value
+- "Future API" without active development tends to drift from current codebase patterns
+- Easier to re-add when actually needed than to maintain dead code
+
+## Related
+
+- GitHub Issue: #216
+- Source: BFHcharts code review 2026-04-27 (Codex finding #10)

--- a/openspec/changes/remove-phase_config-dead-code/specs/code-organization/spec.md
+++ b/openspec/changes/remove-phase_config-dead-code/specs/code-organization/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Internal infrastructure SHALL NOT carry unused scaffolding
+
+The package SHALL NOT carry constructor functions, S3 methods, or function parameters that have no production call sites. Internal scaffolding for "future API" SHALL either be (a) wired into an active code path within one minor version, or (b) removed.
+
+**Rationale:**
+- Reserved-but-unused infrastructure carries maintenance and review weight without delivering value
+- "Future API" tends to drift from current patterns and become incompatible by the time it would be used
+- Easier to re-add when actually needed than to maintain dead code under test
+
+**Examples of removed scaffolding:**
+- `phase_config()` constructor + `print.phase_config()` method (was reserved, never wired)
+- `bfh_spc_plot(phase = NULL)` parameter (read by no code path)
+
+#### Scenario: dead constructor removed
+
+- **GIVEN** an internal constructor function with zero production call sites (verified via grep)
+- **WHEN** the next minor release is prepared
+- **THEN** the constructor SHALL be either wired into a production code path OR removed entirely
+- **AND** removal SHALL include constructor, related S3 methods, NAMESPACE entries, tests, and Rd files
+
+#### Scenario: dead parameter removed from internal function
+
+- **GIVEN** a function parameter that is accepted but never read in the function body
+- **WHEN** the parameter is identified during refactor or review
+- **THEN** the parameter SHALL be removed from the signature
+- **AND** the removal SHALL be safe because the function is internal (not exported in NAMESPACE)

--- a/openspec/changes/remove-phase_config-dead-code/tasks.md
+++ b/openspec/changes/remove-phase_config-dead-code/tasks.md
@@ -1,0 +1,37 @@
+## 1. Removal
+
+- [ ] 1.1 Remove `phase_config()` function from `R/config_objects.R`
+- [ ] 1.2 Remove `print.phase_config()` method from `R/config_objects.R`
+- [ ] 1.3 Remove `phase = NULL` parameter from `bfh_spc_plot()` signature in `R/plot_core.R:85`
+- [ ] 1.4 Remove `phase_config` from `tests/testthat/test-config_objects.R` (~6 tests)
+
+## 2. Documentation regeneration
+
+- [ ] 2.1 Run `devtools::document()` — NAMESPACE auto-updates removing `S3method(print,phase_config)`
+- [ ] 2.2 Remove `man/phase_config.Rd` (auto-removed by document())
+- [ ] 2.3 Remove `man/print.phase_config.Rd` (auto-removed by document())
+- [ ] 2.4 Update `R/config_objects.R` head Roxygen if it lists phase_config
+
+## 3. Verification
+
+- [ ] 3.1 `grep -rn "phase_config" R/ tests/` returns 0 hits
+- [ ] 3.2 `devtools::test()` passes (one or two test files reduced)
+- [ ] 3.3 `devtools::check()` clean
+- [ ] 3.4 NAMESPACE diff matches expectations
+
+## 4. Cross-repo
+
+- [ ] 4.1 Grep biSPCharts for `phase_config` references
+- [ ] 4.2 If hits found: companion PR to remove
+
+## 5. Documentation
+
+- [ ] 5.1 NEWS entry under `## Interne ændringer` (or `## Code cleanup`)
+- [ ] 5.2 Note in changelog that phase_config was scaffolded but never wired in
+
+## 6. Release
+
+- [ ] 6.1 PATCH bump (internal-only removal)
+- [ ] 6.2 Tests pass
+
+Tracking: GitHub Issue #216

--- a/tests/testthat/test-denominator-validator.R
+++ b/tests/testthat/test-denominator-validator.R
@@ -1,0 +1,154 @@
+# Tests for denominator content validation in bfh_qic()
+# Spec: openspec/changes/add-denominator-validator
+# Issue: #205
+
+test_that("p-chart without n is rejected", {
+  data <- data.frame(
+    period = 1:8,
+    events = rep(5L, 8)
+  )
+  expect_error(
+    bfh_qic(data, x = period, y = events, chart_type = "p"),
+    "requires denominator"
+  )
+})
+
+test_that("i-chart without n succeeds (n not required)", {
+  data <- data.frame(
+    period = 1:10,
+    value = c(10, 12, 11, 13, 9, 11, 14, 12, 10, 11)
+  )
+  result <- suppressWarnings(
+    bfh_qic(data, x = period, y = value, chart_type = "i")
+  )
+  expect_s3_class(result, "bfh_qic_result")
+})
+
+test_that("p-chart with n containing zero is rejected", {
+  data <- data.frame(
+    period = 1:3,
+    events = c(5L, 0L, 5L),
+    total  = c(100L, 0L, 100L)
+  )
+  expect_error(
+    bfh_qic(data, x = period, y = events, n = total, chart_type = "p"),
+    "> 0"
+  )
+})
+
+test_that("p-chart with negative n is rejected", {
+  data <- data.frame(
+    period = 1:3,
+    events = c(5L, 1L, 5L),
+    total  = c(100L, -5L, 100L)
+  )
+  expect_error(
+    bfh_qic(data, x = period, y = events, n = total, chart_type = "p"),
+    "> 0"
+  )
+})
+
+test_that("p-chart with Inf in n is rejected", {
+  data <- data.frame(
+    period = 1:3,
+    events = c(5, 5, 5),
+    total  = c(100, Inf, 100)
+  )
+  expect_error(
+    bfh_qic(data, x = period, y = events, n = total, chart_type = "p"),
+    "Inf"
+  )
+})
+
+test_that("p-chart with NA in single n row succeeds (qicharts2 drops it)", {
+  data <- data.frame(
+    period = 1:4,
+    events = c(5L, 5L, 5L, 5L),
+    total  = c(100L, NA_integer_, 100L, 100L)
+  )
+  result <- suppressWarnings(
+    bfh_qic(data, x = period, y = events, n = total, chart_type = "p")
+  )
+  expect_s3_class(result, "bfh_qic_result")
+})
+
+test_that("p-chart with y > n reports row number", {
+  data <- data.frame(
+    period = 1:4,
+    events = c(5L, 6L, 200L, 8L),
+    total  = rep(100L, 4)
+  )
+  expect_error(
+    bfh_qic(data, x = period, y = events, n = total, chart_type = "p"),
+    "y <= n"
+  )
+  expect_error(
+    bfh_qic(data, x = period, y = events, n = total, chart_type = "p"),
+    "row\\(s\\): 3"
+  )
+})
+
+test_that("p-chart with all rows y <= n succeeds", {
+  data <- data.frame(
+    period = 1:5,
+    events = c(5L, 6L, 4L, 8L, 7L),
+    total  = rep(100L, 5)
+  )
+  result <- suppressWarnings(
+    bfh_qic(data, x = period, y = events, n = total, chart_type = "p")
+  )
+  expect_s3_class(result, "bfh_qic_result")
+})
+
+test_that("u-chart with n = 0 is rejected (same > 0 rule)", {
+  data <- data.frame(
+    period = 1:3,
+    events = c(5L, 5L, 5L),
+    exposure = c(100L, 0L, 100L)
+  )
+  expect_error(
+    bfh_qic(data, x = period, y = events, n = exposure, chart_type = "u"),
+    "> 0"
+  )
+})
+
+test_that("u-chart allows y > n (rate, not proportion)", {
+  data <- data.frame(
+    period = 1:3,
+    events = c(50L, 60L, 200L),
+    exposure = rep(100L, 3)
+  )
+  result <- suppressWarnings(
+    bfh_qic(data, x = period, y = events, n = exposure, chart_type = "u")
+  )
+  expect_s3_class(result, "bfh_qic_result")
+})
+
+test_that("pp-chart with y > n is rejected (proportion percent variant)", {
+  data <- data.frame(
+    period = 1:4,
+    events = c(5L, 6L, 200L, 8L),
+    total  = rep(100L, 4)
+  )
+  expect_error(
+    bfh_qic(
+      data,
+      x = period, y = events, n = total,
+      chart_type = "pp", y_axis_unit = "percent"
+    ),
+    "y <= n"
+  )
+})
+
+test_that("xbar-chart skips denominator validation (subgroup via duplicated x)", {
+  set.seed(42)
+  # xbar requires duplicated x values per subgroup; no n column needed
+  data <- data.frame(
+    period = rep(1:5, each = 4),
+    value  = rnorm(20, mean = 50, sd = 5)
+  )
+  result <- suppressWarnings(
+    bfh_qic(data, x = period, y = value, chart_type = "xbar")
+  )
+  expect_s3_class(result, "bfh_qic_result")
+})

--- a/tests/testthat/test-plot_margin.R
+++ b/tests/testthat/test-plot_margin.R
@@ -123,8 +123,10 @@ test_that("asymmetric margins bevares præcist (t/r/b/l adskilt)", {
 
 test_that("plot_margin fungerer med alle chart-typer (deterministisk data)", {
   df <- fixture_numeric_data()
-  # Deterministisk denominator (ingen RNG) for p/u-chart cases
+  # Deterministisk denominator (ingen RNG) for p/u-chart cases.
+  # Clamp y til [0, n] så proportion-kontrakten (y <= n) holder for p-charts.
   df$n <- rep(100L, nrow(df))
+  df$y <- pmin(pmax(round(df$y), 0L), df$n)
 
   chart_types <- c("run", "i", "p", "c", "u")
 
@@ -153,7 +155,8 @@ test_that("plot_margin fungerer med alle chart-typer (deterministisk data)", {
     expect_valid_bfh_qic_result(plot)
     # Margin skal være exact c(5,5,5,5) for hver chart-type
     expect_plot_margin(plot$plot, c(5, 5, 5, 5),
-                       tolerance = 0.01)
+      tolerance = 0.01
+    )
   }
 })
 
@@ -170,7 +173,7 @@ test_that("plot_margin validation rejects wrong length", {
       x = x,
       y = y,
       chart_type = "i",
-      plot_margin = c(5, 5)  # Only 2 values
+      plot_margin = c(5, 5) # Only 2 values
     ),
     "numeric vector of length 4"
   )
@@ -233,7 +236,7 @@ test_that("plot_margin validation rejects wrong type", {
       x = x,
       y = y,
       chart_type = "i",
-      plot_margin = "10mm"  # String instead of numeric/margin
+      plot_margin = "10mm" # String instead of numeric/margin
     ),
     "must be either"
   )

--- a/tests/testthat/test-readme-runs.R
+++ b/tests/testthat/test-readme-runs.R
@@ -1,0 +1,60 @@
+test_that("README Quick Start example 1: run chart returns bfh_qic_result", {
+  data <- data.frame(
+    month = seq(as.Date("2024-01-01"), by = "month", length.out = 24),
+    infections = rpois(24, lambda = 15),
+    surgeries = rpois(24, lambda = 100)
+  )
+
+  result <- bfh_qic(
+    data = data,
+    x = month,
+    y = infections,
+    chart_type = "run",
+    y_axis_unit = "count",
+    chart_title = "Monthly Hospital-Acquired Infections"
+  )
+
+  expect_s3_class(result, "bfh_qic_result")
+})
+
+test_that("README Quick Start example 2: p-chart with target returns bfh_qic_result", {
+  data <- data.frame(
+    month = seq(as.Date("2024-01-01"), by = "month", length.out = 24),
+    infections = rpois(24, lambda = 15),
+    surgeries = rpois(24, lambda = 100)
+  )
+
+  result <- bfh_qic(
+    data = data,
+    x = month,
+    y = infections,
+    n = surgeries,
+    chart_type = "p",
+    y_axis_unit = "percent",
+    chart_title = "Infection Rate per 100 Surgeries",
+    target_value = 0.02,
+    target_text = "↓ Target: 2%"
+  )
+
+  expect_s3_class(result, "bfh_qic_result")
+})
+
+test_that("README Quick Start example 3: i-chart with phase split returns bfh_qic_result", {
+  data <- data.frame(
+    month = seq(as.Date("2024-01-01"), by = "month", length.out = 24),
+    infections = rpois(24, lambda = 15)
+  )
+
+  result <- bfh_qic(
+    data = data,
+    x = month,
+    y = infections,
+    chart_type = "i",
+    y_axis_unit = "count",
+    chart_title = "Infections Before/After Intervention",
+    part = c(12),
+    freeze = 12
+  )
+
+  expect_s3_class(result, "bfh_qic_result")
+})


### PR DESCRIPTION
## Summary

Adds `validate_denominator_data()` helper invoked from `bfh_qic()` to catch invalid denominator data **before** qicharts2 silently produces NaN/Inf rates or proportions > 1. Closes #205.

**Contract** for ratio charts (`p`, `pp`, `u`, `up`):
- `n` required (non-NULL)
- `n` must be numeric and finite
- All non-NA values of `n` must be `> 0`
- Proportion charts (`p`, `pp`): every row with both `y` and `n` present must satisfy `y <= n`
- `NA` in individual rows of `n` is permitted (qicharts2 drops them)
- Other chart types (`run`, `i`, `mr`, `c`, `g`, `t`, `xbar`, `s`) skip validation

Errors include 1-indexed row numbers from source data.

## Breaking change

Callers passing `n = 0/Inf/<0`, omitting `n` for ratio charts, or violating `y <= n` on P-charts now receive hard errors instead of silent NaN/Inf or kryptisk qicharts2 output. Pre-1.0 → MINOR bump (combined with #203 in v0.9.0).

**Migration:**
```r
data_clean <- data[!is.na(data$denominator) & data$denominator > 0, ]
bfh_qic(data_clean, ...)
```

## Files changed

- `R/utils_helpers.R` — new `validate_denominator_data()` helper
- `R/create_spc_chart.R` — wire helper, document contract in `@details`
- `tests/testthat/test-denominator-validator.R` — 13 new tests
- `tests/testthat/test-plot_margin.R` — clamp synthetic `y` to `[0, n]` for p-chart compat (fixture produced y > n)
- `NEWS.md` — breaking change entry under v0.9.0
- `man/bfh_qic.Rd` — regenerated

## Test plan

- [x] `devtools::test()` — 0 failures, 13 new PASS
- [x] `devtools::check()` — 0 errors; 4 warnings + 4 notes all pre-existing
- [x] OpenSpec change `add-denominator-validator` — 24/26 tasks complete
- [ ] Open companion issue in biSPCharts with migration snippet
- [ ] Tag `v0.9.0` after merge

## Cross-repo impact

biSPCharts call site: `R/fct_spc_bfh_invocation.R:113` via `do.call`. Runtime impact only — no static `n=0` literals. Callers should pre-filter or surface validation errors via UI. Lower-bound update: `BFHcharts (>= 0.9.0)` in biSPCharts/DESCRIPTION.

## Refs

- GitHub Issue #205
- Combined release with #203 (`fix-percent-target-scale-contract`) in v0.9.0
- OpenSpec: `openspec/changes/add-denominator-validator/`
- Source: BFHcharts code review 2026-04-27, Codex finding #3