### PR TITLE
feat(typst)!: ignore system fonts by default in PDF export (#227)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BFHcharts
 Title: SPC Visualization for Healthcare Quality Improvement
-Version: 0.9.0
+Version: 0.10.0
 Authors@R: c(
     person(
       "Johan", "Reventlow",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# BFHcharts 0.10.0
+
+## Breaking changes
+
+* **`bfh_export_pdf()` og `bfh_compile_typst()` ignorerer nu system-fonts som
+  default (`ignore_system_fonts = TRUE`).** Tidligere faldt Typst tilbage til
+  system-installerede font-varianter selv når `font_path` var sat, hvilket
+  kunne resultere i forkert weight (fx Mari Heavy med metadata
+  `style=Heavy,Regular` matchede regular-weight). Det giver nu konsistent
+  rendering på tværs af dev-maskiner og cloud-deployment.
+  **Migration:** Hvis eksisterende kode er afhængig af system-fonts ved
+  Typst-render, sæt `ignore_system_fonts = FALSE` eksplicit. (#227)
+
 # BFHcharts 0.9.0
 
 ## Breaking changes

--- a/R/export_pdf.R
+++ b/R/export_pdf.R
@@ -45,6 +45,11 @@
 #'   Passed as \code{--font-path} to the Typst compiler. Useful when fonts
 #'   (e.g., Mari) are bundled in a downstream package and not installed
 #'   system-wide on the deployment platform.
+#' @param ignore_system_fonts Logical. If \code{TRUE} (default), passes
+#'   \code{--ignore-system-fonts} to Typst so only fonts from \code{font_path}
+#'   (or bundled template fonts) are used. Prevents inconsistent rendering
+#'   when developers have additional Mari variants (e.g., Mari Heavy)
+#'   installed system-wide. See \code{\link{bfh_compile_typst}} for details.
 #' @param inject_assets Optional callback function called after Typst template
 #'   structure is created but before compilation. Receives one argument: the path
 #'   to the template directory (e.g., \code{<temp_dir>/bfh-template}). Use this
@@ -169,6 +174,7 @@ bfh_export_pdf <- function(x,
                            analysis_max_chars = 375,
                            dpi = 150,
                            font_path = NULL,
+                           ignore_system_fonts = TRUE,
                            inject_assets = NULL,
                            batch_session = NULL) {
   # Input validation
@@ -483,7 +489,12 @@ bfh_export_pdf <- function(x,
   }
 
   # Compile to PDF via Quarto (with optional font path)
-  bfh_compile_typst(typst_file, output, font_path = effective_font_path)
+  bfh_compile_typst(
+    typst_file,
+    output,
+    font_path = effective_font_path,
+    ignore_system_fonts = ignore_system_fonts
+  )
 
   # Return input object invisibly for pipe chaining
   invisible(x)

--- a/R/utils_typst.R
+++ b/R/utils_typst.R
@@ -176,6 +176,13 @@ bfh_create_typst_document <- function(chart_image,
 #' @param font_path Optional path to directory containing additional fonts.
 #'   Passed as \code{--font-path} to the Typst compiler. Useful when fonts
 #'   are not installed system-wide (e.g., on cloud deployment platforms).
+#' @param ignore_system_fonts Logical. If \code{TRUE} (default), passes
+#'   \code{--ignore-system-fonts} to Typst, ensuring only fonts from
+#'   \code{font_path} are used. Prevents system-installed font variants
+#'   (e.g., Mari Heavy with metadata \code{style=Heavy,Regular}) from
+#'   leaking into the rendered PDF and causing inconsistent weights between
+#'   dev machines and cloud deployment. Set to \code{FALSE} only if relying
+#'   on system fonts is intentional.
 #' @param .system2 Dependency-injection hook for \code{system2()}. Default is
 #'   the real \code{base::system2}. Tests can inject a mock to avoid spawning
 #'   live Quarto processes.
@@ -187,6 +194,7 @@ bfh_create_typst_document <- function(chart_image,
 #'
 #' @keywords internal
 bfh_compile_typst <- function(typst_file, output, font_path = NULL,
+                              ignore_system_fonts = TRUE,
                               .system2 = system2, .quarto_path = NULL) {
   if (!file.exists(typst_file)) {
     stop("Typst file not found: ", typst_file, call. = FALSE)
@@ -219,6 +227,9 @@ bfh_compile_typst <- function(typst_file, output, font_path = NULL,
   compile_args <- c("typst", "compile", shQuote(typst_file), shQuote(output))
   if (!is.null(font_path)) {
     compile_args <- c(compile_args, "--font-path", shQuote(font_path))
+  }
+  if (isTRUE(ignore_system_fonts)) {
+    compile_args <- c(compile_args, "--ignore-system-fonts")
   }
 
   # Use quarto typst compile (not quarto render which expects .qmd files)

--- a/man/bfh_compile_typst.Rd
+++ b/man/bfh_compile_typst.Rd
@@ -8,6 +8,7 @@ bfh_compile_typst(
   typst_file,
   output,
   font_path = NULL,
+  ignore_system_fonts = TRUE,
   .system2 = system2,
   .quarto_path = NULL
 )
@@ -20,6 +21,14 @@ bfh_compile_typst(
 \item{font_path}{Optional path to directory containing additional fonts.
 Passed as \code{--font-path} to the Typst compiler. Useful when fonts
 are not installed system-wide (e.g., on cloud deployment platforms).}
+
+\item{ignore_system_fonts}{Logical. If \code{TRUE} (default), passes
+\code{--ignore-system-fonts} to Typst, ensuring only fonts from
+\code{font_path} are used. Prevents system-installed font variants
+(e.g., Mari Heavy with metadata \code{style=Heavy,Regular}) from
+leaking into the rendered PDF and causing inconsistent weights between
+dev machines and cloud deployment. Set to \code{FALSE} only if relying
+on system fonts is intentional.}
 
 \item{.system2}{Dependency-injection hook for \code{system2()}. Default is
 the real \code{base::system2}. Tests can inject a mock to avoid spawning

--- a/man/bfh_export_pdf.Rd
+++ b/man/bfh_export_pdf.Rd
@@ -16,6 +16,7 @@ bfh_export_pdf(
   analysis_max_chars = 375,
   dpi = 150,
   font_path = NULL,
+  ignore_system_fonts = TRUE,
   inject_assets = NULL,
   batch_session = NULL
 )
@@ -73,6 +74,12 @@ relevant if the plot contains rasterized content.}
 Passed as \code{--font-path} to the Typst compiler. Useful when fonts
 (e.g., Mari) are bundled in a downstream package and not installed
 system-wide on the deployment platform.}
+
+\item{ignore_system_fonts}{Logical. If \code{TRUE} (default), passes
+\code{--ignore-system-fonts} to Typst so only fonts from \code{font_path}
+(or bundled template fonts) are used. Prevents inconsistent rendering
+when developers have additional Mari variants (e.g., Mari Heavy)
+installed system-wide. See \code{\link{bfh_compile_typst}} for details.}
 
 \item{inject_assets}{Optional callback function called after Typst template
 structure is created but before compilation. Receives one argument: the path


### PR DESCRIPTION
## Summary

Adds `ignore_system_fonts = TRUE` parameter to `bfh_compile_typst()` and `bfh_export_pdf()`. Passes `--ignore-system-fonts` to Typst CLI so only fonts from `font_path` (or bundled template fonts) are used.

Prevents inconsistent rendering when developers have additional Mari variants installed system-wide (e.g., `~/Library/Fonts/Mari Heavy.otf` with metadata `style=Heavy,Regular` matching regular weight). Previously Typst could pick MariHeavy as the regular-weight font instead of the bundled MariBook.

## Breaking change

Code relying on system fonts during Typst render must now opt out explicitly via `ignore_system_fonts = FALSE`.

Bumps version to **0.10.0** (pre-1.0 minor bump per VERSIONING_POLICY).

## Resolves

Fixes #227.

## Test plan

- [x] Existing integration tests pass with new default
- [x] `quarto typst compile --ignore-system-fonts` verified working with Quarto 1.8.26 / Typst 0.13.0
- [x] Smoke-test: `--ignore-system-fonts` flag added to compile_args when `ignore_system_fonts = TRUE`
- [x] Downstream verification in biSPCharts: PDF export shows MariBook (not MariHeavy) in `pdffonts` output