### PR TITLE
fix(path-policy): komponent-baseret traversal-check

### DIFF
--- a/R/utils_path_policy.R
+++ b/R/utils_path_policy.R
@@ -81,9 +81,11 @@ validate_export_path <- function(path,
 }
 
 .check_traversal <- function(path) {
-  if (grepl("..", path, fixed = TRUE)) {
+  parts <- strsplit(path, "[/\\\\]")[[1]]
+  if (any(parts == "..")) {
     stop(
-      "path cannot contain '..' (path traversal attempt detected)\n",
+      "path traversal attempt detected:",
+      " '..' is not allowed as a path component\n",
       "  Provided path: ", basename(path),
       call. = FALSE
     )

--- a/tests/testthat/test-path-policy.R
+++ b/tests/testthat/test-path-policy.R
@@ -116,6 +116,32 @@ test_that("validate_export_path returnerer path invisibly uden normalize", {
 })
 
 # ============================================================================
+# TRAVERSAL: KOMPONENT-BASERET CHECK (regression for #214)
+# ============================================================================
+
+test_that(".check_traversal accepterer '..' som del af filnavn (ikke komponent)", {
+  # Disse skal IKKE afvises — '..' er del af filnavnet, ikke en path-komponent
+  expect_no_error(validate_export_path("report..v2.pdf"))
+  expect_no_error(validate_export_path("..hidden.pdf"))
+  expect_no_error(validate_export_path("data..backup.csv"))
+  expect_no_error(validate_export_path("analyse..final.pdf"))
+})
+
+test_that(".check_traversal afviser '..' som selvstændig path-komponent", {
+  expect_error(validate_export_path("../etc/passwd"), "traversal")
+  expect_error(validate_export_path("output/../secret.pdf"), "traversal")
+  expect_error(validate_export_path("../../sensitive.pdf"), "traversal")
+  expect_error(validate_export_path("subdir/.."), "traversal")
+  expect_error(validate_export_path("subdir/../child.pdf"), "traversal")
+})
+
+test_that(".check_traversal håndterer Windows backslash-separator", {
+  # strsplit splitter på både / og \ — '\..\' erkendes som traversal-komponent
+  # på alle platforme
+  expect_error(validate_export_path("subdir\\..\\child.pdf"), "traversal")
+})
+
+# ============================================================================
 # BASIC INPUT VALIDATION
 # ============================================================================
 


### PR DESCRIPTION
## Summary
- Erstatter `grepl("..", fixed=TRUE)` med `strsplit` + `any(parts == "..")` i `.check_traversal()`
- Forhindrer fejlagtig afvisning af legitime filnavne som `report..v2.pdf`
- Håndterer både `/` og `\\` separatorer (cross-platform)

## Test plan
- [x] Positive tests: `report..v2.pdf`, `..hidden.pdf`, `data..backup.csv` accepteres nu
- [x] Negative tests: `../etc/passwd`, `output/../secret.pdf`, `../../sensitive.pdf` afvises stadig
- [x] Windows backslash-separator test
- [x] 38 tests bestået, 0 fejlet

Closes #214