### PR TITLE
refactor(config): fjern phase_config dead code

### DIFF
--- a/R/config_objects.R
+++ b/R/config_objects.R
@@ -32,9 +32,8 @@
 #' )
 #'
 #' viewport <- viewport_dims(width = 800, height = 600, base_size = 14)
-#' phases <- phase_config(show_phases = FALSE)
 #'
-#' plot <- bfh_spc_plot(qic_data, plot_cfg, viewport, phases)
+#' plot <- bfh_spc_plot(qic_data, plot_cfg, viewport)
 #' ```
 #'
 #' @name config_objects
@@ -237,80 +236,5 @@ print.viewport_dims <- function(x, ...) {
   cat("  Width:", if (is.null(x$width)) "Auto" else paste(x$width, "px"), "\n")
   cat("  Height:", if (is.null(x$height)) "Auto" else paste(x$height, "px"), "\n")
   cat("  Base Size:", x$base_size, "\n")
-  invisible(x)
-}
-
-# ============================================================================
-# PHASE CONFIGURATION
-# ============================================================================
-
-#' Create Phase Configuration
-#'
-#' Creates a configuration object for phase/shift handling in SPC charts.
-#' Currently reserved for biSPCharts integration - not used in the
-#' BFHcharts pipeline.
-#'
-#' @param part_positions Integer vector of row positions where phase changes occur (optional)
-#' @param freeze_position Integer row position where baseline should be frozen (optional)
-#'
-#' @return List with class "phase_config"
-#'
-#' @details
-#' This object controls phase separation and control limit freezing.
-#'
-#' **Phase Handling**:
-#' - `part_positions` specifies row numbers where new phases begin
-#' - `freeze_position` locks the baseline calculation up to a specific row
-#' - These are passed directly to qicharts2::qic()
-#'
-#' @keywords internal
-#' @noRd
-#' @examples
-#' # No phases
-#' phases <- phase_config()
-#'
-#' # Phase shift at row 20
-#' phases <- phase_config(part_positions = 20)
-#'
-#' # Multiple phases with frozen baseline
-#' phases <- phase_config(
-#'   part_positions = c(15, 30, 45),
-#'   freeze_position = 15
-#' )
-phase_config <- function(
-  part_positions = NULL,
-  freeze_position = NULL
-) {
-  # Validation
-  if (!is.null(part_positions)) {
-    if (!is.numeric(part_positions) || any(is.na(part_positions)) ||
-      any(part_positions <= 0)) {
-      stop_config_error("part_positions must be positive integers or NULL")
-    }
-  }
-
-  if (!is.null(freeze_position)) assert_positive_scalar(freeze_position, "freeze_position")
-
-  structure(
-    list(
-      part_positions = part_positions,
-      freeze_position = freeze_position
-    ),
-    class = "phase_config"
-  )
-}
-
-#' Print Phase Configuration
-#'
-#' @param x Phase configuration object
-#' @param ... Additional arguments (ignored)
-#'
-#' @return Invisibly returns x
-#' @keywords internal
-#' @noRd
-print.phase_config <- function(x, ...) {
-  cat("Phase Configuration:\n")
-  cat("  Part Positions:", if (is.null(x$part_positions)) "NULL" else paste(x$part_positions, collapse = ", "), "\n")
-  cat("  Freeze Position:", if (is.null(x$freeze_position)) "NULL" else x$freeze_position, "\n")
   invisible(x)
 }

--- a/R/plot_core.R
+++ b/R/plot_core.R
@@ -21,7 +21,6 @@ NULL
 #' @param qic_data Data frame from qicharts2::qic() with return.data = TRUE
 #' @param plot_config Plot configuration
 #' @param viewport Viewport dimensions
-#' @param phase Optional phase configuration
 #' @param plot_margin Numeric vector of length 4 (top, right, bottom, left) in mm,
 #'   or a margin object from ggplot2::margin(), or NULL for default
 #'
@@ -82,7 +81,6 @@ NULL
 bfh_spc_plot <- function(qic_data,
                          plot_config = spc_plot_config(),
                          viewport = viewport_dims(),
-                         phase = NULL,
                          plot_margin = NULL) {
   # Validate inputs
   if (!is.data.frame(qic_data)) {

--- a/tests/testthat/test-config_objects.R
+++ b/tests/testthat/test-config_objects.R
@@ -279,138 +279,21 @@ test_that("print.viewport_dims returns object invisibly", {
 })
 
 # ============================================================================
-# PHASE_CONFIG TESTS
-# ============================================================================
-
-test_that("phase_config creates valid configuration object", {
-  pc <- phase_config()
-
-  expect_s3_class(pc, "phase_config")
-  expect_true(is.list(pc))
-})
-
-test_that("phase_config includes all parameters", {
-  pc <- phase_config(
-    part_positions = c(15, 30, 45),
-    freeze_position = 15
-  )
-
-  expect_equal(pc$part_positions, c(15, 30, 45))
-  expect_equal(pc$freeze_position, 15)
-})
-
-test_that("phase_config uses default NULL values", {
-  pc <- phase_config()
-
-  expect_null(pc$part_positions)
-  expect_null(pc$freeze_position)
-})
-
-test_that("phase_config validates part_positions are positive", {
-  pc <- phase_config(part_positions = c(10, 20, 30))
-  expect_equal(pc$part_positions, c(10, 20, 30))
-
-  pc <- phase_config(part_positions = 15)
-  expect_equal(pc$part_positions, 15)
-
-  expect_error(
-    phase_config(part_positions = c(10, 0, 20)),
-    "part_positions",
-    class = "bfhcharts_config_error"
-  )
-
-  expect_error(
-    phase_config(part_positions = c(10, -5)),
-    "part_positions",
-    class = "bfhcharts_config_error"
-  )
-
-  expect_error(
-    phase_config(part_positions = "ten"),
-    "part_positions",
-    class = "bfhcharts_config_error"
-  )
-
-  expect_error(
-    phase_config(part_positions = NA_integer_),
-    "part_positions",
-    class = "bfhcharts_config_error"
-  )
-})
-
-test_that("phase_config validates freeze_position is positive", {
-  pc <- phase_config(freeze_position = 20)
-  expect_equal(pc$freeze_position, 20)
-
-  expect_error(
-    phase_config(freeze_position = 0),
-    "freeze_position",
-    class = "bfhcharts_config_error"
-  )
-
-  expect_error(
-    phase_config(freeze_position = -10),
-    "freeze_position",
-    class = "bfhcharts_config_error"
-  )
-
-  expect_error(
-    phase_config(freeze_position = NA_real_),
-    "freeze_position",
-    class = "bfhcharts_config_error"
-  )
-})
-
-test_that("print.phase_config displays configuration", {
-  pc <- phase_config(
-    part_positions = c(15, 30),
-    freeze_position = 15
-  )
-
-  output <- capture.output(print(pc))
-
-  expect_true(any(grepl("Phase Configuration", output)))
-  expect_true(any(grepl("Part Positions.*15.*30", output)))
-  expect_true(any(grepl("Freeze Position.*15", output)))
-})
-
-test_that("print.phase_config shows NULL for empty values", {
-  pc <- phase_config()
-
-  output <- capture.output(print(pc))
-
-  expect_true(any(grepl("Part Positions.*NULL", output)))
-  expect_true(any(grepl("Freeze Position.*NULL", output)))
-})
-
-test_that("print.phase_config returns object invisibly", {
-  pc <- phase_config()
-
-  result <- withVisible(print(pc))
-
-  expect_false(result$visible)
-  expect_identical(result$value, pc)
-})
-
-# ============================================================================
 # INTEGRATION TESTS
 # ============================================================================
 
 test_that("Configuration objects can be used together", {
-  # Create all three config objects
+  # Create both config objects
   plot_cfg <- spc_plot_config(chart_type = "p", y_axis_unit = "percent")
   viewport <- viewport_dims(width = 1000, height = 600, base_size = 16)
-  phases <- phase_config(part_positions = 20)
 
   # All should be valid
   expect_s3_class(plot_cfg, "spc_plot_config")
   expect_s3_class(viewport, "viewport_dims")
-  expect_s3_class(phases, "phase_config")
 
   # Should have correct values
   expect_equal(plot_cfg$chart_type, "p")
   expect_equal(viewport$width, 1000)
-  expect_equal(phases$part_positions, 20)
 })
 
 test_that("Configuration objects work in bfh_qic", {


### PR DESCRIPTION
## Summary
- Sletter `phase_config()` og `print.phase_config()` fra `R/config_objects.R` (~70 LOC inkl. Roxygen)
- Fjerner `phase = NULL` parameter fra `bfh_spc_plot()` signatur
- Fjerner ~8 tests der testede den ubrugte kode
- `grep -rn "phase_config" R/ tests/` returnerer 0 hits

## Test plan
- [x] `devtools::document()` opdaterede NAMESPACE korrekt
- [x] `devtools::test()`: 2369 pass, 0 fail
- [x] `devtools::check()`: 0 errors, 0 warnings

Closes #216