### PR TITLE
fix(stats): navngivet RECENT_OBS_WINDOW konstant + effective_window

### DIFF
--- a/R/globals.R
+++ b/R/globals.R
@@ -81,3 +81,10 @@ PDF_CHART_HEIGHT_MM <- 109
 # This ensures consistent, readable labels regardless of how the chart was created
 # Value of 6 is calibrated for the PDF template dimensions
 PDF_LABEL_SIZE <- 6
+
+# ============================================================================
+# SPC ANALYSIS CONSTANTS
+# ============================================================================
+
+# Vindue for seneste observationer i outlier-tæller (6 er standard i SPC-litteraturen)
+RECENT_OBS_WINDOW <- 6L

--- a/R/spc_analysis.R
+++ b/R/spc_analysis.R
@@ -499,7 +499,8 @@ build_fallback_analysis <- function(context,
       outliers_n,
       i18n_lookup("labels.outliers.singular", language),
       i18n_lookup("labels.outliers.plural", language)
-    )
+    ),
+    effective_window = spc_stats$effective_window %||% RECENT_OBS_WINDOW
   )
 
   # --- 1. Stabilitetstekst ---

--- a/R/utils_spc_stats.R
+++ b/R/utils_spc_stats.R
@@ -140,14 +140,22 @@ bfh_extract_spc_stats.bfh_qic_result <- function(x) {
 
   stats$outliers_actual <- sum(qd$sigma.signal, na.rm = TRUE)
 
-  # outliers_recent_count daekker kun seneste 6 obs - aeldre outliers vises
-  # visuelt i diagrammet men beskrives ikke som aktuelle i analyseteksten.
+  # outliers_recent_count daekker kun seneste RECENT_OBS_WINDOW obs - aeldre
+  # outliers vises visuelt i diagrammet men beskrives ikke som aktuelle i
+  # analyseteksten. effective_window = min(RECENT_OBS_WINDOW, n_obs) haandterer
+  # korte serier korrekt og eksponeres til i18n-skabeloner.
   n_obs <- nrow(qd)
-  recent_start <- max(1, n_obs - 5)
-  stats$outliers_recent_count <- sum(
-    qd$sigma.signal[recent_start:n_obs],
-    na.rm = TRUE
-  )
+  effective_window <- min(RECENT_OBS_WINDOW, n_obs)
+  stats$effective_window <- effective_window
+  if (effective_window > 0L) {
+    recent_start <- n_obs - effective_window + 1L
+    stats$outliers_recent_count <- sum(
+      qd$sigma.signal[recent_start:n_obs],
+      na.rm = TRUE
+    )
+  } else {
+    stats$outliers_recent_count <- 0L
+  }
 
   stats
 }

--- a/inst/i18n/da.yaml
+++ b/inst/i18n/da.yaml
@@ -8,7 +8,7 @@
 # ANALYSETEKSTER
 # Placeholders: {runs_actual}, {runs_expected}, {crossings_actual},
 #   {crossings_expected}, {outliers_actual}, {outliers_word},
-#   {centerline}, {target}, {n_points}
+#   {effective_window}, {centerline}, {target}, {n_points}
 # ==============================================================================
 
 analysis:
@@ -36,8 +36,8 @@ analysis:
 
     outliers_only:
       short: "{outliers_actual} {outliers_word} ligger uden for kontrolgrænserne."
-      standard: "{outliers_actual} af de seneste observationer ligger uden for kontrolgrænserne og bør undersøges for særlige årsager."
-      detailed: "{outliers_actual} af de seneste observationer ligger uden for kontrolgrænserne. De bør undersøges for særlige årsager, da de kan skyldes usædvanlige hændelser eller målefejl."
+      standard: "{outliers_actual} af de seneste {effective_window} observationer ligger uden for kontrolgrænserne og bør undersøges for særlige årsager."
+      detailed: "{outliers_actual} af de seneste {effective_window} observationer ligger uden for kontrolgrænserne. De bør undersøges for særlige årsager, da de kan skyldes usædvanlige hændelser eller målefejl."
 
     runs_crossings:
       short: "Processen viser systematisk ustabilitet."
@@ -46,18 +46,18 @@ analysis:
 
     runs_outliers:
       short: "Processen viser et niveauskift og {outliers_actual} {outliers_word} uden for kontrolgrænserne."
-      standard: "Processen viser et niveauskift (serielængde {runs_actual} > {runs_expected}), og {outliers_actual} af de seneste observationer ligger uden for kontrolgrænserne."
-      detailed: "Processen viser et niveauskift (serielængde {runs_actual} > {runs_expected}), og {outliers_actual} af de seneste observationer ligger uden for kontrolgrænserne. Undersøg om niveauskiftet og de afvigende målinger har samme underliggende årsag."
+      standard: "Processen viser et niveauskift (serielængde {runs_actual} > {runs_expected}), og {outliers_actual} af de seneste {effective_window} observationer ligger uden for kontrolgrænserne."
+      detailed: "Processen viser et niveauskift (serielængde {runs_actual} > {runs_expected}), og {outliers_actual} af de seneste {effective_window} observationer ligger uden for kontrolgrænserne. Undersøg om niveauskiftet og de afvigende målinger har samme underliggende årsag."
 
     crossings_outliers:
       short: "Processen viser gruppering og {outliers_actual} {outliers_word} uden for kontrolgrænserne."
-      standard: "Datapunkterne grupperer sig (krydsninger {crossings_actual} < {crossings_expected}), og {outliers_actual} af de seneste observationer ligger uden for kontrolgrænserne."
-      detailed: "Datapunkterne grupperer sig omkring centrallinjen (krydsninger {crossings_actual} < {crossings_expected}), og {outliers_actual} af de seneste observationer ligger uden for kontrolgrænserne. Dette mønster kan indikere skiftende betingelser i processen."
+      standard: "Datapunkterne grupperer sig (krydsninger {crossings_actual} < {crossings_expected}), og {outliers_actual} af de seneste {effective_window} observationer ligger uden for kontrolgrænserne."
+      detailed: "Datapunkterne grupperer sig omkring centrallinjen (krydsninger {crossings_actual} < {crossings_expected}), og {outliers_actual} af de seneste {effective_window} observationer ligger uden for kontrolgrænserne. Dette mønster kan indikere skiftende betingelser i processen."
 
     all_signals:
       short: "Processen er ustabil med flere samtidige signaler."
-      standard: "Processen er ustabil med flere samtidige signaler: niveauskift og gruppering samt {outliers_actual} af de seneste observationer uden for kontrolgrænserne."
-      detailed: "Processen er ustabil med flere samtidige signaler: niveauskift (serielængde {runs_actual} > {runs_expected}), gruppering omkring centrallinjen (krydsninger {crossings_actual} < {crossings_expected}) samt {outliers_actual} af de seneste observationer uden for kontrolgrænserne. Undersøg fælles og særlige årsager systematisk."
+      standard: "Processen er ustabil med flere samtidige signaler: niveauskift og gruppering samt {outliers_actual} af de seneste {effective_window} observationer uden for kontrolgrænserne."
+      detailed: "Processen er ustabil med flere samtidige signaler: niveauskift (serielængde {runs_actual} > {runs_expected}), gruppering omkring centrallinjen (krydsninger {crossings_actual} < {crossings_expected}) samt {outliers_actual} af de seneste {effective_window} observationer uden for kontrolgrænserne. Undersøg fælles og særlige årsager systematisk."
 
   target:
     at_target:

--- a/inst/i18n/en.yaml
+++ b/inst/i18n/en.yaml
@@ -31,8 +31,8 @@ analysis:
 
     outliers_only:
       short: "{outliers_actual} {outliers_word} outside the control limits."
-      standard: "{outliers_actual} of the most recent observations are outside the control limits and should be investigated for special causes."
-      detailed: "{outliers_actual} of the most recent observations are outside the control limits. They should be investigated for special causes, as they may result from unusual events or measurement errors."
+      standard: "{outliers_actual} of the most recent {effective_window} observations are outside the control limits and should be investigated for special causes."
+      detailed: "{outliers_actual} of the most recent {effective_window} observations are outside the control limits. They should be investigated for special causes, as they may result from unusual events or measurement errors."
 
     runs_crossings:
       short: "The process shows systematic instability."
@@ -41,18 +41,18 @@ analysis:
 
     runs_outliers:
       short: "The process shows a level shift and {outliers_actual} {outliers_word} outside the control limits."
-      standard: "The process shows a level shift (run length {runs_actual} > {runs_expected}), and {outliers_actual} of the most recent observations are outside the control limits."
-      detailed: "The process shows a level shift (run length {runs_actual} > {runs_expected}), and {outliers_actual} of the most recent observations are outside the control limits. Investigate whether the level shift and the outlying measurements share a common root cause."
+      standard: "The process shows a level shift (run length {runs_actual} > {runs_expected}), and {outliers_actual} of the most recent {effective_window} observations are outside the control limits."
+      detailed: "The process shows a level shift (run length {runs_actual} > {runs_expected}), and {outliers_actual} of the most recent {effective_window} observations are outside the control limits. Investigate whether the level shift and the outlying measurements share a common root cause."
 
     crossings_outliers:
       short: "The process shows clustering and {outliers_actual} {outliers_word} outside the control limits."
-      standard: "Data points cluster (crossings {crossings_actual} < {crossings_expected}), and {outliers_actual} of the most recent observations are outside the control limits."
-      detailed: "Data points cluster around the centre line (crossings {crossings_actual} < {crossings_expected}), and {outliers_actual} of the most recent observations are outside the control limits. This pattern may indicate shifting process conditions."
+      standard: "Data points cluster (crossings {crossings_actual} < {crossings_expected}), and {outliers_actual} of the most recent {effective_window} observations are outside the control limits."
+      detailed: "Data points cluster around the centre line (crossings {crossings_actual} < {crossings_expected}), and {outliers_actual} of the most recent {effective_window} observations are outside the control limits. This pattern may indicate shifting process conditions."
 
     all_signals:
       short: "The process is unstable with multiple simultaneous signals."
-      standard: "The process is unstable with multiple simultaneous signals: level shift and clustering, plus {outliers_actual} of the most recent observations outside the control limits."
-      detailed: "The process is unstable with multiple simultaneous signals: level shift (run length {runs_actual} > {runs_expected}), clustering around the centre line (crossings {crossings_actual} < {crossings_expected}), and {outliers_actual} of the most recent observations outside the control limits. Investigate common and special causes systematically."
+      standard: "The process is unstable with multiple simultaneous signals: level shift and clustering, plus {outliers_actual} of the most recent {effective_window} observations outside the control limits."
+      detailed: "The process is unstable with multiple simultaneous signals: level shift (run length {runs_actual} > {runs_expected}), clustering around the centre line (crossings {crossings_actual} < {crossings_expected}), and {outliers_actual} of the most recent {effective_window} observations outside the control limits. Investigate common and special causes systematically."
 
   target:
     at_target:

--- a/tests/testthat/test-outliers-recent-count.R
+++ b/tests/testthat/test-outliers-recent-count.R
@@ -1,0 +1,140 @@
+# Tests for RECENT_OBS_WINDOW konstant og effective_window i outlier-tæller
+#
+# Verificerer at:
+# - RECENT_OBS_WINDOW konstant eksisterer og er 6L
+# - effective_window = min(RECENT_OBS_WINDOW, n_obs) for korte serier
+# - outliers_recent_count kun tæller inden for effective_window
+# - Edge cases: n_obs 0–7 håndteres korrekt
+#
+# Relateret: OpenSpec harden-outliers-recent-count
+
+# RECENT_OBS_WINDOW KONSTANT ==================================================
+
+test_that("RECENT_OBS_WINDOW konstant eksisterer og er 6L", {
+  expect_true(exists("RECENT_OBS_WINDOW", envir = asNamespace("BFHcharts")))
+  expect_equal(BFHcharts:::RECENT_OBS_WINDOW, 6L)
+})
+
+# EFFECTIVE_WINDOW I STATS-OUTPUT =============================================
+
+test_that("effective_window er til stede i stats for bfh_qic_result", {
+  sigma_signal <- rep(FALSE, 10)
+  result <- fixture_bfh_qic_result(sigma_signal)
+
+  stats <- bfh_extract_spc_stats(result)
+
+  expect_true("effective_window" %in% names(stats))
+})
+
+test_that("n_obs = 1 giver effective_window = 1", {
+  sigma_signal <- c(FALSE)
+  result <- fixture_bfh_qic_result(sigma_signal)
+
+  stats <- bfh_extract_spc_stats(result)
+
+  expect_equal(stats$effective_window, 1L)
+})
+
+test_that("n_obs = 5 giver effective_window = 5", {
+  sigma_signal <- rep(FALSE, 5)
+  result <- fixture_bfh_qic_result(sigma_signal)
+
+  stats <- bfh_extract_spc_stats(result)
+
+  expect_equal(stats$effective_window, 5L)
+})
+
+test_that("n_obs = 6 giver effective_window = 6", {
+  sigma_signal <- rep(FALSE, 6)
+  result <- fixture_bfh_qic_result(sigma_signal)
+
+  stats <- bfh_extract_spc_stats(result)
+
+  expect_equal(stats$effective_window, 6L)
+})
+
+test_that("n_obs = 7 giver effective_window = 6 (capped til RECENT_OBS_WINDOW)", {
+  sigma_signal <- rep(FALSE, 7)
+  result <- fixture_bfh_qic_result(sigma_signal)
+
+  stats <- bfh_extract_spc_stats(result)
+
+  expect_equal(stats$effective_window, 6L)
+})
+
+test_that("n_obs = 20 giver effective_window = 6 (capped til RECENT_OBS_WINDOW)", {
+  sigma_signal <- rep(FALSE, 20)
+  result <- fixture_bfh_qic_result(sigma_signal)
+
+  stats <- bfh_extract_spc_stats(result)
+
+  expect_equal(stats$effective_window, 6L)
+})
+
+# OUTLIERS KUN I DE FØRSTE OBS ================================================
+
+test_that("outliers kun i første observationer giver outliers_recent_count = 0", {
+  # 10 obs: outlier på position 1-3, ingen i de seneste 6 (positioner 5-10)
+  sigma_signal <- c(TRUE, TRUE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE)
+  result <- fixture_bfh_qic_result(sigma_signal)
+
+  stats <- bfh_extract_spc_stats(result)
+
+  # total outliers = 3, men ingen i seneste 6
+  expect_equal(stats$outliers_actual, 3)
+  expect_equal(stats$outliers_recent_count, 0)
+  expect_equal(stats$effective_window, 6L)
+})
+
+# EDGE CASES: TOM / INGEN SIGMA.SIGNAL ========================================
+
+test_that("ingen sigma.signal kolonne giver NULL effective_window og NULL outliers_recent_count", {
+  qic_data <- data.frame(x = 1:5, y = 1:5, cl = rep(0, 5))
+  result <- structure(
+    list(
+      plot = ggplot2::ggplot(),
+      summary = data.frame(),
+      qic_data = qic_data,
+      config = list(chart_type = "i")
+    ),
+    class = c("bfh_qic_result", "list")
+  )
+
+  stats <- bfh_extract_spc_stats(result)
+
+  # Ingen sigma.signal → outliers_recent_count og effective_window forbliver NULL
+  # (tabel skjuler rækken frem for at vise "-")
+  expect_null(stats$outliers_recent_count)
+  expect_null(stats$effective_window)
+})
+
+test_that("run chart giver NULL effective_window (ingen kontrolgrænser)", {
+  sigma_signal <- rep(FALSE, 10)
+  result <- fixture_bfh_qic_result(sigma_signal, chart_type = "run")
+
+  stats <- bfh_extract_spc_stats(result)
+
+  expect_null(stats$effective_window)
+  expect_null(stats$outliers_recent_count)
+  expect_true(stats$is_run_chart)
+})
+
+# KONSISTENS MED EKSISTERENDE OUTLIER-LOGIK ===================================
+
+test_that("effective_window ændrer ikke eksisterende semantik for outliers_actual (total)", {
+  # Outlier på position 5 (udenfor vinduet) og 20, 21 (i vinduet)
+  # 21 obs total: seneste 6 = positioner 16-21
+  sigma_signal <- c(
+    rep(FALSE, 4),
+    TRUE, # position 5 — udenfor vinduet
+    rep(FALSE, 14),
+    TRUE, TRUE # positioner 20, 21 — i vinduet
+  )
+  result <- fixture_bfh_qic_result(sigma_signal)
+
+  stats <- bfh_extract_spc_stats(result)
+
+  expect_equal(stats$outliers_actual, 3) # total i seneste part
+  expect_equal(stats$outliers_recent_count, 2) # kun i vinduet
+  expect_equal(stats$effective_window, 6L)
+})

--- a/tests/testthat/test-spc_analysis.R
+++ b/tests/testthat/test-spc_analysis.R
@@ -627,8 +627,9 @@ test_that("build_fallback_analysis bruger ental ved 1 outlier", {
   ctx <- fixture_analysis_context(spc_stats = stats)
   txt <- BFHcharts:::build_fallback_analysis(ctx)
   # Grammatisk korrekt dansk: enten "1 observation ligger" (direkte) eller
-  # "1 af de seneste observationer ligger" (flertal i "af de seneste"-konstruktion).
-  expect_match(txt, "1 observation\\b|1 af de seneste observationer")
+  # "1 af de seneste [N] observationer ligger" (flertal i "af de seneste"-konstruktion,
+  # muligvis med et vinduesantal indskudt).
+  expect_match(txt, "1 observation\\b|1 af de seneste \\d* ?observationer")
   # Må ikke indeholde "1 observationer" som direkte konstruktion
   expect_false(grepl("\\b1 observationer\\b", txt))
 })
@@ -642,8 +643,9 @@ test_that("build_fallback_analysis bruger flertal ved 3 outliers", {
   ctx <- fixture_analysis_context(spc_stats = stats)
   txt <- BFHcharts:::build_fallback_analysis(ctx)
   # Grammatisk korrekt dansk: enten "3 observationer" (direkte) eller
-  # "3 af de seneste observationer" (flertal i "af de seneste"-konstruktion).
-  expect_match(txt, "3 observationer|3 af de seneste observationer")
+  # "3 af de seneste [N] observationer" (flertal i "af de seneste"-konstruktion,
+  # muligvis med et vinduesantal indskudt).
+  expect_match(txt, "3 observationer|3 af de seneste \\d* ?observationer")
   # Må aldrig bruge ental efter tal > 1
   expect_false(grepl("\\b3 observation\\b", txt))
 })


### PR DESCRIPTION
## Summary
- Tilføjer `RECENT_OBS_WINDOW <- 6L` konstant i `R/globals.R`
- Erstatter implicit hardcoded `n_obs - 5` literal i `R/utils_spc_stats.R` med `min(RECENT_OBS_WINDOW, n_obs)`
- Eksponerer `effective_window` i stats-output til i18n-skabeloner
- Opdaterer `inst/i18n/da.yaml` og `inst/i18n/en.yaml` til `{effective_window}` placeholder

## Test plan
- [x] Nye tests: n_obs 1/5/6/7/100 edge cases, tom sigma.signal
- [x] `devtools::test()`: 2413 pass, 0 fail

Closes #207