### PR TITLE
feat(summary): eksponér variable kontrolgrænser som min/max kolonner

### DIFF
--- a/R/utils_qic_summary.R
+++ b/R/utils_qic_summary.R
@@ -19,7 +19,33 @@ NULL
 #' @param qic_data Data frame from qicharts2::qic(..., return.data = TRUE)
 #' @param y_axis_unit Unit type for appropriate rounding ("count", "percent", "rate", "time")
 #'
-#' @return Data frame with Danish column names and formatted values
+#' @return Data frame with Danish column names and formatted values.
+#'   One row per phase (part). Columns present depend on chart type:
+#'
+#'   **Always present:**
+#'   - `fase` — phase number (integer)
+#'   - `antal_observationer` — total observations per phase
+#'   - `anvendelige_observationer` — usable observations per phase
+#'   - `laengste_loeb`, `laengste_loeb_max` — run-length statistics
+#'   - `antal_kryds`, `antal_kryds_min` — crossing-count statistics
+#'   - `loebelaengde_signal`, `sigma_signal` — Anhøj + sigma signals (logical)
+#'   - `centerlinje` — center line value
+#'
+#'   **Control limit columns (if lcl/ucl present in qic_data):**
+#'   - `kontrolgraenser_konstante` — logical, TRUE if control limits are
+#'     identical for all observations within this phase. FALSE for p/u-charts
+#'     with varying denominators.
+#'
+#'   *When ALL phases have constant limits* (e.g. I-charts, C-charts):
+#'   - `nedre_kontrolgraense` — scalar lower control limit per phase
+#'   - `oevre_kontrolgraense` — scalar upper control limit per phase
+#'
+#'   *When ANY phase has variable limits* (e.g. P-charts with varying n):
+#'   - `nedre_kontrolgraense_min` / `nedre_kontrolgraense_max` — range of LCL
+#'   - `oevre_kontrolgraense_min` / `oevre_kontrolgraense_max` — range of UCL
+#'
+#'   Run charts (no lcl/ucl) receive no control limit columns at all.
+#'
 #' @keywords internal
 #' @noRd
 #'
@@ -29,7 +55,7 @@ NULL
 #' - n.obs -> antal_observationer
 #' - n.useful -> anvendelige_observationer
 #' - cl -> centerlinje
-#' - lcl / ucl -> nedre_kontrolgraense / oevre_kontrolgraense
+#' - lcl / ucl -> se @return for kontrolgraense-kolonner
 #' - runs.signal -> loebelaengde_signal
 #' - sigma.signal -> sigma_signal
 #'
@@ -37,6 +63,13 @@ NULL
 #' - Control limits: 2 decimals for percent/rate, 1 decimal for count/time
 #' - Counts: integers
 #' - Signals: converted to logical (TRUE/FALSE)
+#'
+#' **Control limits constancy:**
+#' Constancy is checked per phase using `round(x, decimal_places + 2)` to
+#' handle floating-point drift in qicharts2 output. A global column-branch
+#' decision is made: if all phases are constant, scalar columns are used
+#' (backward compatible); if any phase is variable, min/max columns are used
+#' for all phases (with min == max for phases that happen to be constant).
 #'
 #' @examples
 #' \dontrun{
@@ -140,24 +173,61 @@ format_qic_summary <- function(qic_data, y_axis_unit = "count") {
     formatted$centerlinje <- round(raw_summary$cl, decimal_places)
   }
 
-  # Only include lcl/ucl if they are constant across observations
-  # For p/u charts, control limits vary per observation based on denominator
-  # so showing a single value is misleading
+  # Ekspon\u00e9r kontrolgr\u00e6nser med konstans-flag og min/max ved variable gr\u00e6nser.
+  #
+  # P/U-charts har variable gr\u00e6nser (afh\u00e6nger af n\u00e6vner per observation).
+  # Logik (Option A \u2014 column-level branch):
+  #   - Alle faser konstante \u2192 bevar skalare nedre/\u00f8vre_kontrolgr\u00e6nse (backward compat)
+  #                             + kontrolgr\u00e6nser_konstante = TRUE per row
+  #   - Mindst \u00e9n fase variabel \u2192 ekspon\u00e9r min/max kolonner for alle r\u00e6kker
+  #                                + kontrolgr\u00e6nser_konstante = FALSE per row (TRUE kun
+  #                                  for rent konstante faser, se nedenfor)
+  #
+  # Run charts (ingen lcl/ucl) f\u00e5r ingen kontrolgr\u00e6nse-kolonner overhovedet.
   if ("lcl" %in% names(raw_summary) && "ucl" %in% names(raw_summary)) {
-    # Check if control limits are constant by comparing unique values
-    # within each part (phase)
-    lcl_constant <- all(vapply(split(qic_data$lcl, qic_data$part), function(x) {
-      length(unique(round(x, decimal_places + 2))) <= 1
-    }, logical(1)))
-    ucl_constant <- all(vapply(split(qic_data$ucl, qic_data$part), function(x) {
-      length(unique(round(x, decimal_places + 2))) <= 1
-    }, logical(1)))
+    # Beregn konstans per fase (brug samme afrundingspr\u00e6cision som eksisterende kode)
+    round_prec <- decimal_places + 2
 
-    if (lcl_constant && ucl_constant) {
+    part_key <- as.character(raw_summary$part)
+    lcl_split <- split(qic_data$lcl, qic_data$part)
+    ucl_split <- split(qic_data$ucl, qic_data$part)
+
+    # Er gr\u00e6nser konstante inden for den p\u00e5g\u00e6ldende fase?
+    lcl_const_per_part <- vapply(part_key, function(p) {
+      length(unique(round(lcl_split[[p]], round_prec))) <= 1
+    }, logical(1))
+    ucl_const_per_part <- vapply(part_key, function(p) {
+      length(unique(round(ucl_split[[p]], round_prec))) <= 1
+    }, logical(1))
+
+    # Per-row flag: TRUE kun hvis BEGGE lcl og ucl er konstante i den fase
+    part_konstant <- lcl_const_per_part & ucl_const_per_part
+
+    # Global beslutning: er ALLE faser konstante?
+    alle_konstante <- all(part_konstant)
+
+    # Tilf\u00f8j per-row flag
+    formatted[["kontrolgr\u00e6nser_konstante"]] <- part_konstant
+
+    if (alle_konstante) {
+      # Backward-compat: bevar skalare kolonner (\u00e9n v\u00e6rdi per fase)
       formatted[["nedre_kontrolgr\u00e6nse"]] <- round(raw_summary$lcl, decimal_places)
       formatted[["\u00f8vre_kontrolgr\u00e6nse"]] <- round(raw_summary$ucl, decimal_places)
+    } else {
+      # Variable gr\u00e6nser: ekspon\u00e9r min/max per fase
+      formatted[["nedre_kontrolgr\u00e6nse_min"]] <- vapply(part_key, function(p) {
+        round(min(lcl_split[[p]], na.rm = TRUE), decimal_places)
+      }, numeric(1))
+      formatted[["nedre_kontrolgr\u00e6nse_max"]] <- vapply(part_key, function(p) {
+        round(max(lcl_split[[p]], na.rm = TRUE), decimal_places)
+      }, numeric(1))
+      formatted[["\u00f8vre_kontrolgr\u00e6nse_min"]] <- vapply(part_key, function(p) {
+        round(min(ucl_split[[p]], na.rm = TRUE), decimal_places)
+      }, numeric(1))
+      formatted[["\u00f8vre_kontrolgr\u00e6nse_max"]] <- vapply(part_key, function(p) {
+        round(max(ucl_split[[p]], na.rm = TRUE), decimal_places)
+      }, numeric(1))
     }
-    # If not constant, don't include them in summary
   }
 
   # Optionally add 95% limits if present

--- a/R/utils_qic_summary.R
+++ b/R/utils_qic_summary.R
@@ -152,6 +152,8 @@ format_qic_summary <- function(qic_data, y_axis_unit = "count") {
   has_sigma_signal <- "sigma.signal" %in% names(qic_data) &&
     any(!is.na(qic_data$sigma.signal))
 
+  part_key <- as.character(raw_summary$part)
+
   if (has_sigma_signal) {
     if ("part" %in% names(qic_data)) {
       outliers_by_part <- vapply(
@@ -159,7 +161,6 @@ format_qic_summary <- function(qic_data, y_axis_unit = "count") {
         function(x) sum(x, na.rm = TRUE),
         integer(1)
       )
-      part_key <- as.character(raw_summary$part)
       formatted$forventede_outliers <- unname(as.integer(rep(0L, length(part_key))))
       formatted$antal_outliers <- unname(as.integer(outliers_by_part[part_key]))
     } else {
@@ -173,22 +174,10 @@ format_qic_summary <- function(qic_data, y_axis_unit = "count") {
     formatted$centerlinje <- round(raw_summary$cl, decimal_places)
   }
 
-  # Ekspon\u00e9r kontrolgr\u00e6nser med konstans-flag og min/max ved variable gr\u00e6nser.
-  #
-  # P/U-charts har variable gr\u00e6nser (afh\u00e6nger af n\u00e6vner per observation).
-  # Logik (Option A \u2014 column-level branch):
-  #   - Alle faser konstante \u2192 bevar skalare nedre/\u00f8vre_kontrolgr\u00e6nse (backward compat)
-  #                             + kontrolgr\u00e6nser_konstante = TRUE per row
-  #   - Mindst \u00e9n fase variabel \u2192 ekspon\u00e9r min/max kolonner for alle r\u00e6kker
-  #                                + kontrolgr\u00e6nser_konstante = FALSE per row (TRUE kun
-  #                                  for rent konstante faser, se nedenfor)
-  #
-  # Run charts (ingen lcl/ucl) f\u00e5r ingen kontrolgr\u00e6nse-kolonner overhovedet.
   if ("lcl" %in% names(raw_summary) && "ucl" %in% names(raw_summary)) {
-    # Beregn konstans per fase (brug samme afrundingspr\u00e6cision som eksisterende kode)
+    # +2 afrundingspr\u00e6cision matcher eksisterende kode \u2014 d\u00e6mper float-drift fra qicharts2
     round_prec <- decimal_places + 2
 
-    part_key <- as.character(raw_summary$part)
     lcl_split <- split(qic_data$lcl, qic_data$part)
     ucl_split <- split(qic_data$ucl, qic_data$part)
 

--- a/tests/testthat/test-utils_qic_summary.R
+++ b/tests/testthat/test-utils_qic_summary.R
@@ -129,26 +129,95 @@ test_that("format_qic_summary runder korrekt for rate", {
 # VARIABLE KONTROLGRÆNSER (P/U-CHARTS)
 # =============================================================================
 
-test_that("format_qic_summary inkluderer kontrolgrænser ved konstante grænser", {
+test_that("format_qic_summary inkluderer skalare kontrolgrænser ved konstante grænser", {
   qic_data <- fixture_qicharts_summary_data()
-  # Konstante grænser (I-chart)
+  # Konstante grænser (I-chart) — fixture bruger rep(35, n) og rep(65, n)
   result <- format_qic_summary(qic_data, y_axis_unit = "count")
 
+  # Backward-compat: skalare kolonner til stede
   expect_true("nedre_kontrolgrænse" %in% names(result))
   expect_true("øvre_kontrolgrænse" %in% names(result))
+  # Flag sættes til TRUE
+  expect_true("kontrolgrænser_konstante" %in% names(result))
+  expect_true(all(result$kontrolgrænser_konstante))
+  # Min/max kolonner fraværende ved konstante grænser
+  expect_false("nedre_kontrolgrænse_min" %in% names(result))
+  expect_false("nedre_kontrolgrænse_max" %in% names(result))
+  expect_false("øvre_kontrolgrænse_min" %in% names(result))
+  expect_false("øvre_kontrolgrænse_max" %in% names(result))
 })
 
-test_that("format_qic_summary ekskluderer kontrolgrænser ved variable grænser", {
+test_that("format_qic_summary eksponerer min/max ved variable grænser", {
   qic_data <- fixture_qicharts_summary_data()
-  # Simuler variable grænser (som p/u-charts har)
+  # Simuler variable grænser (som p/u-charts har med varierende nævner)
   qic_data$lcl <- seq(30, 40, length.out = 24)
   qic_data$ucl <- seq(60, 70, length.out = 24)
 
   result <- format_qic_summary(qic_data, y_axis_unit = "percent")
 
-  # Variable grænser skal udelades (misvisende at vise én værdi)
+  # Flag sættes til FALSE
+  expect_true("kontrolgrænser_konstante" %in% names(result))
+  expect_false(any(result$kontrolgrænser_konstante))
+  # Min/max kolonner tilstede
+  expect_true("nedre_kontrolgrænse_min" %in% names(result))
+  expect_true("nedre_kontrolgrænse_max" %in% names(result))
+  expect_true("øvre_kontrolgrænse_min" %in% names(result))
+  expect_true("øvre_kontrolgrænse_max" %in% names(result))
+  # Skalare kolonner fraværende (misvisende at vise én værdi)
   expect_false("nedre_kontrolgrænse" %in% names(result))
   expect_false("øvre_kontrolgrænse" %in% names(result))
+  # Min < max (grænser varierer)
+  expect_lt(result$nedre_kontrolgrænse_min, result$nedre_kontrolgrænse_max)
+  expect_lt(result$øvre_kontrolgrænse_min, result$øvre_kontrolgrænse_max)
+})
+
+test_that("format_qic_summary: variable grænser giver korrekte min/max-værdier", {
+  qic_data <- fixture_qicharts_summary_data()
+  # Sæt præcise grænser for nem verifikation
+  qic_data$lcl <- seq(30, 40, length.out = 24)
+  qic_data$ucl <- seq(60, 70, length.out = 24)
+
+  result <- format_qic_summary(qic_data, y_axis_unit = "percent")
+
+  # Min og max skal svare til de faktiske min/max i data (2 decimaler for percent)
+  expect_equal(result$nedre_kontrolgrænse_min, round(30, 2))
+  expect_equal(result$nedre_kontrolgrænse_max, round(40, 2))
+  expect_equal(result$øvre_kontrolgrænse_min, round(60, 2))
+  expect_equal(result$øvre_kontrolgrænse_max, round(70, 2))
+})
+
+test_that("format_qic_summary: p-chart med konstant n → konstante grænser", {
+  # P-chart med samme nævner giver identiske kontrolgrænser
+  qic_data <- fixture_qicharts_summary_data()
+  # lcl/ucl er allerede konstante i fixture (rep(35,n) og rep(65,n))
+  result <- format_qic_summary(qic_data, y_axis_unit = "percent")
+
+  expect_true(all(result$kontrolgrænser_konstante))
+  expect_true("nedre_kontrolgrænse" %in% names(result))
+  expect_true("øvre_kontrolgrænse" %in% names(result))
+})
+
+test_that("format_qic_summary: multi-fase med variable grænser → flag per row korrekt", {
+  qic_data <- fixture_qicharts_summary_data(n = 24, parts = 2)
+  # Fase 1: konstante grænser; fase 2: variable grænser
+  # Men Option A: global beslutning → mindst én variabel → min/max for alle
+  qic_data$lcl[13:24] <- seq(28, 38, length.out = 12)
+  qic_data$ucl[13:24] <- seq(62, 72, length.out = 12)
+
+  result <- format_qic_summary(qic_data, y_axis_unit = "count")
+
+  expect_equal(nrow(result), 2)
+  # Fase 1 er konstant, fase 2 er variabel
+  expect_true(result$kontrolgrænser_konstante[1])
+  expect_false(result$kontrolgrænser_konstante[2])
+  # Global beslutning: mindst én variabel → min/max kolonner for alle
+  expect_true("nedre_kontrolgrænse_min" %in% names(result))
+  expect_true("nedre_kontrolgrænse_max" %in% names(result))
+  expect_false("nedre_kontrolgrænse" %in% names(result))
+  # Fase 1 (konstant) → min == max
+  expect_equal(result$nedre_kontrolgrænse_min[1], result$nedre_kontrolgrænse_max[1])
+  # Fase 2 (variabel) → min < max
+  expect_lt(result$nedre_kontrolgrænse_min[2], result$nedre_kontrolgrænse_max[2])
 })
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- `format_qic_summary()` droppede stiltiende variable kontrolgrænser (P/U-charts med varierende n)
- Tilføjer `kontrolgrænser_konstante` logisk kolonne per fase
- Konstante grænser: bevarer eksisterende skalare `nedre_kontrolgrænse`/`øvre_kontrolgrænse` (backward compat)
- Variable grænser: tilføjer `nedre_kontrolgrænse_min/max` og `øvre_kontrolgrænse_min/max`

## Test plan
- [x] Backward compat: eksisterende assertions på skalare kolonner for I-charts stadig pass
- [x] P-chart med konstant n → konstante grænser
- [x] P-chart med varierende n → variable grænser, min/max kolonner populated
- [x] `devtools::test()`: 2423 pass, 0 fail

Closes #206