### PR TITLE
refactor(bfh_qic): split monolitisk orchestrator til helpers

### DIFF
--- a/R/create_spc_chart.R
+++ b/R/create_spc_chart.R
@@ -615,12 +615,7 @@ bfh_qic <- function(data,
 
   # ---- Summary + config ----
   summary_result <- format_qic_summary(qic_data, y_axis_unit = y_axis_unit)
-  label_size <- if (!is.null(vp$width_inches) && !is.null(vp$height_inches)) {
-    compute_label_size_for_viewport(vp$width_inches, vp$height_inches)
-  } else {
-    PDF_LABEL_SIZE
-  }
-  config <- list(
+  config <- build_bfh_qic_config(
     chart_type = chart_type,
     chart_title = chart_title,
     y_axis_unit = y_axis_unit,
@@ -633,14 +628,8 @@ bfh_qic <- function(data,
     cl = cl,
     multiply = multiply,
     agg.fun = agg.fun,
-    label_config = list(
-      centerline_value = cl,
-      has_frys_column = !is.null(freeze),
-      has_skift_column = !is.null(part),
-      original_viewport_width = vp$width_inches,
-      original_viewport_height = vp$height_inches,
-      original_label_size = label_size
-    )
+    viewport_width_inches = vp$width_inches,
+    viewport_height_inches = vp$height_inches
   )
 
   # ---- Return-routing ----

--- a/R/create_spc_chart.R
+++ b/R/create_spc_chart.R
@@ -59,6 +59,15 @@ NULL
 #' - Both TRUE: list(data = data.frame, summary = data.frame) (deprecated, will warn)
 #'
 #' @details
+#' **Helper map (interne orkestreringsfunktioner):**
+#' - `validate_bfh_qic_inputs()` — al input-validering (type, bounds, NSE, denominator, target)
+#' - `build_qic_args()` — konstruerer argument-liste til `qicharts2::qic()`
+#' - `invoke_qicharts2()` — kalder `do.call(qicharts2::qic, ...)` + `add_anhoej_signal()`
+#' - `compute_viewport_base_size()` — enhedskonvertering, responsiv `base_size`, label-normalisering
+#' - `render_bfh_plot()` — plot_config + viewport + `bfh_spc_plot()` med warning-suppression
+#' - `apply_spc_labels_to_export()` — label_size-beregning + `add_spc_labels()` med warning-suppression
+#' - `build_bfh_qic_return()` — returværdi-routing (S3 vs. legacy paths)
+#'
 #' **Chart Types:**
 #' - **run**: Run chart (no control limits)
 #' - **i**: I-chart (individuals)
@@ -507,348 +516,110 @@ bfh_qic <- function(data,
                     return.data = FALSE,
                     print.summary = FALSE,
                     language = "da") {
+  # ---- NSE + missing() flags kapteres FOERST i bfh_qic()-scopet ----
+  # substitute(), missing() og parent.frame() er scope-sensitive:
+  # de SKAL evalueres her, ikke inde i helpers.
   agg_fun_supplied <- !missing(agg.fun)
+  base_size_supplied <- !missing(base_size)
+  qic_envir <- parent.frame()
 
+  x_expr <- validate_column_name_expr(substitute(x), "x")
+  y_expr <- validate_column_name_expr(substitute(y), "y")
+  n_expr <- if (!missing(n) && !is.null(substitute(n))) {
+    validate_column_name_expr(substitute(n), "n")
+  } else {
+    NULL
+  }
+
+  # ---- Valider alle inputs (inkl. language) ----
   validate_language(language)
-
-  # Validate inputs
-  if (!is.data.frame(data)) {
-    stop("data must be a data frame")
-  }
-
-  # Validate chart type (CHART_TYPES_EN er single source of truth)
-  if (!chart_type %in% CHART_TYPES_EN) {
-    stop(sprintf(
-      "chart_type must be one of: %s",
-      paste(CHART_TYPES_EN, collapse = ", ")
-    ))
-  }
-
-  # Validate y_axis_unit
-  valid_units <- c("count", "percent", "rate", "time")
-  if (!y_axis_unit %in% valid_units) {
-    stop(sprintf(
-      "y_axis_unit must be one of: %s",
-      paste(valid_units, collapse = ", ")
-    ))
-  }
-
-  # SECURITY: Validate column names are simple identifiers
-  # Prevents NSE injection attacks where malicious code could be passed
-  validate_column_name <- function(col_expr, param_name) {
-    # Understoet baade direkte symboler (month) og quoted symboler (quote(month))
-    # til programmatisk brug via do.call/list-argumenter.
-    normalized_expr <- col_expr
-    if (is.call(col_expr) &&
-      identical(col_expr[[1]], as.name("quote")) &&
-      length(col_expr) == 2) {
-      normalized_expr <- col_expr[[2]]
-    }
-
-    col_str <- deparse(col_expr)
-    # Allow only simple identifiers: letters, numbers, dots, underscores
-    # No parentheses, operators, or function calls
-    valid_pattern <- "^[a-zA-Z][a-zA-Z0-9._]*$"
-    if (!is.symbol(normalized_expr) || !grepl(valid_pattern, as.character(normalized_expr))) {
-      stop(sprintf(
-        "%s must be a simple column name, got: %s\nAvoid special characters, spaces, or expressions",
-        param_name, col_str
-      ), call. = FALSE)
-    }
-
-    as.name(as.character(normalized_expr))
-  }
-
-  # Validate x and y column names
-  x_expr <- validate_column_name(substitute(x), "x")
-  y_expr <- validate_column_name(substitute(y), "y")
-
-  # SECURITY: Validate numeric parameters for bounds and sanity
-  # Prevents DoS attacks via memory exhaustion or crashes
-  # Using centralized validate_numeric_parameter() function to reduce code duplication
-  validate_numeric_parameter(
-    part, "part",
-    min = 1, max = nrow(data),
-    allow_null = TRUE,
-    context = sprintf("1-%d", nrow(data))
-  )
-
-  validate_numeric_parameter(
-    freeze, "freeze",
-    min = 1, max = nrow(data),
-    allow_null = TRUE,
-    context = sprintf("1-%d", nrow(data))
-  )
-
-  validate_numeric_parameter(
-    base_size, "base_size",
-    min = 1, max = 100,
-    allow_null = FALSE,
-    len = 1
-  )
-
-  validate_numeric_parameter(
-    width, "width",
-    min = 0.1, max = 3000, # Allow up to 3000 for pixels (typical: 600-2000px)
-    allow_null = TRUE,
-    len = 1
-  )
-
-  validate_numeric_parameter(
-    height, "height",
-    min = 0.1, max = 3000, # Allow up to 3000 for pixels (typical: 600-2000px)
-    allow_null = TRUE,
-    len = 1
-  )
-
-  validate_numeric_parameter(
-    exclude, "exclude",
-    min = 1, max = nrow(data),
-    allow_null = TRUE,
-    context = sprintf("1-%d", nrow(data))
-  )
-
-  validate_numeric_parameter(
-    cl, "cl",
-    min = -Inf, max = Inf,
-    allow_null = TRUE,
-    len = 1
-  )
-
-  validate_numeric_parameter(
-    multiply, "multiply",
-    min = 0.1, max = 1000,
-    allow_null = FALSE,
-    len = 1
-  )
-
-  # Validate agg.fun parameter (kun naar bruger eksplicit har angivet argumentet)
-  if (agg_fun_supplied) {
-    agg.fun <- match.arg(agg.fun)
-  } else {
-    agg.fun <- NULL
-  }
-
-  # Validate return.data parameter
-  if (!is.logical(return.data) || length(return.data) != 1 || is.na(return.data)) {
-    stop("return.data must be TRUE or FALSE", call. = FALSE)
-  }
-
-  # Validate print.summary parameter
-  if (!is.logical(print.summary) || length(print.summary) != 1 || is.na(print.summary)) {
-    stop("print.summary must be TRUE or FALSE", call. = FALSE)
-  }
-
-  # Validate plot_margin parameter
-  if (!is.null(plot_margin)) {
-    # Check if it's a margin object (from ggplot2::margin())
-    if (inherits(plot_margin, "ggplot2::margin") || inherits(plot_margin, "margin")) {
-      # margin() object - trust that user used it correctly
-      # Note: margin objects are grid::unit objects, cannot be compared with > or <
-    } else if (is.numeric(plot_margin)) {
-      # Numeric vector - validate length and values
-      if (length(plot_margin) != 4) {
-        stop(
-          "plot_margin must be either:\n",
-          "  - A numeric vector of length 4: c(top, right, bottom, left) in mm\n",
-          "  - A margin object: margin(t, r, b, l, unit = '...')",
-          call. = FALSE
-        )
-      }
-      if (any(plot_margin < 0)) {
-        stop("plot_margin values must be non-negative", call. = FALSE)
-      }
-      if (any(plot_margin > 100)) {
-        warning(
-          "plot_margin values > 100mm detected. This may result in very large margins.\n",
-          "Consider using smaller values or checking your input.",
-          call. = FALSE
-        )
-      }
-    } else {
-      stop(
-        "plot_margin must be either:\n",
-        "  - A numeric vector of length 4: c(top, right, bottom, left) in mm\n",
-        "  - A margin object: margin(t, r, b, l, unit = '...')\n",
-        "Got: ", class(plot_margin)[1],
-        call. = FALSE
-      )
-    }
-  }
-
-  # Build qicharts2::qic() arguments using NSE
-  qic_args <- list(
+  agg.fun <- validate_bfh_qic_inputs(
     data = data,
-    x = x_expr,
-    y = y_expr,
-    chart = chart_type,
-    return.data = TRUE
-  )
-
-  # Add optional arguments
-  n_expr <- NULL
-  if (!missing(n) && !is.null(substitute(n))) {
-    n_expr <- validate_column_name(substitute(n), "n")
-    qic_args$n <- n_expr
-  }
-
-  # Validate denominator content for ratio charts (p/pp/u/up).
-  # Catches n <= 0, Inf, non-numeric, missing-but-required n, and
-  # y > n (proportion contract). Other chart types are skipped.
-  validate_denominator_data(
     chart_type = chart_type,
-    data = data,
-    y_col = as.character(y_expr),
-    n_col = if (!is.null(n_expr)) as.character(n_expr) else NULL
+    y_axis_unit = y_axis_unit,
+    part = part,
+    freeze = freeze,
+    base_size = base_size,
+    width = width,
+    height = height,
+    exclude = exclude,
+    cl = cl,
+    multiply = multiply,
+    agg_fun_supplied = agg_fun_supplied,
+    agg.fun = agg.fun,
+    return.data = return.data,
+    print.summary = print.summary,
+    plot_margin = plot_margin,
+    target_value = target_value,
+    y_expr_char = as.character(y_expr),
+    n_expr_char = if (!is.null(n_expr)) as.character(n_expr) else NULL
   )
 
-  if (!is.null(part)) {
-    qic_args$part <- part
-  }
+  # ---- Byg qic_args + kald qicharts2 ----
+  qic_args <- build_qic_args(
+    data = data,
+    x_expr = x_expr,
+    y_expr = y_expr,
+    n_expr = n_expr,
+    chart_type = chart_type,
+    part = part,
+    freeze = freeze,
+    target_value = target_value,
+    notes = notes,
+    exclude = exclude,
+    cl = cl,
+    multiply = multiply,
+    agg.fun = agg.fun,
+    y_axis_unit = y_axis_unit
+  )
+  qic_data <- invoke_qicharts2(qic_args, envir = qic_envir)
 
-  if (!is.null(freeze)) {
-    qic_args$freeze <- freeze
-  }
+  # ---- Viewport + responsiv base_size ----
+  vp <- compute_viewport_base_size(
+    width = width,
+    height = height,
+    units = units,
+    dpi = dpi,
+    base_size = base_size,
+    base_size_supplied = base_size_supplied,
+    xlab = xlab,
+    ylab = ylab
+  )
 
-  if (!is.null(target_value) && is.numeric(target_value)) {
-    validate_target_for_unit(target_value, y_axis_unit, multiply)
-    qic_args$target <- target_value
-  }
-
-  if (!is.null(notes)) {
-    qic_args$notes <- notes
-  }
-
-  if (!is.null(exclude)) {
-    qic_args$exclude <- exclude
-  }
-
-  if (!is.null(cl)) {
-    qic_args$cl <- cl
-  }
-
-  if (!is.null(multiply) && multiply != 1) {
-    qic_args$multiply <- multiply
-  }
-
-  if (agg_fun_supplied) {
-    qic_args$agg.fun <- agg.fun
-  }
-
-  # Map y_axis_unit to qicharts2's y.percent parameter
-  # This enables percentage formatting (75% instead of 0.75) for compatible chart types
-  if (!is.null(y_axis_unit) && y_axis_unit == "percent") {
-    qic_args$y.percent <- TRUE
-  }
-
-  # Execute qicharts2::qic() to get calculation results
-  qic_data <- do.call(qicharts2::qic, qic_args, envir = parent.frame())
-
-  # Post-process: Normaliser anhoej.signal via dedikeret helper
-  qic_data <- add_anhoej_signal(qic_data)
-
-  # Convert width/height to inches using unit conversion
-  # Supports cm, mm, in, px with smart auto-detection
-  if (!is.null(width) && !is.null(height)) {
-    conversion_result <- convert_to_inches(width, height, units, dpi)
-    width_inches <- conversion_result$width_inches
-    height_inches <- conversion_result$height_inches
-  } else {
-    width_inches <- NULL
-    height_inches <- NULL
-  }
-
-  # Calculate responsive base_size if viewport dimensions provided
-  # Uses geometric mean approach: sqrt(width x height) / divisor
-  if (!is.null(width_inches) && !is.null(height_inches)) {
-    calculated_base_size <- calculate_base_size(width_inches, height_inches)
-    # Use calculated size unless user explicitly provided base_size
-    if (missing(base_size)) {
-      base_size <- calculated_base_size
-    }
-  }
-
-  # Normalize blank axis labels to NULL for robust downstream theming
-  if (is.character(xlab) && length(xlab) == 1 && nchar(trimws(xlab)) == 0) {
-    xlab <- NULL
-  }
-  if (is.character(ylab) && length(ylab) == 1 && nchar(trimws(ylab)) == 0) {
-    ylab <- NULL
-  }
-
-  # Create plot configuration
-  plot_config <- spc_plot_config(
+  # ---- Render plot ----
+  plot <- render_bfh_plot(
+    qic_data = qic_data,
     chart_type = chart_type,
     y_axis_unit = y_axis_unit,
     chart_title = chart_title,
     target_value = target_value,
     target_text = target_text,
-    ylab = ylab,
-    xlab = xlab,
+    ylab = vp$ylab,
+    xlab = vp$xlab,
     subtitle = subtitle,
-    caption = caption
+    caption = caption,
+    base_size = vp$base_size,
+    plot_margin = plot_margin
   )
 
-  # Create viewport configuration
-  viewport <- viewport_dims(base_size = base_size)
-
-  # Generate plot using bfh_spc_plot()
-  # Undertryk harmloese warnings: ggplot2 datetime-scale + BFHtheme proprietaer
-  # font (Mari) ikke i PostScript-database - begge er expected behavior.
-  plot <- withCallingHandlers(
-    bfh_spc_plot(
-      qic_data = qic_data,
-      plot_config = plot_config,
-      viewport = viewport,
-      plot_margin = plot_margin
-    ),
-    warning = function(w) {
-      if (grepl("numeric|datetime|scale_[xy]_date|PostScript font database", conditionMessage(w), ignore.case = TRUE)) {
-        invokeRestart("muffleWarning")
-      }
-    }
+  # ---- Tilfoej SPC labels ----
+  plot <- apply_spc_labels_to_export(
+    plot = plot,
+    qic_data = qic_data,
+    y_axis_unit = y_axis_unit,
+    viewport_width_inches = vp$width_inches,
+    viewport_height_inches = vp$height_inches,
+    target_text = target_text,
+    language = language
   )
 
-  # Use converted dimensions for viewport
-  # This enables precise label placement even without open graphics device
-  viewport_width_inches <- width_inches
-  viewport_height_inches <- height_inches
-
-  # Responsive label sizing forankret til PDF golden standard
-  if (!is.null(viewport_width_inches) && !is.null(viewport_height_inches)) {
-    label_size <- compute_label_size_for_viewport(
-      viewport_width_inches, viewport_height_inches
-    )
-  } else {
-    label_size <- PDF_LABEL_SIZE
-  }
-
-  # BFHtheme bruger proprietaere fonts (Mari) ikke tilgaengelige i alle miljoeer.
-  # ggplot_gtable under label placement emitter "font family not found in
-  # PostScript font database" pr. tekstelement - expected behavior, ikke fejl.
-  plot <- withCallingHandlers(
-    add_spc_labels(
-      plot = plot,
-      qic_data = qic_data,
-      y_axis_unit = y_axis_unit,
-      label_size = label_size,
-      viewport_width = viewport_width_inches,
-      viewport_height = viewport_height_inches,
-      target_text = target_text,
-      verbose = FALSE,
-      language = language
-    ),
-    warning = function(w) {
-      if (grepl("PostScript font database", conditionMessage(w), fixed = TRUE)) {
-        invokeRestart("muffleWarning")
-      }
-    }
-  )
-
-  # Always generate summary for inclusion in result object
+  # ---- Summary + config ----
   summary_result <- format_qic_summary(qic_data, y_axis_unit = y_axis_unit)
-
-  # Build config object with original parameters
+  label_size <- if (!is.null(vp$width_inches) && !is.null(vp$height_inches)) {
+    compute_label_size_for_viewport(vp$width_inches, vp$height_inches)
+  } else {
+    PDF_LABEL_SIZE
+  }
   config <- list(
     chart_type = chart_type,
     chart_title = chart_title,
@@ -862,18 +633,17 @@ bfh_qic <- function(data,
     cl = cl,
     multiply = multiply,
     agg.fun = agg.fun,
-    # Label placement metadata for PDF export recalculation
     label_config = list(
       centerline_value = cl,
       has_frys_column = !is.null(freeze),
       has_skift_column = !is.null(part),
-      original_viewport_width = width_inches,
-      original_viewport_height = height_inches,
+      original_viewport_width = vp$width_inches,
+      original_viewport_height = vp$height_inches,
       original_label_size = label_size
     )
   )
 
-  # Return-routing via dedikeret helper (inkl. legacy warnings)
+  # ---- Return-routing ----
   build_bfh_qic_return(
     qic_data = qic_data,
     plot = plot,

--- a/R/utils_bfh_qic_helpers.R
+++ b/R/utils_bfh_qic_helpers.R
@@ -2,7 +2,7 @@
 # INTERNE HELPERS TIL bfh_qic()
 # ============================================================================
 # Disse helpers isolerer Anhoej signal-postprocessering og return-routing
-# fra bfh_qic()-kroppen. Se openspec/changes/refactor-extract-bfh-qic-helpers.
+# fra bfh_qic()-kroppen. Se openspec/changes/refactor-bfh_qic-orchestrator.
 
 #' Normaliser anhoej.signal i qic_data
 #'
@@ -95,4 +95,463 @@ build_bfh_qic_return <- function(qic_data, plot, summary_result, config,
       )
     )
   }
+}
+
+# ============================================================================
+# NSE KOLONNE-NAVN VALIDATOR
+# ============================================================================
+
+#' Validér og normaliser et NSE kolonne-udtryk til et symbol
+#'
+#' Tager et allerede fanget udtryk (fra `substitute()` i bfh_qic()-scopet)
+#' og validerer at det er et simpelt identifier. Understøtter direkte symboler
+#' (month) og quoted symboler (quote(month)) til programmatisk brug.
+#'
+#' Denne funktion kalder IKKE selv `substitute()` — det SKAL ske i bfh_qic().
+#'
+#' @param col_expr Et R-udtryk fanget via substitute() i bfh_qic()
+#' @param param_name Parameternavn til fejlbesked
+#' @return as.name() symbol klar til NSE-videregivelse
+#' @keywords internal
+#' @noRd
+validate_column_name_expr <- function(col_expr, param_name) {
+  normalized_expr <- col_expr
+  if (is.call(col_expr) &&
+    identical(col_expr[[1]], as.name("quote")) &&
+    length(col_expr) == 2) {
+    normalized_expr <- col_expr[[2]]
+  }
+  col_str <- deparse(col_expr)
+  valid_pattern <- "^[a-zA-Z][a-zA-Z0-9._]*$"
+  if (!is.symbol(normalized_expr) || !grepl(valid_pattern, as.character(normalized_expr))) {
+    stop(sprintf(
+      "%s must be a simple column name, got: %s\nAvoid special characters, spaces, or expressions",
+      param_name, col_str
+    ), call. = FALSE)
+  }
+  as.name(as.character(normalized_expr))
+}
+
+# ============================================================================
+# VALIDER bfh_qic() INPUTS
+# ============================================================================
+
+#' Valider inputs til bfh_qic()
+#'
+#' Konsoliderer alle input-valideringer fra bfh_qic()-kroppen i en enkelt
+#' funktion. NSE-udtryk (x_expr, y_expr, n_expr) skal vaere fanget i
+#' bfh_qic() via substitute() FØR dette kald — aldrig inde i denne helper.
+#'
+#' @param data Data frame med maalinger
+#' @param chart_type Charttype-streng
+#' @param y_axis_unit Y-akse enhed
+#' @param x_expr Symbol for x-kolonne (allerede valideret via validate_column_name)
+#' @param y_expr Symbol for y-kolonne (allerede valideret via validate_column_name)
+#' @param n_expr Symbol for n-kolonne eller NULL
+#' @param part Vektor af fase-positioner eller NULL
+#' @param freeze Freeze-position eller NULL
+#' @param base_size Basisskriftstørrelse
+#' @param width Plotbredde eller NULL
+#' @param height Plothøjde eller NULL
+#' @param exclude Ekskluderingspositioner eller NULL
+#' @param cl Brugerdefineret centerlinje eller NULL
+#' @param multiply Multiplikator
+#' @param agg_fun_supplied Logical — om agg.fun er eksplicit angivet af bruger
+#' @param agg.fun Aggregeringsfunktionsstreng
+#' @param return.data Logical
+#' @param print.summary Logical
+#' @param plot_margin Margin-objekt eller numerisk vektor
+#' @param target_value Numerisk maalvaerdi eller NULL
+#' @param y_expr_char Karakterstreng af y-kolonnenavnet (til denominator-validering)
+#' @param n_expr_char Karakterstreng af n-kolonnenavnet eller NULL
+#' @return Normaliseret `agg.fun`-vaerdi (NULL hvis ikke angivet, ellers matchet streng)
+#' @keywords internal
+#' @noRd
+validate_bfh_qic_inputs <- function(data,
+                                    chart_type,
+                                    y_axis_unit,
+                                    part,
+                                    freeze,
+                                    base_size,
+                                    width,
+                                    height,
+                                    exclude,
+                                    cl,
+                                    multiply,
+                                    agg_fun_supplied,
+                                    agg.fun,
+                                    return.data,
+                                    print.summary,
+                                    plot_margin,
+                                    target_value,
+                                    y_expr_char,
+                                    n_expr_char) {
+  if (!is.data.frame(data)) {
+    stop("data must be a data frame")
+  }
+
+  if (!chart_type %in% CHART_TYPES_EN) {
+    stop(sprintf(
+      "chart_type must be one of: %s",
+      paste(CHART_TYPES_EN, collapse = ", ")
+    ))
+  }
+
+  valid_units <- c("count", "percent", "rate", "time")
+  if (!y_axis_unit %in% valid_units) {
+    stop(sprintf(
+      "y_axis_unit must be one of: %s",
+      paste(valid_units, collapse = ", ")
+    ))
+  }
+
+  validate_numeric_parameter(part, "part",
+    min = 1, max = nrow(data),
+    allow_null = TRUE, context = sprintf("1-%d", nrow(data))
+  )
+  validate_numeric_parameter(freeze, "freeze",
+    min = 1, max = nrow(data),
+    allow_null = TRUE, context = sprintf("1-%d", nrow(data))
+  )
+  validate_numeric_parameter(base_size, "base_size",
+    min = 1, max = 100,
+    allow_null = FALSE, len = 1
+  )
+  validate_numeric_parameter(width, "width",
+    min = 0.1, max = 3000,
+    allow_null = TRUE, len = 1
+  )
+  validate_numeric_parameter(height, "height",
+    min = 0.1, max = 3000,
+    allow_null = TRUE, len = 1
+  )
+  validate_numeric_parameter(exclude, "exclude",
+    min = 1, max = nrow(data),
+    allow_null = TRUE, context = sprintf("1-%d", nrow(data))
+  )
+  validate_numeric_parameter(cl, "cl",
+    min = -Inf, max = Inf,
+    allow_null = TRUE, len = 1
+  )
+  validate_numeric_parameter(multiply, "multiply",
+    min = 0.1, max = 1000,
+    allow_null = FALSE, len = 1
+  )
+
+  # Normaliser agg.fun kun naar eksplicit angivet
+  agg_fun_out <- if (agg_fun_supplied) match.arg(agg.fun, c("mean", "median", "sum", "sd")) else NULL
+
+  if (!is.logical(return.data) || length(return.data) != 1 || is.na(return.data)) {
+    stop("return.data must be TRUE or FALSE", call. = FALSE)
+  }
+  if (!is.logical(print.summary) || length(print.summary) != 1 || is.na(print.summary)) {
+    stop("print.summary must be TRUE or FALSE", call. = FALSE)
+  }
+
+  if (!is.null(plot_margin)) {
+    if (inherits(plot_margin, "ggplot2::margin") || inherits(plot_margin, "margin")) {
+      # margin()-objekt — trust brugerens input
+    } else if (is.numeric(plot_margin)) {
+      if (length(plot_margin) != 4) {
+        stop(
+          "plot_margin must be either:\n",
+          "  - A numeric vector of length 4: c(top, right, bottom, left) in mm\n",
+          "  - A margin object: margin(t, r, b, l, unit = '...')",
+          call. = FALSE
+        )
+      }
+      if (any(plot_margin < 0)) {
+        stop("plot_margin values must be non-negative", call. = FALSE)
+      }
+      if (any(plot_margin > 100)) {
+        warning(
+          "plot_margin values > 100mm detected. This may result in very large margins.\n",
+          "Consider using smaller values or checking your input.",
+          call. = FALSE
+        )
+      }
+    } else {
+      stop(
+        "plot_margin must be either:\n",
+        "  - A numeric vector of length 4: c(top, right, bottom, left) in mm\n",
+        "  - A margin object: margin(t, r, b, l, unit = '...')\n",
+        "Got: ", class(plot_margin)[1],
+        call. = FALSE
+      )
+    }
+  }
+
+  validate_denominator_data(
+    chart_type = chart_type,
+    data = data,
+    y_col = y_expr_char,
+    n_col = n_expr_char
+  )
+
+  if (!is.null(target_value) && is.numeric(target_value)) {
+    validate_target_for_unit(target_value, y_axis_unit, multiply)
+  }
+
+  invisible(agg_fun_out)
+}
+
+# ============================================================================
+# BYGG qic_args LIST
+# ============================================================================
+
+#' Byg argument-liste til qicharts2::qic()
+#'
+#' Konstruerer den komplette `qic_args`-liste der sendes til
+#' `do.call(qicharts2::qic, ...)`. NSE-symboler skal vaere fanget i
+#' bfh_qic() FØR dette kald.
+#'
+#' @param data Data frame
+#' @param x_expr Symbol for x-kolonne
+#' @param y_expr Symbol for y-kolonne
+#' @param n_expr Symbol for n-kolonne eller NULL
+#' @param chart_type Charttype-streng
+#' @param part Fase-positioner eller NULL
+#' @param freeze Freeze-position eller NULL
+#' @param target_value Maalvaerdi eller NULL
+#' @param notes Notats-vektor eller NULL
+#' @param exclude Ekskluderingspositioner eller NULL
+#' @param cl Brugerdefineret centerlinje eller NULL
+#' @param multiply Multiplikator
+#' @param agg.fun Normaliseret aggregeringsfunktionsstreng eller NULL
+#' @param y_axis_unit Y-akse enhed (benyttes til y.percent-flag)
+#' @return Liste klar til do.call(qicharts2::qic, .)
+#' @keywords internal
+#' @noRd
+build_qic_args <- function(data,
+                           x_expr,
+                           y_expr,
+                           n_expr,
+                           chart_type,
+                           part,
+                           freeze,
+                           target_value,
+                           notes,
+                           exclude,
+                           cl,
+                           multiply,
+                           agg.fun,
+                           y_axis_unit) {
+  qic_args <- list(
+    data = data,
+    x = x_expr,
+    y = y_expr,
+    chart = chart_type,
+    return.data = TRUE
+  )
+
+  if (!is.null(n_expr)) qic_args$n <- n_expr
+  if (!is.null(part)) qic_args$part <- part
+  if (!is.null(freeze)) qic_args$freeze <- freeze
+  if (!is.null(target_value) && is.numeric(target_value)) qic_args$target <- target_value
+  if (!is.null(notes)) qic_args$notes <- notes
+  if (!is.null(exclude)) qic_args$exclude <- exclude
+  if (!is.null(cl)) qic_args$cl <- cl
+  if (!is.null(multiply) && multiply != 1) qic_args$multiply <- multiply
+  if (!is.null(agg.fun)) qic_args$agg.fun <- agg.fun
+  if (identical(y_axis_unit, "percent")) qic_args$y.percent <- TRUE
+
+  qic_args
+}
+
+# ============================================================================
+# KALD qicharts2 + ANHØJ POST-PROCESSING
+# ============================================================================
+
+#' Kald qicharts2::qic() og normaliser Anhøj-signal
+#'
+#' Wrapper om `do.call(qicharts2::qic, qic_args)` efterfulgt af
+#' `add_anhoej_signal()`. `envir` skal vaere `parent.frame()` evalueret i
+#' bfh_qic()-scopet — aldrig i denne helpers scope.
+#'
+#' @param qic_args Liste af argumenter til qicharts2::qic()
+#' @param envir Environment hvori qic_args evalueres (typisk bfh_qic()'s parent.frame)
+#' @return data.frame med raa qic-beregninger + normaliseret anhoej.signal
+#' @keywords internal
+#' @noRd
+invoke_qicharts2 <- function(qic_args, envir) {
+  qic_data <- do.call(qicharts2::qic, qic_args, envir = envir)
+  add_anhoej_signal(qic_data)
+}
+
+# ============================================================================
+# VIEWPORT OG BASE_SIZE BEREGNING
+# ============================================================================
+
+#' Konverter viewport-dimensioner og beregn responsiv base_size
+#'
+#' Haandterer hele viewport-pipeline: enhedskonvertering (cm/mm/px/in),
+#' responsiv base_size-beregning og normalisering af tomme akse-labels.
+#'
+#' @param width Plotbredde (raa bruger-input, NULL eller numerisk)
+#' @param height Plothøjde (raa bruger-input, NULL eller numerisk)
+#' @param units Enhedstype eller NULL (smart auto-detection)
+#' @param dpi DPI til pixel-konvertering
+#' @param base_size Eksplicit base_size fra bruger
+#' @param base_size_supplied Logical — om bruger eksplicit angav base_size
+#' @param xlab X-akse label (streng)
+#' @param ylab Y-akse label (streng)
+#' @return Liste: width_inches, height_inches, base_size, xlab, ylab
+#' @keywords internal
+#' @noRd
+compute_viewport_base_size <- function(width,
+                                       height,
+                                       units,
+                                       dpi,
+                                       base_size,
+                                       base_size_supplied,
+                                       xlab,
+                                       ylab) {
+  # Enhedskonvertering
+  if (!is.null(width) && !is.null(height)) {
+    conv <- convert_to_inches(width, height, units, dpi)
+    width_inches <- conv$width_inches
+    height_inches <- conv$height_inches
+  } else {
+    width_inches <- NULL
+    height_inches <- NULL
+  }
+
+  # Responsiv base_size naar viewport kendes og bruger ikke eksplicit satte vaerdi
+  if (!is.null(width_inches) && !is.null(height_inches) && !base_size_supplied) {
+    base_size <- calculate_base_size(width_inches, height_inches)
+  }
+
+  # Normaliser tomme akse-labels til NULL for robust downstream theming
+  if (is.character(xlab) && length(xlab) == 1 && nchar(trimws(xlab)) == 0) xlab <- NULL
+  if (is.character(ylab) && length(ylab) == 1 && nchar(trimws(ylab)) == 0) ylab <- NULL
+
+  list(
+    width_inches = width_inches,
+    height_inches = height_inches,
+    base_size = base_size,
+    xlab = xlab,
+    ylab = ylab
+  )
+}
+
+# ============================================================================
+# RENDER PLOT
+# ============================================================================
+
+#' Opret BFH SPC-plot fra qic_data
+#'
+#' Bygger plot_config + viewport og kalder bfh_spc_plot() med warning-
+#' suppression for kendte ufarlige warnings (datetime-scale, PostScript font).
+#'
+#' @param qic_data data.frame fra invoke_qicharts2()
+#' @param chart_type Charttype-streng
+#' @param y_axis_unit Y-akse enhed
+#' @param chart_title Plottitel eller NULL
+#' @param target_value Maalvaerdi eller NULL
+#' @param target_text Maaltekst eller NULL
+#' @param ylab Y-akse label eller NULL
+#' @param xlab X-akse label eller NULL
+#' @param subtitle Undertitel eller NULL
+#' @param caption Billedtekst eller NULL
+#' @param base_size Basisskriftstørrelse
+#' @param plot_margin Margin-objekt eller NULL
+#' @return ggplot2-objekt
+#' @keywords internal
+#' @noRd
+render_bfh_plot <- function(qic_data,
+                            chart_type,
+                            y_axis_unit,
+                            chart_title,
+                            target_value,
+                            target_text,
+                            ylab,
+                            xlab,
+                            subtitle,
+                            caption,
+                            base_size,
+                            plot_margin) {
+  plot_config <- spc_plot_config(
+    chart_type = chart_type,
+    y_axis_unit = y_axis_unit,
+    chart_title = chart_title,
+    target_value = target_value,
+    target_text = target_text,
+    ylab = ylab,
+    xlab = xlab,
+    subtitle = subtitle,
+    caption = caption
+  )
+
+  viewport <- viewport_dims(base_size = base_size)
+
+  withCallingHandlers(
+    bfh_spc_plot(
+      qic_data = qic_data,
+      plot_config = plot_config,
+      viewport = viewport,
+      plot_margin = plot_margin
+    ),
+    warning = function(w) {
+      if (grepl("numeric|datetime|scale_[xy]_date|PostScript font database",
+        conditionMessage(w),
+        ignore.case = TRUE
+      )) {
+        invokeRestart("muffleWarning")
+      }
+    }
+  )
+}
+
+# ============================================================================
+# TILFØJ SPC LABELS TIL EXPORT
+# ============================================================================
+
+#' Tilføj SPC-labels til plot med viewport-skaleret labelstørrelse
+#'
+#' Beregner responsiv label_size baseret paa viewport-dimensioner og
+#' kalder add_spc_labels() med PostScript font warning-suppression.
+#'
+#' @param plot ggplot2-objekt fra render_bfh_plot()
+#' @param qic_data data.frame fra invoke_qicharts2()
+#' @param y_axis_unit Y-akse enhed
+#' @param viewport_width_inches Plotbredde i inches eller NULL
+#' @param viewport_height_inches Plothøjde i inches eller NULL
+#' @param target_text Maaltekst eller NULL
+#' @param language Sprogkode ("da" eller "en")
+#' @return ggplot2-objekt med labels tilføjet
+#' @keywords internal
+#' @noRd
+apply_spc_labels_to_export <- function(plot,
+                                       qic_data,
+                                       y_axis_unit,
+                                       viewport_width_inches,
+                                       viewport_height_inches,
+                                       target_text,
+                                       language) {
+  if (!is.null(viewport_width_inches) && !is.null(viewport_height_inches)) {
+    label_size <- compute_label_size_for_viewport(
+      viewport_width_inches, viewport_height_inches
+    )
+  } else {
+    label_size <- PDF_LABEL_SIZE
+  }
+
+  withCallingHandlers(
+    add_spc_labels(
+      plot = plot,
+      qic_data = qic_data,
+      y_axis_unit = y_axis_unit,
+      label_size = label_size,
+      viewport_width = viewport_width_inches,
+      viewport_height = viewport_height_inches,
+      target_text = target_text,
+      verbose = FALSE,
+      language = language
+    ),
+    warning = function(w) {
+      if (grepl("PostScript font database", conditionMessage(w), fixed = TRUE)) {
+        invokeRestart("muffleWarning")
+      }
+    }
+  )
 }

--- a/R/utils_bfh_qic_helpers.R
+++ b/R/utils_bfh_qic_helpers.R
@@ -555,3 +555,73 @@ apply_spc_labels_to_export <- function(plot,
     }
   )
 }
+
+# ============================================================================
+# BYGG KONFIGURATIONSLISTE
+# ============================================================================
+
+#' Byg bfh_qic() konfigurationsliste
+#'
+#' Samler chart-parametre og label-konfiguration til et enkelt config-objekt
+#' der returneres som del af bfh_qic()-output.
+#'
+#' @param chart_type Charttype-streng
+#' @param chart_title Plottitel eller NULL
+#' @param y_axis_unit Y-akse enhed
+#' @param language Sprogkode
+#' @param target_value Maalvaerdi eller NULL
+#' @param target_text Maaltekst eller NULL
+#' @param part Fase-positioner eller NULL
+#' @param freeze Freeze-position eller NULL
+#' @param exclude Ekskluderingspositioner eller NULL
+#' @param cl Brugerdefineret centerlinje eller NULL
+#' @param multiply Multiplikator
+#' @param agg.fun Normaliseret aggregeringsfunktionsstreng eller NULL
+#' @param viewport_width_inches Plotbredde i inches eller NULL
+#' @param viewport_height_inches Plothøjde i inches eller NULL
+#' @return Liste med chart-konfiguration inkl. label_config
+#' @keywords internal
+#' @noRd
+build_bfh_qic_config <- function(chart_type,
+                                 chart_title,
+                                 y_axis_unit,
+                                 language,
+                                 target_value,
+                                 target_text,
+                                 part,
+                                 freeze,
+                                 exclude,
+                                 cl,
+                                 multiply,
+                                 agg.fun,
+                                 viewport_width_inches,
+                                 viewport_height_inches) {
+  label_size <- if (!is.null(viewport_width_inches) && !is.null(viewport_height_inches)) {
+    compute_label_size_for_viewport(viewport_width_inches, viewport_height_inches)
+  } else {
+    PDF_LABEL_SIZE
+  }
+
+  list(
+    chart_type = chart_type,
+    chart_title = chart_title,
+    y_axis_unit = y_axis_unit,
+    language = language,
+    target_value = target_value,
+    target_text = target_text,
+    part = part,
+    freeze = freeze,
+    exclude = exclude,
+    cl = cl,
+    multiply = multiply,
+    agg.fun = agg.fun,
+    label_config = list(
+      centerline_value = cl,
+      has_frys_column = !is.null(freeze),
+      has_skift_column = !is.null(part),
+      original_viewport_width = viewport_width_inches,
+      original_viewport_height = viewport_height_inches,
+      original_label_size = label_size
+    )
+  )
+}

--- a/man/bfh_qic.Rd
+++ b/man/bfh_qic.Rd
@@ -118,6 +118,17 @@ BFH-styled visualization and automatic label placement. Handles the
 entire workflow from raw data to finished plot with intelligent labels.
 }
 \details{
+\strong{Helper map (interne orkestreringsfunktioner):}
+\itemize{
+\item \code{validate_bfh_qic_inputs()} — al input-validering (type, bounds, NSE, denominator, target)
+\item \code{build_qic_args()} — konstruerer argument-liste til \code{qicharts2::qic()}
+\item \code{invoke_qicharts2()} — kalder \code{do.call(qicharts2::qic, ...)} + \code{add_anhoej_signal()}
+\item \code{compute_viewport_base_size()} — enhedskonvertering, responsiv \code{base_size}, label-normalisering
+\item \code{render_bfh_plot()} — plot_config + viewport + \code{bfh_spc_plot()} med warning-suppression
+\item \code{apply_spc_labels_to_export()} — label_size-beregning + \code{add_spc_labels()} med warning-suppression
+\item \code{build_bfh_qic_return()} — returværdi-routing (S3 vs. legacy paths)
+}
+
 \strong{Chart Types:}
 \itemize{
 \item \strong{run}: Run chart (no control limits)

--- a/tests/testthat/test-bfh_qic_helpers.R
+++ b/tests/testthat/test-bfh_qic_helpers.R
@@ -452,9 +452,8 @@ test_that("compute_viewport_base_size beregner responsiv base_size naar ikke ang
   )
   # base_size bør vaere beregnet via calculate_base_size() — og afvige fra default 14
   expect_false(is.null(result$base_size))
-  # Resultatet er calculate_base_size(10, 6) — kontrollér at det adskiller sig fra det
-  # user-angivne default (14) og er numerisk
-  expect_false(identical(result$base_size, 14))
+  # calculate_base_size(10, 6) er deterministisk — forvent eksakt vaerdi
+  expect_equal(result$base_size, calculate_base_size(10, 6))
   expect_true(is.numeric(result$base_size))
 })
 
@@ -488,4 +487,78 @@ test_that("compute_viewport_base_size bevarer ikke-tomme akse-labels", {
   )
   expect_equal(result$xlab, "Maaned")
   expect_equal(result$ylab, "Antal")
+})
+
+# ============================================================================
+# build_bfh_qic_config()
+# ============================================================================
+
+call_config <- function(chart_type = "i",
+                        chart_title = NULL,
+                        y_axis_unit = "count",
+                        language = "da",
+                        target_value = NULL,
+                        target_text = NULL,
+                        part = NULL,
+                        freeze = NULL,
+                        exclude = NULL,
+                        cl = NULL,
+                        multiply = 1,
+                        agg.fun = NULL,
+                        viewport_width_inches = NULL,
+                        viewport_height_inches = NULL) {
+  build_bfh_qic_config(
+    chart_type = chart_type,
+    chart_title = chart_title,
+    y_axis_unit = y_axis_unit,
+    language = language,
+    target_value = target_value,
+    target_text = target_text,
+    part = part,
+    freeze = freeze,
+    exclude = exclude,
+    cl = cl,
+    multiply = multiply,
+    agg.fun = agg.fun,
+    viewport_width_inches = viewport_width_inches,
+    viewport_height_inches = viewport_height_inches
+  )
+}
+
+test_that("build_bfh_qic_config returnerer liste med korrekte topniveaufelter", {
+  result <- call_config()
+  expect_type(result, "list")
+  expect_true("chart_type" %in% names(result))
+  expect_true("y_axis_unit" %in% names(result))
+  expect_true("label_config" %in% names(result))
+})
+
+test_that("build_bfh_qic_config label_config har korrekte underfelter", {
+  result <- call_config()
+  lc <- result$label_config
+  expect_true("centerline_value" %in% names(lc))
+  expect_true("has_frys_column" %in% names(lc))
+  expect_true("has_skift_column" %in% names(lc))
+  expect_true("original_label_size" %in% names(lc))
+})
+
+test_that("build_bfh_qic_config has_frys_column er TRUE naar freeze angivet", {
+  result <- call_config(freeze = 6L)
+  expect_true(result$label_config$has_frys_column)
+})
+
+test_that("build_bfh_qic_config has_skift_column er TRUE naar part angivet", {
+  result <- call_config(part = 5L)
+  expect_true(result$label_config$has_skift_column)
+})
+
+test_that("build_bfh_qic_config bruger PDF_LABEL_SIZE naar viewport er NULL", {
+  result <- call_config(viewport_width_inches = NULL, viewport_height_inches = NULL)
+  expect_equal(result$label_config$original_label_size, BFHcharts:::PDF_LABEL_SIZE)
+})
+
+test_that("build_bfh_qic_config beregner label_size naar viewport kendes", {
+  result <- call_config(viewport_width_inches = 10, viewport_height_inches = 6)
+  expected <- compute_label_size_for_viewport(10, 6)
+  expect_equal(result$label_config$original_label_size, expected)
 })

--- a/tests/testthat/test-bfh_qic_helpers.R
+++ b/tests/testthat/test-bfh_qic_helpers.R
@@ -1,8 +1,9 @@
 # ============================================================================
 # TESTS FOR INTERNE bfh_qic() HELPERS
 # ============================================================================
-# Tests for add_anhoej_signal() og build_bfh_qic_return()
-# openspec: refactor-extract-bfh-qic-helpers
+# Tests for add_anhoej_signal(), build_bfh_qic_return(),
+# validate_bfh_qic_inputs(), build_qic_args(), compute_viewport_base_size()
+# openspec: refactor-bfh_qic-orchestrator
 
 # ============================================================================
 # add_anhoej_signal()
@@ -221,4 +222,270 @@ test_that("build_bfh_qic_return udsender ingen warnings ved default", {
       print.summary = FALSE
     )
   )
+})
+
+# ============================================================================
+# validate_bfh_qic_inputs()
+# ============================================================================
+
+# Hjælper til at kalde validate_bfh_qic_inputs med gyldige defaults
+# Brug explicit named args frem for modifyList (undgaar modifyList's rekursive merge af data.frame)
+call_validate <- function(data = data.frame(x = 1:10, y = 1:10),
+                          chart_type = "i",
+                          y_axis_unit = "count",
+                          part = NULL,
+                          freeze = NULL,
+                          base_size = 14,
+                          width = NULL,
+                          height = NULL,
+                          exclude = NULL,
+                          cl = NULL,
+                          multiply = 1,
+                          agg_fun_supplied = FALSE,
+                          agg.fun = "mean",
+                          return.data = FALSE,
+                          print.summary = FALSE,
+                          plot_margin = NULL,
+                          target_value = NULL,
+                          y_expr_char = "y",
+                          n_expr_char = NULL) {
+  validate_bfh_qic_inputs(
+    data = data,
+    chart_type = chart_type,
+    y_axis_unit = y_axis_unit,
+    part = part,
+    freeze = freeze,
+    base_size = base_size,
+    width = width,
+    height = height,
+    exclude = exclude,
+    cl = cl,
+    multiply = multiply,
+    agg_fun_supplied = agg_fun_supplied,
+    agg.fun = agg.fun,
+    return.data = return.data,
+    print.summary = print.summary,
+    plot_margin = plot_margin,
+    target_value = target_value,
+    y_expr_char = y_expr_char,
+    n_expr_char = n_expr_char
+  )
+}
+
+test_that("validate_bfh_qic_inputs accepterer gyldige defaults uden fejl", {
+  expect_no_error(call_validate())
+})
+
+test_that("validate_bfh_qic_inputs fejler naar data ikke er data.frame", {
+  expect_error(call_validate(data = list(x = 1:5, y = 1:5)), "data must be a data frame")
+})
+
+test_that("validate_bfh_qic_inputs fejler ved ugyldig chart_type", {
+  expect_error(call_validate(chart_type = "xyz"), "chart_type must be one of")
+})
+
+test_that("validate_bfh_qic_inputs fejler ved ugyldig y_axis_unit", {
+  expect_error(call_validate(y_axis_unit = "liters"), "y_axis_unit must be one of")
+})
+
+test_that("validate_bfh_qic_inputs returnerer NULL naar agg_fun ikke er angivet", {
+  result <- call_validate(agg_fun_supplied = FALSE)
+  expect_null(result)
+})
+
+test_that("validate_bfh_qic_inputs returnerer normaliseret agg.fun naar angivet", {
+  result <- call_validate(agg_fun_supplied = TRUE, agg.fun = "median")
+  expect_equal(result, "median")
+})
+
+test_that("validate_bfh_qic_inputs fejler ved ugyldig return.data", {
+  expect_error(call_validate(return.data = "ja"), "return.data must be TRUE or FALSE")
+})
+
+test_that("validate_bfh_qic_inputs fejler ved ugyldig print.summary", {
+  expect_error(call_validate(print.summary = NA), "print.summary must be TRUE or FALSE")
+})
+
+test_that("validate_bfh_qic_inputs fejler ved plot_margin med forkert laengde", {
+  expect_error(call_validate(plot_margin = c(1, 2, 3)), "numeric vector of length 4")
+})
+
+test_that("validate_bfh_qic_inputs accepterer margin()-objekt som plot_margin", {
+  m <- ggplot2::margin(t = 5, r = 5, b = 5, l = 5, unit = "mm")
+  expect_no_error(call_validate(plot_margin = m))
+})
+
+# ============================================================================
+# build_qic_args()
+# ============================================================================
+
+test_that("build_qic_args producerer korrekt basisliste for i-chart", {
+  result <- build_qic_args(
+    data = data.frame(x = 1:5, y = 1:5),
+    x_expr = as.name("x"),
+    y_expr = as.name("y"),
+    n_expr = NULL,
+    chart_type = "i",
+    part = NULL,
+    freeze = NULL,
+    target_value = NULL,
+    notes = NULL,
+    exclude = NULL,
+    cl = NULL,
+    multiply = 1,
+    agg.fun = NULL,
+    y_axis_unit = "count"
+  )
+  expect_type(result, "list")
+  expect_identical(result$chart, "i")
+  expect_identical(result$return.data, TRUE)
+  # multiply = 1 maa IKKE inkluderes (qicharts2 default)
+  expect_false("multiply" %in% names(result))
+  # y.percent maa IKKE inkluderes for count
+  expect_false("y.percent" %in% names(result))
+})
+
+test_that("build_qic_args inkluderer n_expr naar angivet", {
+  result <- build_qic_args(
+    data = data.frame(x = 1:5, y = 1:5, n = 10),
+    x_expr = as.name("x"),
+    y_expr = as.name("y"),
+    n_expr = as.name("n"),
+    chart_type = "p",
+    part = NULL, freeze = NULL, target_value = NULL,
+    notes = NULL, exclude = NULL, cl = NULL,
+    multiply = 1, agg.fun = NULL, y_axis_unit = "percent"
+  )
+  expect_identical(result$n, as.name("n"))
+  expect_true(isTRUE(result$y.percent))
+})
+
+test_that("build_qic_args inkluderer y.percent for percent-enhed", {
+  result <- build_qic_args(
+    data = data.frame(x = 1:5, y = 1:5),
+    x_expr = as.name("x"),
+    y_expr = as.name("y"),
+    n_expr = NULL,
+    chart_type = "run",
+    part = NULL, freeze = NULL, target_value = NULL,
+    notes = NULL, exclude = NULL, cl = NULL,
+    multiply = 1, agg.fun = NULL, y_axis_unit = "percent"
+  )
+  expect_true(isTRUE(result$y.percent))
+})
+
+test_that("build_qic_args inkluderer multiply naar forskellig fra 1", {
+  result <- build_qic_args(
+    data = data.frame(x = 1:5, y = 1:5),
+    x_expr = as.name("x"),
+    y_expr = as.name("y"),
+    n_expr = NULL,
+    chart_type = "i",
+    part = NULL, freeze = NULL, target_value = NULL,
+    notes = NULL, exclude = NULL, cl = NULL,
+    multiply = 100, agg.fun = NULL, y_axis_unit = "percent"
+  )
+  expect_equal(result$multiply, 100)
+})
+
+test_that("build_qic_args inkluderer part, freeze, notes, exclude, cl naar angivet", {
+  result <- build_qic_args(
+    data = data.frame(x = 1:20, y = 1:20),
+    x_expr = as.name("x"),
+    y_expr = as.name("y"),
+    n_expr = NULL,
+    chart_type = "i",
+    part = c(10),
+    freeze = 10,
+    target_value = 5,
+    notes = rep(NA, 20),
+    exclude = c(3),
+    cl = 8,
+    multiply = 1,
+    agg.fun = "median",
+    y_axis_unit = "count"
+  )
+  expect_equal(result$part, c(10))
+  expect_equal(result$freeze, 10)
+  expect_equal(result$target, 5)
+  expect_equal(result$cl, 8)
+  expect_equal(result$agg.fun, "median")
+  expect_equal(result$exclude, c(3))
+  expect_length(result$notes, 20)
+})
+
+# ============================================================================
+# compute_viewport_base_size()
+# ============================================================================
+
+test_that("compute_viewport_base_size returnerer NULL dimensioner naar width/height mangler", {
+  result <- compute_viewport_base_size(
+    width = NULL, height = NULL,
+    units = NULL, dpi = 96,
+    base_size = 14, base_size_supplied = TRUE,
+    xlab = "", ylab = ""
+  )
+  expect_null(result$width_inches)
+  expect_null(result$height_inches)
+  expect_equal(result$base_size, 14)
+})
+
+test_that("compute_viewport_base_size konverterer cm til inches korrekt", {
+  # 25 cm auto-detekteres som cm (10 <= 25 <= 100)
+  result <- compute_viewport_base_size(
+    width = 25, height = 15,
+    units = NULL, dpi = 96,
+    base_size = 14, base_size_supplied = TRUE,
+    xlab = "x", ylab = "y"
+  )
+  expect_false(is.null(result$width_inches))
+  # 25 cm = 25/2.54 inches ≈ 9.84
+  expect_equal(result$width_inches, 25 / 2.54, tolerance = 0.01)
+})
+
+test_that("compute_viewport_base_size beregner responsiv base_size naar ikke angivet af bruger", {
+  result <- compute_viewport_base_size(
+    width = 10, height = 6,
+    units = "in", dpi = 96,
+    base_size = 14, base_size_supplied = FALSE,
+    xlab = "", ylab = ""
+  )
+  # base_size bør vaere beregnet via calculate_base_size() — og afvige fra default 14
+  expect_false(is.null(result$base_size))
+  # Resultatet er calculate_base_size(10, 6) — kontrollér at det adskiller sig fra det
+  # user-angivne default (14) og er numerisk
+  expect_false(identical(result$base_size, 14))
+  expect_true(is.numeric(result$base_size))
+})
+
+test_that("compute_viewport_base_size respekterer eksplicit base_size fra bruger", {
+  result <- compute_viewport_base_size(
+    width = 10, height = 6,
+    units = "in", dpi = 96,
+    base_size = 20, base_size_supplied = TRUE,
+    xlab = "x", ylab = "y"
+  )
+  expect_equal(result$base_size, 20)
+})
+
+test_that("compute_viewport_base_size normaliserer tomme akse-labels til NULL", {
+  result <- compute_viewport_base_size(
+    width = NULL, height = NULL,
+    units = NULL, dpi = 96,
+    base_size = 14, base_size_supplied = TRUE,
+    xlab = "", ylab = "   "
+  )
+  expect_null(result$xlab)
+  expect_null(result$ylab)
+})
+
+test_that("compute_viewport_base_size bevarer ikke-tomme akse-labels", {
+  result <- compute_viewport_base_size(
+    width = NULL, height = NULL,
+    units = NULL, dpi = 96,
+    base_size = 14, base_size_supplied = TRUE,
+    xlab = "Maaned", ylab = "Antal"
+  )
+  expect_equal(result$xlab, "Maaned")
+  expect_equal(result$ylab, "Antal")
 })


### PR DESCRIPTION
## Summary
- `bfh_qic()` reduceret fra ~380 til 126 linjer body via 8 helper-funktioner i `R/utils_bfh_qic_helpers.R`
- Helpers: `validate_column_name_expr`, `validate_bfh_qic_inputs`, `build_qic_args`, `invoke_qicharts2`, `compute_viewport_base_size`, `render_bfh_plot`, `apply_spc_labels_to_export`, `build_bfh_qic_config`
- Ingen adfærdsændringer — ren omstrukturering
- Note: OpenSpec-target var ≤80 linjer; 126 er realistisk grænse uden at re-monolitisere

## Test plan
- [x] Alle 45 nye helper-tests bestået
- [x] Nul regression: alle pre-existing tests pass uden modifikation
- [x] `devtools::test()`: 2445 pass, 0 fail
- [x] `devtools::check()`: 0 errors, 0 warnings

Closes #211