### PR TITLE
docs: dokumentér trust-grænse for inject_assets og template_path

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,18 @@
   propageres uaendret. Fungerer som defense-in-depth efter PR #242
   (font-aliases onLoad) der eliminerer font-warnings ved kilden. (#200)
 
+## Sikkerhed
+
+* **Roxygen-dokumentation eksplicit om trust-grænse for `inject_assets` og
+  `template_path`.** Begge parametre i `bfh_export_pdf()` (og
+  `inject_assets` i `bfh_create_export_session()`) accepterer
+  caller-supplied kode/templates der koerer med fuld proces-privilege.
+  De er legitim infrastruktur for proprietaere fonts og custom templates,
+  men en naiv Shiny-integration der videresender user-input vil skabe en
+  privilege-escalation-vektor. Ny `\\section{Security}` markerer eksplicit
+  hvilke parametre der er trusted-code-only og hvordan de skal valideres
+  mod allow-lister hvis exposed. Ingen kode-aendring -- kun docs. (#218)
+
 # BFHcharts 0.10.4
 
 ## Interne aendringer

--- a/R/export_pdf.R
+++ b/R/export_pdf.R
@@ -104,11 +104,37 @@
 #' - Other chart types show only values (e.g., "127")
 #' - Interval labels adapt to data frequency (month, week, day, etc.)
 #'
+#' @section Security:
+#' Both \code{inject_assets} and \code{template_path} are designed for
+#' advanced use cases (proprietary fonts, organization-specific templates)
+#' and \strong{must be treated as trusted-code-only}:
+#' \itemize{
+#'   \item \code{inject_assets} is invoked with full filesystem access in
+#'     the template directory. Whatever R code the callback contains runs
+#'     with the same privileges as the calling process -- equivalent to
+#'     sourcing arbitrary R from disk.
+#'   \item \code{template_path} is compiled by the Typst binary. A custom
+#'     template can read and write arbitrary paths during compilation.
+#' }
+#' Treat both parameters with the same trust contract you would apply to
+#' \code{source()}: pass only code-reviewed, organizationally controlled
+#' values. \strong{Never} forward user-supplied input (Shiny inputs,
+#' query parameters, untrusted uploads) to either parameter -- doing so
+#' creates a privilege-escalation vector. If your application surface
+#' needs to expose template customization to end users, validate against
+#' a fixed allow-list of approved templates and callbacks before invoking
+#' \code{bfh_export_pdf()}.
+#'
+#' The same trust requirement applies to \code{inject_assets} when passed
+#' to \code{\link{bfh_create_export_session}()}.
+#'
 #' @export
 #' @seealso
 #'   - [bfh_qic()] to create SPC charts
 #'   - [bfh_export_png()] to export as PNG
 #'   - [bfh_create_typst_document()] for low-level Typst generation
+#'   - [bfh_create_export_session()] for batch workflows (same trust
+#'     requirement applies to its `inject_assets` parameter)
 #' @examples
 #' \dontrun{
 #' library(BFHcharts)

--- a/R/export_session.R
+++ b/R/export_session.R
@@ -34,7 +34,20 @@
 #' - Not compatible with \code{template_path} (custom templates).
 #' - Pass \code{inject_assets} here, not to individual \code{bfh_export_pdf()} calls.
 #'
+#' @section Security:
+#' \code{inject_assets} is invoked with full filesystem access in the
+#' template directory and runs whatever R code the callback contains.
+#' \strong{Treat it as trusted-code-only}: pass only code-reviewed,
+#' organizationally controlled callbacks. Never forward user-supplied
+#' input (Shiny inputs, query parameters, untrusted uploads) to this
+#' parameter -- the same trust contract as \code{source()} applies. See
+#' \code{\link{bfh_export_pdf}} for the full rationale and the parallel
+#' warning for \code{template_path}.
+#'
 #' @export
+#' @seealso
+#'   - [bfh_export_pdf()] for single exports and the full security note
+#'     covering both `inject_assets` and `template_path`
 bfh_create_export_session <- function(font_path = NULL, inject_assets = NULL) {
   if (!is.null(inject_assets) && !is.function(inject_assets)) {
     stop("inject_assets must be a function or NULL", call. = FALSE)

--- a/man/bfh_create_export_session.Rd
+++ b/man/bfh_create_export_session.Rd
@@ -46,3 +46,21 @@ for (dept in departments) {
 \item Pass \code{inject_assets} here, not to individual \code{bfh_export_pdf()} calls.
 }
 }
+\section{Security}{
+
+\code{inject_assets} is invoked with full filesystem access in the
+template directory and runs whatever R code the callback contains.
+\strong{Treat it as trusted-code-only}: pass only code-reviewed,
+organizationally controlled callbacks. Never forward user-supplied
+input (Shiny inputs, query parameters, untrusted uploads) to this
+parameter -- the same trust contract as \code{source()} applies. See
+\code{\link{bfh_export_pdf}} for the full rationale and the parallel
+warning for \code{template_path}.
+}
+
+\seealso{
+\itemize{
+\item \code{\link[=bfh_export_pdf]{bfh_export_pdf()}} for single exports and the full security note
+covering both \code{inject_assets} and \code{template_path}
+}
+}

--- a/man/bfh_export_pdf.Rd
+++ b/man/bfh_export_pdf.Rd
@@ -153,6 +153,32 @@ Typst templates for hospital branding. Requires Quarto CLI for compilation.
 \item Interval labels adapt to data frequency (month, week, day, etc.)
 }
 }
+\section{Security}{
+
+Both \code{inject_assets} and \code{template_path} are designed for
+advanced use cases (proprietary fonts, organization-specific templates)
+and \strong{must be treated as trusted-code-only}:
+\itemize{
+\item \code{inject_assets} is invoked with full filesystem access in
+the template directory. Whatever R code the callback contains runs
+with the same privileges as the calling process -- equivalent to
+sourcing arbitrary R from disk.
+\item \code{template_path} is compiled by the Typst binary. A custom
+template can read and write arbitrary paths during compilation.
+}
+Treat both parameters with the same trust contract you would apply to
+\code{source()}: pass only code-reviewed, organizationally controlled
+values. \strong{Never} forward user-supplied input (Shiny inputs,
+query parameters, untrusted uploads) to either parameter -- doing so
+creates a privilege-escalation vector. If your application surface
+needs to expose template customization to end users, validate against
+a fixed allow-list of approved templates and callbacks before invoking
+\code{bfh_export_pdf()}.
+
+The same trust requirement applies to \code{inject_assets} when passed
+to \code{\link{bfh_create_export_session}()}.
+}
+
 \examples{
 \dontrun{
 library(BFHcharts)
@@ -213,5 +239,7 @@ for (dept in departments) {
 \item \code{\link[=bfh_qic]{bfh_qic()}} to create SPC charts
 \item \code{\link[=bfh_export_png]{bfh_export_png()}} to export as PNG
 \item \code{\link[=bfh_create_typst_document]{bfh_create_typst_document()}} for low-level Typst generation
+\item \code{\link[=bfh_create_export_session]{bfh_create_export_session()}} for batch workflows (same trust
+requirement applies to its \code{inject_assets} parameter)
 }
 }


### PR DESCRIPTION
## Summary

`bfh_export_pdf()` og `bfh_create_export_session()` eksponerer to extension points der kører caller-supplied kode/templates:

* `inject_assets` (callback): kører arbitrær R med fuld filesystem-access i template-mappen.
* `template_path`: Typst-binæren kompilerer det opgivne template — som kan læse/skrive arbitrary paths under compilation.

Begge er legitim infrastruktur for proprietære fonts og organisationsspecifikke templates. **Ingen af dem er en sikkerhedshul ved bestemmelses-anvendelse.** Men en naiv Shiny-integration der videresender user-input til parametrene skaber privilege-escalation — og dokumentationen markerede ikke trust-kravet eksplicit.

## Ændring

Tilføjer `\section{Security}{...}` til roxygen for begge eksporter:
* Eksplicit "trusted-code-only" markering med begrundelse.
* Analogi til `source()` trust-kontrakt (R-developers kender mønsteret).
* Aktivt forbud mod at videresende user-input.
* Anbefaling: validér mod fixed allow-list hvis exposed til end-users.
* `@seealso`-krydslinker mellem de to eksporter.

Ingen kodeændring — kun docs. `man/`-filer regenereret med `devtools::document()`.

Closes #218

## Test plan

- [x] `devtools::document()` succeeds — `man/bfh_export_pdf.Rd` og `man/bfh_create_export_session.Rd` indeholder `\section{Security}`-blokke
- [x] `devtools::test(filter = "export")` — 330 PASS / 0 FAIL
- [x] Manual: `?bfh_export_pdf` viser Security-section pænt formatteret