### PR TITLE
fix: registrér Mari/Arial som Helvetica-aliaser ved package load

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # BFHcharts 0.10.5 (development)
 
+## Bug fixes
+
+* **Eliminer "font family not found in PostScript font database" warnings
+  i production.** Mari/Arial registreres nu som Helvetica-aliaser i
+  `grDevices::postscriptFonts()` og `grDevices::pdfFonts()` ved package
+  load (ny `.onLoad()` i `R/zzz.R`). Tidligere blev registreringen kun
+  udfoert i test-setup -- production-kald af `bfh_qic()` og
+  `ggplot2::ggsave()` producerede ~40-50 harmlose PostScript-warnings per
+  kald (fra `grid::C_stringMetric` font-metric-lookup). Registreringen er
+  konservativ: eksisterende Mari/Arial-registreringer (fx via
+  systemfonts) overskrives ikke. Den interne
+  `.muffle_expected_warnings()` helper bevares som defense-in-depth for
+  datetime/numeric scale warnings. (#202)
+
 ## Interne aendringer
 
 * **Filomdoebning: `R/create_spc_chart.R` -> `R/bfh_qic.R`.** Funktionen

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,70 @@
+# nocov start
+# Package load hooks
+# nocov end
+
+#' Register Proprietary Font Aliases in PostScript/PDF Font Databases
+#'
+#' BFHtheme bruger Mari-fonts (proprietaere) der eksisterer som screen-fonts
+#' men som standard ikke er registreret i R's interne PostScript/PDF
+#' font-databaser. Manglende registrering producerer harmlose
+#' "font family '...' not found in PostScript font database" warnings fra
+#' grid::C_stringMetric font-metric-lookup hver gang ggplot2-grobs renderes
+#' under SVG/PDF/PostScript-output (bl.a. ggplot_gtable, geom_text,
+#' label-placement-pipelinen i bfh_qic()).
+#'
+#' Funktionen registrerer Mari og Arial som **Helvetica-aliaser** i
+#' \code{grDevices::postscriptFonts()} og \code{grDevices::pdfFonts()} -- men
+#' kun hvis de ikke allerede er til stede. Brugere der har konfigureret rigtige
+#' Mari-fonts (fx via systemfonts) faar derfor deres eksisterende registrering
+#' bevaret.
+#'
+#' Helvetica-metrics er en sikker fallback: character-width forskellene mellem
+#' Mari og Helvetica er smaa nok til at label-placering, target-tekster m.m.
+#' fortsat ser korrekt ud. Den fulde rendering er fortsat afhaengig af at den
+#' rigtige Mari findes i system-font-DB'en (Typst/PNG/PDF-output via Quarto +
+#' \code{font_path}-mekanismen) -- denne registrering er KUN for grid's interne
+#' metric-lookup.
+#'
+#' @keywords internal
+#' @noRd
+register_bfh_font_aliases <- function() {
+  ps_fonts <- tryCatch(grDevices::postscriptFonts(), error = function(e) NULL)
+  pdf_fonts <- tryCatch(grDevices::pdfFonts(), error = function(e) NULL)
+  if (is.null(ps_fonts) || is.null(pdf_fonts)) {
+    return(invisible(FALSE))
+  }
+
+  helv_ps <- ps_fonts[["Helvetica"]]
+  helv_pdf <- pdf_fonts[["Helvetica"]]
+  if (is.null(helv_ps) || is.null(helv_pdf)) {
+    return(invisible(FALSE))
+  }
+
+  for (fname in c("Mari", "Arial")) {
+    if (!fname %in% names(ps_fonts)) {
+      tryCatch(
+        do.call(
+          grDevices::postscriptFonts,
+          stats::setNames(list(helv_ps), fname)
+        ),
+        error = function(e) NULL
+      )
+    }
+    if (!fname %in% names(pdf_fonts)) {
+      tryCatch(
+        do.call(
+          grDevices::pdfFonts,
+          stats::setNames(list(helv_pdf), fname)
+        ),
+        error = function(e) NULL
+      )
+    }
+  }
+  invisible(TRUE)
+}
+
+# nocov start
+.onLoad <- function(libname, pkgname) {
+  register_bfh_font_aliases()
+}
+# nocov end


### PR DESCRIPTION
## Summary

`bfh_qic()` og `ggplot2::ggsave()` producerer historisk ~40-50 warnings af typen `"font family 'Mari' not found in PostScript font database"` per kald i production. Stammer fra `grid::C_stringMetric` font-metric-lookup når grobs renderes til SVG/PDF-devices. Harmløse (lookup falder tilbage til Helvetica-metrics) men noisy.

Tidligere fix-strategi:
* `.muffle_expected_warnings()` i `bfh_qic()` (PR #240) — symptom-fix
* 217 `suppressWarnings()`-wrappere i tests (#201) — symptom-fix
* `local()`-blok i `tests/testthat/setup.R` der registrerer Mari/Arial som Helvetica-aliaser — root-cause fix, **men kun for tests**

## Ændring

Flyt alias-registreringen til pakke-level `.onLoad()`-hook i ny `R/zzz.R`. Helperfunktionen `register_bfh_font_aliases()` køres ved hver package-load og:

1. Læser eksisterende `postscriptFonts()` og `pdfFonts()` registry.
2. Registrerer Mari og Arial som Helvetica-aliaser **kun hvis de mangler** (bevaring af brugerens egne registreringer fx via `systemfonts`).
3. `tryCatch` beskytter mod fejl i exotiske R-konfigurationer.

Helvetica-metrics er en sikker fallback for grid's interne lookup. Fuld rendering med rigtig Mari sker stadig via Typst/Quarto + `font_path`-mekanismen i `bfh_export_pdf()`; denne fix påvirker kun grid-baseret output (SVG/PDF).

## Konsekvens

* **#200** (`.muffle_expected_warnings()` PR #240) bevares som defense-in-depth for datetime/numeric scale warnings — fortsat relevant.
* **#201** (217 `suppressWarnings()` i tests) kan nu cleanes op i en follow-up — wrapperne er teknisk redundante efter denne fix.
* `tests/testthat/setup.R`-duplikatet kan fjernes når `.onLoad()`-fixet er bevist stabilt (gør det ikke i denne PR for at undgå scope creep).

Closes #202

## Test plan

- [x] `devtools::test()` — 2494 PASS / 0 FAIL / 0 ERROR / 44 SKIP
- [x] Manual: `bfh_qic()` produces 0 PostScript warnings under rendering
- [x] Manual: `ggsave(plot)` produces 0 PostScript warnings
- [x] Verificér `Mari %in% names(grDevices::postscriptFonts())` returnerer `TRUE` umiddelbart efter `library(BFHcharts)`