### PR TITLE
docs: tilføj fire kliniske vignettes for chart-typer, faser, targets, eksport

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -36,3 +36,5 @@
 ^BFHLLM_INTEGRATION\.md$
 ^TRANSLATORS\.md$
 ^CLAUDE\.md\.backup$
+^doc$
+^Meta$

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ BFHcharts.Rcheck/
 BFHcharts_*.tar.gz
 # Backup files
 *.backup
+# Vignette build artifacts
+/doc/
+/Meta/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,10 @@ Suggests:
     covr,
     pdftools (>= 3.3.0),
     withr,
-    BFHllm
+    BFHllm,
+    knitr,
+    rmarkdown
+VignetteBuilder: knitr
 Remotes:
     johanreventlow/BFHtheme,
     johanreventlow/BFHllm

--- a/NEWS.md
+++ b/NEWS.md
@@ -85,6 +85,31 @@
   tests koerer live; uploader PDF/Typst-artifacts ved fejl for
   remote-debugging.
 
+## Dokumentation
+
+* **Fire kliniske vignettes (#219).** Pakken havde tidligere kun reference-
+  dokumentation via roxygen — kliniske brugere manglede end-to-end guidance
+  paa hvilke chart-typer der passer til hvilke spoergsmaal, hvordan
+  interventioner haandteres, og hvad target-kontrakten dikterer. Fire nye
+  Rmd-vignettes i `vignettes/`:
+
+  - **`chart-types`**: Beslutningstrae fra klinisk spoergsmaal til
+    `chart_type`-valg. Per-type use cases, sample-size guidance,
+    anti-patterns. Reference: Provost & Murray (2011).
+  - **`phases-and-freeze`**: Distinguere `part` (separate centerlinjer per
+    fase) vs `freeze` (fastlaast baseline). Klinisk eksempel: pre/post
+    intervention med frosset baseline. Almindelige fejl + migration-pattern.
+  - **`targets-and-percent`**: Dokumenterer percent-target-kontrakten fra
+    v0.9.0 (#203). Migration-eksempel fra silently misvisende
+    `target_value = 2.0` paa percent-akse til korrekt
+    `target_value = 0.02` (proportion) eller `multiply = 100`.
+  - **`safe-exports`**: Sikkerheds-praksis for `inject_assets` og
+    `template_path` (#218). Allow-list-pattern til Shiny-applications,
+    pre-deploy security checklist.
+
+  Infrastruktur: `VignetteBuilder: knitr` tilfoejet til DESCRIPTION,
+  `knitr` + `rmarkdown` i Suggests, build artifacts i `.gitignore`.
+
 # BFHcharts 0.10.4
 
 ## Interne aendringer

--- a/vignettes/chart-types.Rmd
+++ b/vignettes/chart-types.Rmd
@@ -1,0 +1,171 @@
+---
+title: "Vælg den rigtige SPC-charttype"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Vælg den rigtige SPC-charttype}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.width = 7,
+  fig.height = 4
+)
+```
+
+## Hvorfor charttypen er vigtig
+
+Forkert charttype giver misvisende konklusioner. En infektionsrate visualiseret som
+i-chart (individuelle målinger) ignorerer at varians afhænger af antal patienter
+i nævneren. En andelsmåling (proportion) i en c-chart antager at maximum er
+uendeligt — hvilket aldrig er sandt for proportioner ≤ 1.
+
+Denne vignette mapper kliniske spørgsmål til charttyper og giver beslutningsregler.
+
+## Beslutningstræ
+
+```
+  Hvad måler du?
+  │
+  ├── Tællinger (counts)
+  │   │
+  │   ├── Konstant areal/eksponering (fx fald per måned, alle samme afdeling)?
+  │   │   → c-chart (Poisson, tællinger med konstant forventning)
+  │   │
+  │   └── Varierende eksponering (fald per 1000 patientdage)?
+  │       → u-chart (Poisson, rate per eksponering)
+  │
+  ├── Proportioner (events / total)
+  │   │
+  │   ├── Klassisk binomial (fx genindlæggelser / udskrivninger)?
+  │   │   → p-chart
+  │   │
+  │   ├── Procent på y-akse (præsentation i %)?
+  │   │   → pp-chart (Laney p', overdispersion-korrigeret)
+  │   │
+  │   └── Rate i procent (sygefravær % af planlagt tid)?
+  │       → up-chart (Laney u')
+  │
+  ├── Kontinuerte målinger
+  │   │
+  │   ├── Subgrouped data (fx 5 målinger per dag)?
+  │   │   → xbar-chart (mean) + s-chart (variation)
+  │   │
+  │   ├── Individuelle målinger (én måling per periode)?
+  │   │   → i-chart + mr-chart (moving range)
+  │   │
+  │   └── For lille n eller ikke-normal fordeling?
+  │       → run-chart (kun centerlinje, ingen kontrolgrænser)
+  │
+  └── Tid eller antal mellem hændelser
+      │
+      ├── Tid mellem (dage mellem fald)?
+      │   → t-chart (Nelson-transformation for skæv fordeling)
+      │
+      └── Antal mellem (vagter siden sidste fejl)?
+          → g-chart (geometrisk fordeling)
+```
+
+## Per chart-type: hvornår, hvorfor
+
+### `p` — proportion (binomial)
+
+Klassisk: `p = events / total`. Bruges når data er binær per observation
+(fx infektion ja/nej for hver patient) og du vil måle andelen.
+
+```{r p-example}
+library(BFHcharts)
+
+# 12 måneder, infektioner per 1000 udskrivninger
+data <- data.frame(
+  month = seq(as.Date("2024-01-01"), by = "month", length.out = 12),
+  infections = c(15, 18, 12, 14, 16, 13, 11, 9, 10, 8, 7, 6),
+  discharges = c(950, 1020, 980, 1050, 1010, 990, 970, 1030, 1000, 985, 995, 1015)
+)
+
+bfh_qic(data,
+  x = month, y = infections, n = discharges,
+  chart_type = "p",
+  y_axis_unit = "percent",
+  chart_title = "Infektionsrate"
+)
+```
+
+**Krav**: `n` (denominator) skal være ikke-NULL og positiv. `events <= n` for hver række.
+
+### `u` — rate per eksponering (Poisson)
+
+Bruges når events tælles per "eksponeringsenhed" (patientdage, vagter, behandlinger).
+I modsætning til `p` har `u` ikke et øvre bound (rates kan i princippet overstige 1).
+
+```{r u-example, eval = FALSE}
+# Fald per 1000 patientdage
+bfh_qic(data,
+  x = month, y = falls, n = patient_days,
+  chart_type = "u",
+  y_axis_unit = "rate"
+)
+```
+
+### `c` — konstant-eksponering tællinger
+
+Bruges når eksponering er praktisk konstant (samme afdeling, samme periodelængde).
+Simpler end u-chart men kræver konstans-antagelsen.
+
+### `i` — individuelle kontinuerte målinger
+
+For målinger hvor du har én værdi per periode (fx daglig ventetid). Brug **altid**
+sammen med `mr`-chart for at se variation mellem konsekutive målinger.
+
+### `xbar` + `s` — subgrouped kontinuerte data
+
+Når hver periode har flere målinger (fx 5 patienter målt per dag). `xbar` viser
+gennemsnit, `s` viser within-group variation. Kraftigt par når subgroup-størrelsen
+er stabil.
+
+### `run` — for lille n eller ikke-normalitet
+
+Hvis du har <12 datapunkter, eller fordelingen er kraftigt skæv, er kontrolgrænser
+upålidelige. Run-chart giver kun centerlinje + Anhøj-regler — fang systematiske
+ændringer uden fejlagtig falsk-positiv.
+
+### `t` og `g` — tid/antal mellem hændelser
+
+Til sjældne events. `t` (dage mellem) bruger Nelson-transformation for at håndtere
+skæv eksponentiel fordeling. `g` (count mellem) for diskret tælling.
+
+## Anti-patterns: når SPC misleder
+
+| Mønster | Problem |
+|---------|---------|
+| Bruge `i` til andele | Ignorerer denominator → forkerte kontrolgrænser |
+| Bruge `c` til varierende eksponering | Antager konstant baseline → falske signaler |
+| Skifte chart-type efter at have set data | Bias (cherry-picking) — bestem på forhånd |
+| Genberegne baseline efter intervention | Brug `freeze` til at låse pre-intervention CL |
+| <12 datapunkter med kontrolgrænser | Brug `run` indtil du har ≥12-15 punkter |
+
+## Sample size guidance
+
+| Chart-type | Minimum n | Anbefalet n |
+|------------|-----------|-------------|
+| `p`, `u`   | 8         | 20+ med n_i > 10 |
+| `c`        | 8         | 20+ med c_bar > 5 |
+| `i`, `mr`  | 12        | 20+ |
+| `xbar`, `s`| 8 subgroups| 20+ subgroups, n_i ≥ 4 |
+| `t`, `g`   | 8 events  | 25+ events |
+| `run`      | 8         | 12+ |
+
+## Reference
+
+- Provost LP & Murray SK (2011). *The Health Care Data Guide*. Jossey-Bass.
+- Mohammed MA et al. (2008). "Plotting basic control charts." *BMJ Quality & Safety* 17:137-145.
+- Anhøj J & Olesen AV (2014). "Run charts revisited." *PLOS ONE* 9(11):e113825.
+
+## Se også
+
+- `vignette("phases-and-freeze")` — håndtér interventioner og baseline
+- `vignette("targets-and-percent")` — target-værdi og procent-akser
+- `?bfh_qic` — fuld parameter-dokumentation

--- a/vignettes/phases-and-freeze.Rmd
+++ b/vignettes/phases-and-freeze.Rmd
@@ -1,0 +1,177 @@
+---
+title: "Faser og fastfrysning af baseline"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Faser og fastfrysning af baseline}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.width = 7,
+  fig.height = 4
+)
+```
+
+## To måder at håndtere ændringer
+
+`bfh_qic()` understøtter to relaterede men forskellige mekanismer for håndtering
+af interventioner og baseline-perioder:
+
+| Parameter | Hvad det gør | Klinisk brug |
+|-----------|-------------|--------------|
+| `part`    | Splitter dataset i flere faser; hver fase får **egen** centerlinje + kontrolgrænser | Sammenligning før/efter intervention |
+| `freeze`  | Beregner kontrolgrænser kun fra første N rækker; bruger samme grænser for alle efterfølgende | Etabler baseline, vis afvigelser efter |
+
+## `part` — flere faser med separate kontrolgrænser
+
+Brug når du vil sammenligne to (eller flere) statistisk distinkte perioder, fx
+før og efter en kvalitetsforbedrings-intervention. Hver fase får egen centerlinje
+og egne kontrolgrænser.
+
+```{r part-example}
+library(BFHcharts)
+
+# Pre-intervention: månedlig infektionsrate ~15%
+# Intervention rullet ud i marts 2024
+# Post-intervention: rate falder til ~8%
+data <- data.frame(
+  month = seq(as.Date("2024-01-01"), by = "month", length.out = 12),
+  infections = c(15, 18, 14, 9, 8, 7, 8, 9, 7, 6, 8, 7),
+  discharges = rep(100L, 12)
+)
+
+# part = 3 splitter dataset efter periode 3 (marts)
+bfh_qic(data,
+  x = month, y = infections, n = discharges,
+  chart_type = "p",
+  y_axis_unit = "percent",
+  part = 3,
+  chart_title = "Infektionsrate (intervention marts 2024)"
+)
+```
+
+**Anvendelse**:
+- `part = 3` splitter efter 3. observation
+- `part = c(3, 9)` opretter 3 faser med splits ved positioner 3 og 9
+- Hver fase beregner sin egen `p_bar`, `UCL`, `LCL`
+
+**Hvornår** bruges `part`:
+- Du har en **kendt intervention** med specifik dato
+- Du forventer at processen er statistisk anderledes efter
+- Du ikke ønsker at fase 1 forurener fase 2's kontrolgrænser
+
+## `freeze` — fastlås baseline-grænser
+
+Brug når du vil etablere en stabil baseline og vise hvordan efterfølgende perioder
+afviger. I modsætning til `part` får alle perioder samme kontrolgrænser
+(beregnet fra de første N punkter).
+
+```{r freeze-example}
+# Baseline = de første 6 måneder (jan-jun 2024)
+# Baseline-grænser bruges for hele datasættet — afsløre intervention-effekt
+bfh_qic(data,
+  x = month, y = infections, n = discharges,
+  chart_type = "p",
+  y_axis_unit = "percent",
+  freeze = 6,
+  chart_title = "Infektionsrate (baseline jan-jun, frosset)"
+)
+```
+
+**Anvendelse**:
+- `freeze = 6` beregner CL/UCL/LCL kun fra observationer 1-6
+- Alle observationer 7+ tegnes mod **samme** grænser
+- Punkter under LCL post-baseline = signifikant forbedring
+
+**Hvornår** bruges `freeze`:
+- Du har en **historisk stabil** baseline du vil måle imod
+- Du **ikke** ønsker at post-intervention perioder skal "trække" centerlinjen
+- Du vil vise effektstørrelse af en intervention visuelt
+
+## Kombineret: `part` + `freeze`
+
+Begge parametre kan kombineres når du har flere sekventielle interventioner:
+
+```{r part-freeze-example, eval = FALSE}
+# Baseline: jan-jun 2024 (frosset)
+# Intervention 1: jul-sep 2024
+# Intervention 2: okt-dec 2024
+bfh_qic(data,
+  x = month, y = infections, n = discharges,
+  chart_type = "p",
+  part = c(6, 9),
+  freeze = 6
+)
+```
+
+Resultat: 3 faser; fase 1's grænser er frosne fra de første 6 punkter; fase 2 og 3
+beregner deres egne grænser fra deres data.
+
+## Almindelige fejl
+
+### Fejl 1: Refreeze på hver datasæt-opdatering
+
+```r
+# ❌ Forkert: dynamisk freeze gør grænser ustabile
+bfh_qic(data, ..., freeze = nrow(data) - 3)  # Sidste 3 ekskluderet hver gang
+
+# ✅ Rigtigt: fast freeze-position fra original baseline
+bfh_qic(data, ..., freeze = 12)  # 12 første måneder, fast
+```
+
+### Fejl 2: Bruge `part` som "moving window"
+
+`part` er ikke en glidende vindue. Hver fase er **statistisk uafhængig** —
+data fra fase 1 påvirker ikke fase 2's kontrolgrænser.
+
+### Fejl 3: For tidlig faseopsplitning
+
+Du har brug for ≥8 datapunkter per fase for meningsfulde kontrolgrænser. Under
+det: brug `run`-chart for fasen i stedet, eller udskyd fase-split til mere data
+er tilgængelig.
+
+### Fejl 4: Faseopsplitning baseret på data (post-hoc)
+
+Bestem `part`-positioner **før** du ser data — baseret på kendte interventionstidspunkter.
+Splitter du efter at have set hvor data ændrer sig, har du committed cherry-picking.
+
+## Klinisk eksempel: medicineringsfejl
+
+```{r clinical-example}
+# Antal medicineringsfejl per 1000 ordinationer
+# Intervention: ny dobbeltkontrol-procedure indført okt 2024
+data <- data.frame(
+  month = seq(as.Date("2024-01-01"), by = "month", length.out = 18),
+  errors = c(
+    # Pre-intervention: ~12 fejl/1000
+    11, 13, 14, 12, 10, 13, 14, 11, 15,
+    # Post-intervention: ~6 fejl/1000
+    7, 5, 6, 4, 7, 5, 4, 6, 5
+  ),
+  prescriptions = rep(1000L, 18)
+)
+
+# Vis effekt med frosset baseline
+bfh_qic(data,
+  x = month, y = errors, n = prescriptions,
+  chart_type = "u",
+  y_axis_unit = "rate",
+  freeze = 9,
+  chart_title = "Medicineringsfejl per 1000 ordinationer",
+  target_text = "↓ Mål: <8 fejl/1000",
+  target_value = 8
+)
+```
+
+Punkter under LCL efter periode 9 demonstrerer signifikant forbedring; baseline
+fastfrosset så reduktion er visuelt tydelig.
+
+## Se også
+
+- `vignette("chart-types")` — vælg den rigtige charttype først
+- `vignette("targets-and-percent")` — sat realistiske mål
+- `?bfh_qic` — `@param part`, `@param freeze` parameter-detaljer

--- a/vignettes/safe-exports.Rmd
+++ b/vignettes/safe-exports.Rmd
@@ -1,0 +1,203 @@
+---
+title: "Sikre eksporter med custom templates og fonts"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Sikre eksporter med custom templates og fonts}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+## To extension points med trust-krav
+
+`bfh_export_pdf()` og `bfh_create_export_session()` eksponerer to parametre der
+**kører caller-supplied kode/templates**. Begge er legitime for proprietære fonts
+og organisationsspecifikke templates, men begge kræver eksplicit trust:
+
+| Parameter | Hvad det gør | Risiko ved misbrug |
+|-----------|--------------|--------------------|
+| `inject_assets` | Kalder en R-callback med skrive-adgang til template-mappen | Vilkårlig R-kode-eksekvering |
+| `template_path` | Erstatter den pakkede Typst-template | Vilkårlig Typst (kan læse/skrive paths under compilation) |
+
+Begge parametre skal behandles med samme tillidskontrakt som `source()`:
+**aldrig fra user-input**, altid fra code-reviewed organisationskontrolleret kilde.
+
+## Brug `font_path` for de fleste tilfælde
+
+Hvis du **kun** har brug for at injicere fonts, brug `font_path` i stedet for
+`inject_assets`. Det er sikkert at videresende fra konfiguration eller
+miljøvariable, og kræver ikke trust på samme niveau:
+
+```{r font-path, eval = FALSE}
+library(BFHcharts)
+
+# Fonts er statiske filer på disk — ingen kode-eksekvering
+bfh_export_pdf(result, "rapport.pdf",
+  font_path = "/etc/bfh-fonts"
+)
+```
+
+`font_path` videregives som `--font-path` til Typst-compileren. Typst læser
+fonts fra mappen men eksekverer ingen kode fra den.
+
+## `inject_assets` — kun til organisations-kontrolleret kode
+
+Brug `inject_assets` når du har **dynamiske** filsystem-operationer der ikke
+passer ind i en fast `font_path`-mappe. Eksempel: en privat pakke der bundler
+fonts og afpakker dem til template-mappen lige før compilation.
+
+```{r inject-assets-good, eval = FALSE}
+# Sikkert: callback fra code-reviewed privat pakke
+inject_my_org_assets <- function(template_dir) {
+  font_dir <- file.path(template_dir, "fonts")
+  dir.create(font_dir, showWarnings = FALSE)
+  file.copy(
+    system.file("fonts", "Mari", package = "MyOrgPrivateFonts"),
+    font_dir,
+    recursive = TRUE
+  )
+}
+
+bfh_export_pdf(result, "rapport.pdf",
+  inject_assets = inject_my_org_assets
+)
+```
+
+```r
+# FARLIGT: callback bygget fra Shiny-input
+server <- function(input, output, session) {
+  output$pdf <- downloadHandler(
+    content = function(file) {
+      # ALDRIG videresend user-supplied kode/strenge til inject_assets:
+      user_callback <- parse_user_input(input$user_callback)
+      bfh_export_pdf(result, file, inject_assets = user_callback)
+    }
+  )
+}
+```
+
+Sidstnævnte mønster konverterer en Shiny-input til en eksekverbar callback —
+hvilket giver brugeren vilkårlig kode-eksekvering på serveren. Kald den
+"remote code execution" eller "RCE": uacceptabel selv i interne enterprise
+deployments.
+
+## `template_path` — kun til organisations-kontrolleret Typst
+
+Tilsvarende: `template_path` peger på en `.typ`-fil som Typst-compileren kører.
+En custom template kan udføre filsystem-operationer under compilation — så
+**aldrig** modtag template-stien fra user-input.
+
+```{r template-path-good, eval = FALSE}
+# Sikkert: template fra organisations-repo, code-reviewed
+bfh_export_pdf(result, "rapport.pdf",
+  template_path = system.file(
+    "templates", "afdelings-template.typ",
+    package = "MyOrgTemplates"
+  )
+)
+```
+
+```r
+# FARLIGT: template-sti fra user upload
+template <- input$uploaded_template$datapath
+bfh_export_pdf(result, "rapport.pdf",
+  template_path = template
+)
+```
+
+Den uploadede `.typ`-fil eksekveres af Typst-compileren med samme privilege
+som R-processen. Vilkårlig Typst-kode kan læse og skrive filsystem-paths.
+
+## Allow-list pattern: hvis du **skal** eksponere customisering
+
+Hvis dit Shiny-interface skal lade brugere vælge mellem **forhåndsgodkendte**
+templates, validér mod en fixed allow-list før kald:
+
+```{r allowlist, eval = FALSE}
+APPROVED_TEMPLATES <- list(
+  standard = system.file("templates/standard.typ", package = "MyOrg"),
+  klinisk  = system.file("templates/klinisk.typ", package = "MyOrg"),
+  forskning = system.file("templates/forskning.typ", package = "MyOrg")
+)
+
+server <- function(input, output, session) {
+  output$pdf <- downloadHandler(
+    content = function(file) {
+      # User vælger fra dropdown med navn — ikke fil-sti
+      template <- APPROVED_TEMPLATES[[input$template_name]]
+      if (is.null(template) || !file.exists(template)) {
+        stop("Ugyldig template valgt")
+      }
+      bfh_export_pdf(result, file, template_path = template)
+    }
+  )
+}
+```
+
+UI komponenten viser kun navnene fra allow-listen — fil-stier eksponeres aldrig.
+
+## Batch eksport med `bfh_create_export_session()`
+
+For mange eksporter med identiske template-assets: brug session for at undgå
+gentaget I/O. Trust-kravet for `inject_assets` er det samme:
+
+```{r batch, eval = FALSE}
+session <- bfh_create_export_session(
+  font_path = "/etc/bfh-fonts",
+  inject_assets = inject_my_org_assets   # Code-reviewed callback
+)
+on.exit(close(session))
+
+for (afdeling in afdelinger) {
+  result <- bfh_qic(data_per_afd[[afdeling]], ...)
+  bfh_export_pdf(result, paste0(afdeling, ".pdf"),
+    batch_session = session,
+    metadata = list(department = afdeling)
+  )
+}
+```
+
+`inject_assets` kaldes **én gang** ved session-opret; assets deles på tværs af
+alle eksporter. Trust-kravet er det samme som single-call mode.
+
+## Font-fallback chain
+
+Hvis `font_path` ikke matcher Typst's font-lookup, falder den tilbage på
+system-fonts (medmindre `ignore_system_fonts = TRUE`, default fra v0.10.0).
+Anbefalet praksis i production:
+
+```{r font-fallback, eval = FALSE}
+bfh_export_pdf(result, "rapport.pdf",
+  font_path = "/etc/bfh-fonts",
+  ignore_system_fonts = TRUE
+)
+```
+
+Med `ignore_system_fonts = TRUE` bruger Typst kun fonts fra `font_path` plus
+de bundle'de template-fonts. Det forhindrer overraskende rendering-forskelle
+mellem dev-maskiner og production-deployments hvor system-font-versioner divergerer.
+
+## Pre-deploy security checklist
+
+Før dit Shiny app eller batch-script går i produktion:
+
+- [ ] `inject_assets` callbacks kommer fra code-reviewed kilde (ikke user-input)
+- [ ] `template_path` peger på en organisations-kontrolleret `.typ`-fil
+- [ ] Hvis customisering eksponeres: allow-list validering før kald
+- [ ] `font_path` peger på read-only mappe (ingen brugerskrivning)
+- [ ] `ignore_system_fonts = TRUE` for reproducerbar rendering
+- [ ] Output-stier validerede (ingen path traversal)
+- [ ] Error messages eksponerer ikke template- eller filsystem-internals
+
+## Se også
+
+- `vignette("chart-types")` — vælg charttype før eksport
+- `?bfh_export_pdf` — `\section{Security}` med fuld trust-rationale
+- `?bfh_create_export_session` — batch-session security note
+- BFHcharts issue #218 — security boundary discussion

--- a/vignettes/targets-and-percent.Rmd
+++ b/vignettes/targets-and-percent.Rmd
@@ -1,0 +1,208 @@
+---
+title: "Mål-værdier og procent-akser"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Mål-værdier og procent-akser}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.width = 7,
+  fig.height = 4
+)
+```
+
+## Den hyppigste fejl: 2% bliver til 200%
+
+Før BFHcharts 0.9.0 producerede dette stille en misvisende graf:
+
+```r
+bfh_qic(data, ...,
+  y_axis_unit = "percent",
+  target_value = 2.0,                    # Brugerens hensigt: "2%"
+  target_text = "↓ Mål: 2%"
+)
+```
+
+`bfh_qic()` plottede target-linjen ved y = 2.0 — som på en procent-akse renderer
+som **200%**. Klinisk konsekvens: et mål der ser ud som umuligt at nå (eller, værre,
+som "altid nået").
+
+Fra v0.9.0 valideres `target_value` mod skalaen implyeret af `multiply`:
+
+| `multiply` | Forventet `target_value` skala | Eksempel |
+|------------|-------------------------------|----------|
+| `1` (default) | Proportion `[0, 1.5]` | `target_value = 0.02` betyder 2% |
+| `100`         | Procent `[0, 150]`     | `target_value = 2.0` betyder 2% |
+
+Validering uden for området kaster en hård fejl med migration-hint.
+
+## Kontrakten i praksis
+
+### Option A: Proportion (default, `multiply = 1`)
+
+Data er proportioner i [0, 1]. Y-aksen formateres med `%`-suffix (BFHcharts
+multiplicerer med 100 ved tegning, men værdier er proportioner internt).
+
+```{r option-a-fixed}
+library(BFHcharts)
+
+data <- data.frame(
+  month = seq(as.Date("2024-01-01"), by = "month", length.out = 12),
+  infections = c(15, 18, 12, 14, 16, 13, 11, 9, 10, 8, 7, 6),
+  discharges = rep(100L, 12)
+)
+
+# multiply = 1 (default), target som proportion
+bfh_qic(data,
+  x = month, y = infections, n = discharges,
+  chart_type = "p",
+  y_axis_unit = "percent",
+  target_value = 0.10,      # 10% — proportion
+  target_text = "↓ Mål: <10%"
+)
+```
+
+### Option B: Procent (`multiply = 100`)
+
+Data og target er begge i procent (0-100 skala). Y-aksen formateres uden konvertering.
+
+```{r option-b-fixed}
+bfh_qic(data,
+  x = month, y = infections, n = discharges,
+  chart_type = "p",
+  y_axis_unit = "percent",
+  multiply = 100,
+  target_value = 10,        # 10% — procent
+  target_text = "↓ Mål: <10%"
+)
+```
+
+Begge giver samme visuelle resultat. Vælg den der matcher hvordan dine data er
+gemt (proportion vs procent).
+
+## Direction-operatorer i `target_text`
+
+`target_text` understøtter directional indicators der **erstatter** target-linjen
+med en pil ved plot-kanten:
+
+| Symbol | Betydning |
+|--------|-----------|
+| `↑`    | Højere er bedre (ingen line, kun pil opad) |
+| `↓`    | Lavere er bedre (ingen line, kun pil nedad) |
+| `<`    | Mål er øvre grænse |
+| `>`    | Mål er nedre grænse |
+
+```{r arrow-target}
+# Pil-target (ingen visible line)
+bfh_qic(data,
+  x = month, y = infections, n = discharges,
+  chart_type = "p",
+  y_axis_unit = "percent",
+  target_value = 0.10,
+  target_text = "↓ Mål: 10%"   # Pil-version
+)
+```
+
+Når `target_text` indeholder `↑`, `↓`, `<`, eller `>`, suppresseres target-linjen
+i plottet for at undgå dobbelt-visualisering. Pilen placeres ved den right-edge
+label-pipeline.
+
+## Hvornår er target en benchmark vs aspiration?
+
+Tre kategorier af mål, hver med forskellig statistisk fortolkning:
+
+### Benchmark (sammenligning)
+
+Mål = ekstern reference (national gennemsnit, regional median). Brug fast linje
+uden directional pil. Ikke en kontrolgrænse — bare en visualiseringsreference.
+
+```{r benchmark, eval = FALSE}
+bfh_qic(data, ...,
+  target_value = 0.12,         # National gennemsnit 12%
+  target_text = "Nationalt gns."
+)
+```
+
+### Aspiration (mål)
+
+Mål = ønsket fremtidig tilstand. Ofte med directional pil (`↑`/`↓`).
+Vis at processen er på vej derhen, eller at fokuseret indsats kræves.
+
+```{r aspiration, eval = FALSE}
+bfh_qic(data, ...,
+  target_value = 0.05,
+  target_text = "↓ Mål Q4 2025: 5%"
+)
+```
+
+### Lower-/upper-limit (kontrakt)
+
+Mål = absolut grænse (regulatorisk, etisk). Kombiner med `<` eller `>` for at
+markere retningen. Punkter der overstiger grænsen er **akut** action-trigger.
+
+```{r limit, eval = FALSE}
+bfh_qic(data, ...,
+  target_value = 0.15,
+  target_text = "< Maks acceptabel: 15%"
+)
+```
+
+## Sanity-check af din konfiguration
+
+Hvis du er i tvivl, sammenlign target-værdi mod data-skala:
+
+```{r sanity, eval = FALSE}
+# Hvad er din data-range?
+range(data$y)     # Hvis [0, 0.2] → multiply = 1, target i samme skala
+range(data$y)     # Hvis [0, 20]  → multiply = 100, target i samme skala
+
+# Validér eksplicit
+stopifnot(
+  target_value >= 0,
+  target_value <= max(data$y) * 2  # Sanity check: target ikke 100x off
+)
+```
+
+## Migration fra pre-0.9.0
+
+```r
+# Gammel kode (silently misvisende):
+bfh_qic(data, ...,
+  y_axis_unit = "percent",
+  target_value = 2.0           # Plottet som 200% på percent-akse
+)
+
+# Ny kode — Option A (anbefalet):
+bfh_qic(data, ...,
+  y_axis_unit = "percent",
+  target_value = 0.02          # 2% som proportion
+)
+
+# Ny kode — Option B (hvis data allerede i procent):
+bfh_qic(data, ...,
+  y_axis_unit = "percent",
+  multiply = 100,
+  target_value = 2.0           # 2% som procent
+)
+```
+
+Valideringsfejlen vil identificere problemet med præcis migrationshjælp:
+
+```
+Error: target_value (2.0) ligger uden for forventet område [0, 1.5]
+for y_axis_unit = 'percent' med multiply = 1.
+Du mente sandsynligvis target_value = 0.02 (2% som proportion)
+eller target_value = 2.0 med multiply = 100 (2% som procent).
+```
+
+## Se også
+
+- `vignette("chart-types")` — vælg charttype først
+- `vignette("phases-and-freeze")` — håndtér interventioner og baseline
+- `?bfh_qic` — `@details` "Percent Target Contract" sektion
+- NEWS for v0.9.0 — fuld breaking-change beskrivelse


### PR DESCRIPTION
## Summary

BFHcharts havde tidligere kun reference-dokumentation via roxygen. README nævnede at "vignettes are planned" men intet blev nogensinde shipped. Kliniske brugere (kvalitetsteams, dataanalytikere) manglede end-to-end guidance på hvilke chart-typer der passer til hvilke spørgsmål, hvordan interventioner håndteres, og hvad target-kontrakten fra v0.9.0 dikterer.

## Fire nye knitr-vignettes

| Vignette | Indhold | Reference |
|----------|---------|-----------|
| `chart-types` | Beslutningstræ fra klinisk spørgsmål til `chart_type`-valg + per-type use cases + sample-size guidance + anti-patterns | Provost & Murray (2011), Mohammed et al. (2008) |
| `phases-and-freeze` | Distinguere `part` (separate centerlinjer per fase) vs `freeze` (fastlåst baseline). Klinisk eksempel: pre/post intervention med frosset baseline | — |
| `targets-and-percent` | Percent-target-kontrakten fra v0.9.0 (#203). Migration fra `target_value = 2.0` på percent-akse (silently 200%) til `target_value = 0.02` eller `multiply = 100`. Direction-operatorer (`↑`, `↓`, `<`, `>`) | NEWS for v0.9.0 |
| `safe-exports` | Sikkerheds-praksis for `inject_assets` + `template_path` (#218). Allow-list-pattern til Shiny. Pre-deploy security checklist | PR #241 |

## Infrastruktur

* `DESCRIPTION`: `VignetteBuilder: knitr` + `Suggests: knitr, rmarkdown`
* `.gitignore`: `doc/` + `Meta/` (build artifacts) blokerer
* `.Rbuildignore`: `^doc$` + `^Meta$` auto-tilføjet af `devtools::build_vignettes()`

Closes #219

## Test plan

- [x] `devtools::build_vignettes()` — alle 4 vignettes builder successfully
- [x] HTML output renders korrekt i RStudio Viewer
- [x] Kode-blokke valideret manuelt
- [x] Eksempler bruger `eval = FALSE` hvor passende for at undgå CI-render-cost (pkg-build kører code blocks der har `eval = TRUE`)
- [ ] **Post-merge**: verificér r-universe / pkgdown site renderer vignettes korrekt
- [ ] **Bruger-feedback**: lad én klinisk SME (kvalitetsteam) review for accuracy + komplethed

## Coordination med andre PRs

* `safe-exports.Rmd` refererer `\section{Security}` fra `bfh_export_pdf()` roxygen — afhænger af PR #241 (`docs: trust-grænse`). Hvis #241 merges først er linket levende.
* `targets-and-percent.Rmd` dokumenterer kontrakten fra v0.9.0 (allerede merged via #203).
* `chart-types.Rmd` dokumenterer denominator-validering fra v0.9.0 (allerede merged via #205).