### PR TITLE
chore(release): bump version til 0.10.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BFHcharts
 Title: SPC Visualization for Healthcare Quality Improvement
-Version: 0.10.4
+Version: 0.10.5
 Authors@R: c(
     person(
       "Johan", "Reventlow",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# BFHcharts 0.10.5 (development)
+# BFHcharts 0.10.5
 
 ## Bug fixes
 


### PR DESCRIPTION
## Summary

Release-bump efter sekventiel merge af 8 cleanup/feature/test/docs PRs til develop:

| PR | Issue | Beskrivelse |
|----|-------|-------------|
| #238 | #217 #204 | rename create_spc_chart.R → bfh_qic.R + docs cleanup |
| #239 | #215 | dependency cleanup, dead-code removal, repo-rod hygiene |
| #240 | #200 | DRY refactor af font-warning handlers |
| #241 | #218 | docs: trust-grænse for inject_assets/template_path |
| #242 | #202 | fix: Mari/Arial font-aliaser via .onLoad() |
| #243 | #208 | numerisk verifikation for xbar/s/mr/t/g/pp/up (39 tests) |
| #244 | #210 | scheduled live Quarto/Typst render-tests CI |
| #245 | #219 | fire kliniske vignettes |

## Ændring

* `DESCRIPTION`: `Version: 0.10.4` → `0.10.5`
* `NEWS.md`: header "0.10.5 (development)" → "0.10.5"

## Test plan

- [x] `devtools::test()` på combined develop-state — 2533/2533 PASS / 0 FAIL / 44 SKIP
- [x] Pre-push hook kørte fuld test-suite (~127s, alle grøn)

## Næste skridt

Efter merge til develop: åbn separat develop → main PR for release. Tag-release workflow opretter `v0.10.5` automatisk når DESCRIPTION-version matcher.