### PR TITLE
fix(ci): tilføj manglende deps til render-tests workflow

### DIFF
--- a/.github/workflows/render-tests.yaml
+++ b/.github/workflows/render-tests.yaml
@@ -108,13 +108,16 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pdftools any::rcmdcheck
+          extra-packages: any::pdftools any::rcmdcheck any::pkgload any::testthat
           needs: check
 
       - name: Run render-gate'd tests
         run: |
           options(crayon.enabled = TRUE)
-          devtools::load_all()
+          # pkgload::load_all() er letvaegtsalternativ til devtools::load_all()
+          # uden devtools' ekstra dev-dependencies (hvilket kraever ekstra
+          # CI-installtid).
+          pkgload::load_all(".", quiet = TRUE)
           res <- testthat::test_dir(
             "tests/testthat",
             filter = "export|integration-export|utils_typst|utils_quarto|pdf-output|security-export",


### PR DESCRIPTION
## Problem

Render-tests workflow fra PR #244 fejler i CI med:

\`\`\`
Error in loadNamespace(x) : there is no package called 'devtools'
\`\`\`

`devtools` er ikke installeret af `setup-r-dependencies` eftersom det ikke er listet i `extra-packages` og ikke er en BFHcharts-dependency. Workflow brød på første kørsel mod release-PR #247.

## Fix

* Skift `devtools::load_all()` → `pkgload::load_all()` (letvægt-alternativ uden devtools' ekstra dev-deps; pkgload er kerne-mekanismen som devtools' load_all kalder internt)
* Tilføj `pkgload` + `testthat` til `extra-packages` så de er garanteret tilgængelige uafhængigt af DESCRIPTION's Suggests-deklaration

## Test plan

- [ ] **CI**: workflow kører successfully på denne PR (kræver Quarto, kun denne workflow på render-tests-trigger paths)
- [ ] **Manual**: efter merge til develop verificér at release-PR #247's render-tests checks bliver grønne