### PR TITLE
fix(ci): bump Quarto til 1.6.40 (Typst 0.13+ for --ignore-system-fonts)

### DIFF
--- a/.github/workflows/render-tests.yaml
+++ b/.github/workflows/render-tests.yaml
@@ -93,7 +93,10 @@ jobs:
 
       - uses: quarto-dev/quarto-actions/setup@v2
         with:
-          version: "1.5.57"
+          # Quarto 1.6+ kraeves: BFHcharts bruger \`--ignore-system-fonts\`
+          # (Typst 0.13+-flag) via bfh_compile_typst(). Quarto 1.5.x ships
+          # Typst 0.11 som ikke understoetter flaget.
+          version: "1.6.40"
 
       - name: Verify Quarto installation
         run: |


### PR DESCRIPTION
## Problem

Render-tests workflow fejlede på release-PR #247 efter hotfix #248 var merged:

\`\`\`
error: unexpected argument '--ignore-system-fonts' found
\`\`\`

BFHcharts' `bfh_compile_typst()` kalder `quarto typst compile ... --ignore-system-fonts`. Det er et **Typst 0.13+**-flag. Quarto 1.5.x ships Typst 0.11 som ikke understøtter det.

`ignore_system_fonts = TRUE` blev default i v0.10.0 (#227) for konsistent rendering på tværs af miljøer.

## Fix

Bump Quarto-version i `.github/workflows/render-tests.yaml` fra `1.5.57` → `1.6.40`. Quarto 1.6.x ships Typst 0.13.x.

Inline-kommentar i workflow forklarer rationale for fremtidige bumps.

## Test plan

- [ ] **CI**: workflow kører successfully på denne PR (men render-tests fyrer kun på path-match — denne PR ændrer kun `.github/workflows/render-tests.yaml` selv, så vil trigge)
- [ ] **Post-merge**: verificér at release-PR #247's render-tests checks bliver grønne