### PR TITLE
fix(ci): skift til Quarto pre-release for Typst 0.13+ support

### DIFF
--- a/.github/workflows/render-tests.yaml
+++ b/.github/workflows/render-tests.yaml
@@ -93,10 +93,12 @@ jobs:
 
       - uses: quarto-dev/quarto-actions/setup@v2
         with:
-          # Quarto 1.6+ kraeves: BFHcharts bruger \`--ignore-system-fonts\`
-          # (Typst 0.13+-flag) via bfh_compile_typst(). Quarto 1.5.x ships
-          # Typst 0.11 som ikke understoetter flaget.
-          version: "1.6.40"
+          # BFHcharts bruger \`--ignore-system-fonts\` (Typst 0.13+-flag) via
+          # bfh_compile_typst(). Quarto 1.5.x og 1.6.x ships begge Typst 0.11
+          # som ikke understoetter flaget. Quarto 1.7.x ships Typst 0.13.x.
+          # Bruger "pre-release"-channel indtil 1.7.x bliver stable, hvorefter
+          # vi kan pinne en specifik version.
+          version: "pre-release"
 
       - name: Verify Quarto installation
         run: |


### PR DESCRIPTION
## Problem

PR #249 (Quarto 1.6.40) løste ikke render-tests fejlen. CI-log fra #247:

\`\`\`
Quarto 1.6.40
Typst version 0.11.0: OK
...
running command 'quarto typst compile ... --ignore-system-fonts'
error: unexpected argument '--ignore-system-fonts' found
\`\`\`

Quarto 1.6.40 ships **Typst 0.11.0**, ikke 0.13.0 som jeg antog. `--ignore-system-fonts` blev tilføjet til Typst CLI i 0.13.

Quarto 1.7.x ships Typst 0.13.x, men 1.7.x er endnu i pre-release-channel.

## Fix

Skift fra `version: "1.6.40"` til `version: "pre-release"` i render-tests workflow setup.

Inline-kommentar opdateret med Typst-version-mapping og note om at pinne specifik 1.7.x når den bliver stable.

## Test plan

- [ ] **CI**: workflow self-tester på denne PR (path-filter inkluderer workflow-filen)
- [ ] **Post-merge**: re-trigger #247's render-tests via develop-update; verificér Typst-version i log er ≥ 0.13