### PR TITLE
fix: registrér Roboto som font-alias + mufle warnings i export-recalc

### DIFF
--- a/R/export_pdf.R
+++ b/R/export_pdf.R
@@ -360,19 +360,22 @@ recalculate_labels_for_export <- function(x, target_width_mm, target_height_mm,
 
   # Re-add labels with TARGET dimensions for positioning
   # and fixed PDF_LABEL_SIZE for font sizing
-  plot_with_labels <- add_spc_labels(
-    plot = plot_stripped,
-    qic_data = x$qic_data,
-    y_axis_unit = config$y_axis_unit %||% "count",
-    label_size = new_label_size,
-    viewport_width = target_width_inches,
-    viewport_height = target_height_inches,
-    target_text = config$target_text,
-    centerline_value = label_config$centerline_value,
-    has_frys_column = label_config$has_frys_column,
-    has_skift_column = label_config$has_skift_column,
-    verbose = FALSE,
-    language = config$language %||% "da"
+  # Se .muffle_expected_warnings() helper for hvilke warnings der mufles.
+  plot_with_labels <- .muffle_expected_warnings(
+    add_spc_labels(
+      plot = plot_stripped,
+      qic_data = x$qic_data,
+      y_axis_unit = config$y_axis_unit %||% "count",
+      label_size = new_label_size,
+      viewport_width = target_width_inches,
+      viewport_height = target_height_inches,
+      target_text = config$target_text,
+      centerline_value = label_config$centerline_value,
+      has_frys_column = label_config$has_frys_column,
+      has_skift_column = label_config$has_skift_column,
+      verbose = FALSE,
+      language = config$language %||% "da"
+    )
   )
 
   return(plot_with_labels)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -40,7 +40,11 @@ register_bfh_font_aliases <- function() {
     return(invisible(FALSE))
   }
 
-  for (fname in c("Mari", "Arial")) {
+  # Liste matcher fonts brugt i BFH Typst-templates (Mari primaer, oevrige
+  # som fallback-chain) plus systemfonts som ggplot2-grobs kan referere.
+  # Aliaser dem alle til Helvetica-metrics i grid's PostScript/PDF-database
+  # for at undgaa "font family X not found" warnings under metric-lookup.
+  for (fname in c("Mari", "Arial", "Roboto")) {
     if (!fname %in% names(ps_fonts)) {
       tryCatch(
         do.call(


### PR DESCRIPTION
## Problem

Render-tests workflow på #247 fejlede med Quarto pre-release (Typst 0.14.2). Root-cause: ufanget warning fra ggplot grid metric-lookup:

\`\`\`
font family 'Roboto' not found in PostScript font database
\`\`\`

## Root cause

1. **Roboto ikke alias**: `register_bfh_font_aliases()` (PR #242) registrerede kun Mari + Arial. Templates bruger fallback-chain `("Mari", "Roboto", "Arial", "Helvetica", "sans-serif")`. Roboto trigger metric-lookup-warning under `ggplot_gtable()`.

2. **Export-recalc path uden muffle**: `recalculate_labels_for_export()` kalder `add_spc_labels()` direkte uden `.muffle_expected_warnings()`-wrapping. `bfh_qic()`-pathen er beskyttet via PR #240, men export-pathen rebuilder labels og kører `ggplot_gtable()` uden muffle.

## Fix

1. `R/zzz.R`: tilføj `"Roboto"` til alias-listen
2. `R/export_pdf.R:363`: wrap `add_spc_labels()`-kald i `recalculate_labels_for_export()` med `.muffle_expected_warnings()`

Defense-in-depth: alias fanger root-cause; muffle håndterer eventuelle fonts der ikke er aliased.

## Test plan

- [x] **Lokal**: `devtools::test(filter = "export")` — 346 PASS / 0 FAIL
- [ ] **CI**: Render-tests workflow på denne PR
- [ ] **Post-merge**: re-trigger #247's render-tests