### PR TITLE
fix(ci): begræns render-tests til cron + workflow_dispatch

### DIFF
--- a/.github/workflows/render-tests.yaml
+++ b/.github/workflows/render-tests.yaml
@@ -24,27 +24,19 @@ on:
     # Hver mandag kl. 06:00 UTC (07:00 CET / 08:00 CEST)
     - cron: "0 6 * * 1"
   workflow_dispatch:
-  push:
-    branches: [main, develop]
-    paths:
-      - "R/export*.R"
-      - "R/utils_typst*.R"
-      - "R/utils_quarto*.R"
-      - "R/utils_export*.R"
-      - "inst/templates/typst/**"
-      - "tests/testthat/test-export*.R"
-      - "tests/testthat/test-integration-export*.R"
-      - "tests/testthat/test-utils_typst*.R"
-      - "tests/testthat/test-utils_quarto*.R"
-      - ".github/workflows/render-tests.yaml"
-  pull_request:
-    branches: [main, develop]
-    paths:
-      - "R/export*.R"
-      - "R/utils_typst*.R"
-      - "R/utils_quarto*.R"
-      - "R/utils_export*.R"
-      - "inst/templates/typst/**"
+  # NOTE: pull_request og push triggers er fjernet bevidst. Render-tests
+  # forudsaetter at Mari (proprietaer) er tilgaengelig som font, eller at
+  # \`--ignore-system-fonts\` deaktiveres. Hverken er muligt paa offentlige
+  # GitHub-runners uden enten:
+  #   1. Encrypted Mari-fonts via repository secrets, eller
+  #   2. Test-flag der saetter ignore_system_fonts=FALSE og injekterer
+  #      open fallback-fonts (DejaVu/Liberation) via font_path
+  # Indtil en af de to loesninger er paa plads, koerer render-tests kun
+  # scheduled (ugentligt) for at fange catastrophic-regression -- ikke
+  # som PR-blocking gate. Konsekvensen: regressioner i Typst-rendering kan
+  # slippe igennem til main mellem ugentlige cron-koerselser. Mitigation:
+  # manuel quality-check af PDF-output paa release-PRs.
+  # Tracking: (TODO -- aaben follow-up issue for permanent fix)
 
 permissions: read-all
 


### PR DESCRIPTION
## Problem

Render-tests workflow har vist sig **upraktisk som PR-gate** uden adgang til Mari (proprietær font) på CI-runners:

* Hvis `--ignore-system-fonts = TRUE` (production default) → Typst kan ikke finde nogen font (Mari/Roboto/Arial/Helvetica/sans-serif alle blokeret) → exit 1
* Hvis `--ignore-system-fonts = FALSE` → fungerer, men det er ikke det produktion-flow brugere ser

Forsøg på at fixe via:
* PR #248: tilføj `pkgload`/`testthat` deps ✅ (men afslørede næste lag)
* PR #249: bump Quarto 1.5→1.6 ✅ (men 1.6 ships Typst 0.11, ikke 0.13)
* PR #253: skift til pre-release Quarto (Typst 0.14.2) ✅ (men afslørede font-rendering issue)
* PR #254: registrér Roboto + mufle warnings ✅ (men Mari-font missing fra CI runner)

Næste fix ville kræve enten:
1. Encrypted Mari-fonts via repository secrets
2. Test-flag der sætter `ignore_system_fonts = FALSE` og injekterer open fallback-fonts via font_path

Begge er substantial infrastruktur-arbejde der ikke skal gate v0.10.5 release.

## Fix

* Fjern `pull_request` og `push` triggers fra `render-tests.yaml`
* Behold `schedule` (ugentlig cron, mandag 06:00 UTC) + `workflow_dispatch` (manuel)
* Inline-kommentar dokumenterer rationale + krav for genaktivering

## Konsekvens

Regressioner i Typst-rendering kan slippe igennem til main mellem ugentlige cron-kørsler. Mitigation: manuel quality-check af PDF-output på release-PRs.

## Follow-up

TODO: åbn opfølgende issue der specificerer permanent fix (encrypted Mari secrets eller font_path-injection-test-mode).

## Test plan

- [x] Pre-push hook: 2494 PASS / 0 FAIL
- [ ] Post-merge: verificér at #247 release-PR ikke længere har render-tests checks