### PR TITLE
docs(bfh_qic): ret print.summary-docs og tilføj manglende charttyper

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,24 @@
+# BFHcharts (development)
+
+## Dokumentation
+
+* **`bfh_qic()` `print.summary`-dokumentation afspejler nu v0.11.0-fjernelsen.**
+  `@param print.summary` beskrev fortsat parameteren som "deprecated, will warn",
+  selvom runtime hard-errorer siden v0.11.0. Dokumentationen er opdateret til
+  at angive at kald med `print.summary = TRUE` giver en fejl, med
+  migrationsvejledning til det moderne S3-API (`result$summary`).
+  Eksempler 20-22 i `?bfh_qic` er omskrevet til at bruge `bfh_qic_result`-objektet
+  direkte fremfor det fjernede `print.summary`-argument.
+  (#update-print-summary-removal-docs)
+
+* **`bfh_qic()` `@param chart_type` og `@details Chart Types` dokumenterer nu
+  alle 12 validerede charttyper.** `mr` (Moving Range), `pp` (Laney-justeret
+  proportioner) og `up` (Laney-justeret rater) var accepteret af validatoren men
+  fraværende i public docs. Alle tre er nu dokumenteret med brugsvejledning,
+  inkl. hvornår Laney-varianterne (`pp`/`up`) er relevante (store denominatorer,
+  n > 1000 per subgruppe). To nye eksempler tilføjet: `pp`-chart og `mr`-chart
+  parret med I-chart. (#complete-chart-type-public-docs)
+
 # BFHcharts 0.11.0
 
 ## Breaking changes

--- a/R/bfh_qic.R
+++ b/R/bfh_qic.R
@@ -20,7 +20,7 @@ NULL
 #' @param x Name of x-axis column (unquoted, NSE). Usually date/time column.
 #' @param y Name of y-axis column (unquoted, NSE). The measurement variable.
 #' @param n Name of denominator column for ratio charts (optional, unquoted, NSE)
-#' @param chart_type Chart type: "run", "i", "p", "c", "u", "xbar", "s", "t", "g"
+#' @param chart_type Chart type: "run", "i", "mr", "p", "pp", "u", "up", "c", "g", "xbar", "s", "t"
 #' @param y_axis_unit Unit type: "count", "percent", "rate", or "time"
 #' @param chart_title Plot title (optional)
 #' @param target_value Numeric target value (optional)
@@ -43,11 +43,11 @@ NULL
 #' @param subtitle Plot subtitle text (default: NULL for no subtitle)
 #' @param caption Plot caption text (default: NULL for no caption)
 #' @param return.data Logical. If TRUE, return the raw qic data frame instead of bfh_qic_result object. If FALSE (default), return bfh_qic_result S3 object. Legacy parameter maintained for backwards compatibility.
-#' @param print.summary \strong{DEPRECATED.} Logical. The summary is now always included in the bfh_qic_result object. Access it via \code{result$summary}. This parameter will be removed in a future version. When TRUE, triggers deprecation warning and returns legacy list(plot, summary) format.
+#' @param print.summary \strong{REMOVED in v0.11.0.} Calling with \code{print.summary = TRUE} raises an error. Use \code{return.data = TRUE} and access \code{result$qic_summary}, or use the default \code{bfh_qic_result} object and access \code{result$summary} directly.
 #' @param language Character string specifying output language. One of \code{"da"} (Danish, default) or \code{"en"} (English). Passed through to analysis and label generation. Default \code{"da"} preserves backward compatibility.
 #'
 #' @return
-#' - Default (return.data = FALSE, print.summary = FALSE): \code{bfh_qic_result} S3 object with components:
+#' - Default (return.data = FALSE): \code{bfh_qic_result} S3 object with components:
 #'   \itemize{
 #'     \item \code{$plot}: ggplot2 object with the SPC chart
 #'     \item \code{$summary}: data.frame with SPC statistics
@@ -55,8 +55,6 @@ NULL
 #'     \item \code{$config}: list with original function parameters
 #'   }
 #' - return.data = TRUE: data.frame with qic calculations (legacy behavior)
-#' - print.summary = TRUE: list(plot = ggplot, summary = data.frame) (deprecated, will warn)
-#' - Both TRUE: list(data = data.frame, summary = data.frame) (deprecated, will warn)
 #'
 #' @details
 #' **Helper map (interne orkestreringsfunktioner):**
@@ -71,13 +69,21 @@ NULL
 #' **Chart Types:**
 #' - **run**: Run chart (no control limits)
 #' - **i**: I-chart (individuals)
+#' - **mr**: Moving Range chart — measures point-to-point variability.
+#'   Typically paired with an I-chart to characterise both process level (I)
+#'   and short-term variation (MR).
 #' - **p**: P-chart (proportions, requires n)
-#' - **c**: C-chart (counts)
+#' - **pp**: P-prime chart (Laney-adjusted proportions) — use instead of `p`
+#'   when denominators are very large (n > 1000 per subgroup) and standard
+#'   control limits become artificially tight due to over-dispersion. Requires n.
 #' - **u**: U-chart (rates, requires n)
+#' - **up**: U-prime chart (Laney-adjusted rates) — same rationale as `pp`,
+#'   applied to count rates. Requires n.
+#' - **c**: C-chart (counts)
+#' - **g**: G-chart (geometric)
 #' - **xbar**: X-bar chart
 #' - **s**: S-chart
 #' - **t**: T-chart (time between events)
-#' - **g**: G-chart (geometric)
 #'
 #' **Y-Axis Units:**
 #' - **count**: Integer counts with K/M notation
@@ -439,33 +445,30 @@ NULL
 #'   y = infections,
 #'   chart_type = "i",
 #'   y_axis_unit = "count",
-#'   chart_title = "Infections - With Summary",
-#'   print.summary = TRUE # Return list(plot, summary)
+#'   chart_title = "Infections - With Summary"
 #' )
 #'
 #' # Access the plot
 #' result$plot
 #'
-#' # Access the summary statistics (Danish column names)
+#' # Access the summary statistics (Danish column names) via S3 object
 #' print(result$summary)
 #' # Columns: fase, antal_observationer, anvendelige_observationer,
 #' #          centerlinje, nedre_kontrolgraense, oevre_kontrolgraense,
 #' #          laengste_loeb, antal_kryds, loebelaengde_signal, sigma_signal
 #'
-#' # Example 21: Get both raw data and summary
+#' # Example 21: Get both raw qic data and summary via S3 object
 #' result <- bfh_qic(
 #'   data = data,
 #'   x = month,
 #'   y = infections,
 #'   chart_type = "i",
 #'   y_axis_unit = "count",
-#'   part = c(12), # Split into phases
-#'   return.data = TRUE,
-#'   print.summary = TRUE # Return list(data, summary)
+#'   part = c(12) # Split into phases
 #' )
 #'
-#' # Access raw qic data
-#' result$data
+#' # Access raw qic data (all qicharts2 calculations)
+#' result$qic_data
 #'
 #' # Access summary statistics (one row per phase)
 #' result$summary
@@ -481,11 +484,10 @@ NULL
 #'   chart_type = "p",
 #'   y_axis_unit = "percent",
 #'   chart_title = "Infection Rate - Multi-phase Analysis",
-#'   part = c(12),
-#'   print.summary = TRUE
+#'   part = c(12)
 #' )
 #'
-#' # Extract key metrics for reporting
+#' # Extract key metrics for reporting via result$summary
 #' summary_stats <- result$summary
 #' cat("Fase 1 centerlinje:", summary_stats$centerlinje[1], "%\n")
 #' cat("Fase 2 centerlinje:", summary_stats$centerlinje[2], "%\n")
@@ -494,6 +496,41 @@ NULL
 #' if (summary_stats$sigma_signal[2]) {
 #'   cat("VIGTIG: Special cause variation detekteret i fase 2!\n")
 #' }
+#'
+#' # Example 23: P-prime chart for large denominators (Laney-adjusted)
+#' data_large_n <- data.frame(
+#'   month = seq(as.Date("2024-01-01"), by = "month", length.out = 24),
+#'   events = rpois(24, lambda = 50),
+#'   population = rpois(24, lambda = 5000) # Very large denominators
+#' )
+#' plot_pp <- bfh_qic(
+#'   data = data_large_n,
+#'   x = month,
+#'   y = events,
+#'   n = population,
+#'   chart_type = "pp", # Laney-adjusted: prevents artificially tight limits
+#'   y_axis_unit = "percent",
+#'   chart_title = "Event Rate (Laney P-prime)"
+#' )
+#'
+#' # Example 24: Moving Range chart paired with I-chart
+#' # Use MR-chart alongside I-chart for full process variation characterisation
+#' plot_i <- bfh_qic(
+#'   data = data,
+#'   x = month,
+#'   y = infections,
+#'   chart_type = "i",
+#'   y_axis_unit = "count",
+#'   chart_title = "Infections - Process Level (I-chart)"
+#' )
+#' plot_mr <- bfh_qic(
+#'   data = data,
+#'   x = month,
+#'   y = infections,
+#'   chart_type = "mr", # Moving Range: short-term variation
+#'   y_axis_unit = "count",
+#'   chart_title = "Infections - Short-term Variation (MR-chart)"
+#' )
 #' }
 bfh_qic <- function(data,
                     x,

--- a/man/bfh_qic.Rd
+++ b/man/bfh_qic.Rd
@@ -45,7 +45,7 @@ bfh_qic(
 
 \item{n}{Name of denominator column for ratio charts (optional, unquoted, NSE)}
 
-\item{chart_type}{Chart type: "run", "i", "p", "c", "u", "xbar", "s", "t", "g"}
+\item{chart_type}{Chart type: "run", "i", "mr", "p", "pp", "u", "up", "c", "g", "xbar", "s", "t"}
 
 \item{y_axis_unit}{Unit type: "count", "percent", "rate", or "time"}
 
@@ -91,13 +91,13 @@ bfh_qic(
 
 \item{return.data}{Logical. If TRUE, return the raw qic data frame instead of bfh_qic_result object. If FALSE (default), return bfh_qic_result S3 object. Legacy parameter maintained for backwards compatibility.}
 
-\item{print.summary}{\strong{DEPRECATED.} Logical. The summary is now always included in the bfh_qic_result object. Access it via \code{result$summary}. This parameter will be removed in a future version. When TRUE, triggers deprecation warning and returns legacy list(plot, summary) format.}
+\item{print.summary}{\strong{REMOVED in v0.11.0.} Calling with \code{print.summary = TRUE} raises an error. Use \code{return.data = TRUE} and access \code{result$qic_summary}, or use the default \code{bfh_qic_result} object and access \code{result$summary} directly.}
 
 \item{language}{Character string specifying output language. One of \code{"da"} (Danish, default) or \code{"en"} (English). Passed through to analysis and label generation. Default \code{"da"} preserves backward compatibility.}
 }
 \value{
 \itemize{
-\item Default (return.data = FALSE, print.summary = FALSE): \code{bfh_qic_result} S3 object with components:
+\item Default (return.data = FALSE): \code{bfh_qic_result} S3 object with components:
 \itemize{
 \item \code{$plot}: ggplot2 object with the SPC chart
 \item \code{$summary}: data.frame with SPC statistics
@@ -105,8 +105,6 @@ bfh_qic(
 \item \code{$config}: list with original function parameters
 }
 \item return.data = TRUE: data.frame with qic calculations (legacy behavior)
-\item print.summary = TRUE: list(plot = ggplot, summary = data.frame) (deprecated, will warn)
-\item Both TRUE: list(data = data.frame, summary = data.frame) (deprecated, will warn)
 }
 }
 \description{
@@ -133,13 +131,21 @@ entire workflow from raw data to finished plot with intelligent labels.
 \itemize{
 \item \strong{run}: Run chart (no control limits)
 \item \strong{i}: I-chart (individuals)
+\item \strong{mr}: Moving Range chart — measures point-to-point variability.
+Typically paired with an I-chart to characterise both process level (I)
+and short-term variation (MR).
 \item \strong{p}: P-chart (proportions, requires n)
-\item \strong{c}: C-chart (counts)
+\item \strong{pp}: P-prime chart (Laney-adjusted proportions) — use instead of \code{p}
+when denominators are very large (n > 1000 per subgroup) and standard
+control limits become artificially tight due to over-dispersion. Requires n.
 \item \strong{u}: U-chart (rates, requires n)
+\item \strong{up}: U-prime chart (Laney-adjusted rates) — same rationale as \code{pp},
+applied to count rates. Requires n.
+\item \strong{c}: C-chart (counts)
+\item \strong{g}: G-chart (geometric)
 \item \strong{xbar}: X-bar chart
 \item \strong{s}: S-chart
 \item \strong{t}: T-chart (time between events)
-\item \strong{g}: G-chart (geometric)
 }
 
 \strong{Y-Axis Units:}
@@ -516,33 +522,30 @@ result <- bfh_qic(
   y = infections,
   chart_type = "i",
   y_axis_unit = "count",
-  chart_title = "Infections - With Summary",
-  print.summary = TRUE # Return list(plot, summary)
+  chart_title = "Infections - With Summary"
 )
 
 # Access the plot
 result$plot
 
-# Access the summary statistics (Danish column names)
+# Access the summary statistics (Danish column names) via S3 object
 print(result$summary)
 # Columns: fase, antal_observationer, anvendelige_observationer,
 #          centerlinje, nedre_kontrolgraense, oevre_kontrolgraense,
 #          laengste_loeb, antal_kryds, loebelaengde_signal, sigma_signal
 
-# Example 21: Get both raw data and summary
+# Example 21: Get both raw qic data and summary via S3 object
 result <- bfh_qic(
   data = data,
   x = month,
   y = infections,
   chart_type = "i",
   y_axis_unit = "count",
-  part = c(12), # Split into phases
-  return.data = TRUE,
-  print.summary = TRUE # Return list(data, summary)
+  part = c(12) # Split into phases
 )
 
-# Access raw qic data
-result$data
+# Access raw qic data (all qicharts2 calculations)
+result$qic_data
 
 # Access summary statistics (one row per phase)
 result$summary
@@ -558,11 +561,10 @@ result <- bfh_qic(
   chart_type = "p",
   y_axis_unit = "percent",
   chart_title = "Infection Rate - Multi-phase Analysis",
-  part = c(12),
-  print.summary = TRUE
+  part = c(12)
 )
 
-# Extract key metrics for reporting
+# Extract key metrics for reporting via result$summary
 summary_stats <- result$summary
 cat("Fase 1 centerlinje:", summary_stats$centerlinje[1], "\%\n")
 cat("Fase 2 centerlinje:", summary_stats$centerlinje[2], "\%\n")
@@ -571,5 +573,40 @@ cat("Forbedring:", summary_stats$centerlinje[1] - summary_stats$centerlinje[2], 
 if (summary_stats$sigma_signal[2]) {
   cat("VIGTIG: Special cause variation detekteret i fase 2!\n")
 }
+
+# Example 23: P-prime chart for large denominators (Laney-adjusted)
+data_large_n <- data.frame(
+  month = seq(as.Date("2024-01-01"), by = "month", length.out = 24),
+  events = rpois(24, lambda = 50),
+  population = rpois(24, lambda = 5000) # Very large denominators
+)
+plot_pp <- bfh_qic(
+  data = data_large_n,
+  x = month,
+  y = events,
+  n = population,
+  chart_type = "pp", # Laney-adjusted: prevents artificially tight limits
+  y_axis_unit = "percent",
+  chart_title = "Event Rate (Laney P-prime)"
+)
+
+# Example 24: Moving Range chart paired with I-chart
+# Use MR-chart alongside I-chart for full process variation characterisation
+plot_i <- bfh_qic(
+  data = data,
+  x = month,
+  y = infections,
+  chart_type = "i",
+  y_axis_unit = "count",
+  chart_title = "Infections - Process Level (I-chart)"
+)
+plot_mr <- bfh_qic(
+  data = data,
+  x = month,
+  y = infections,
+  chart_type = "mr", # Moving Range: short-term variation
+  y_axis_unit = "count",
+  chart_title = "Infections - Short-term Variation (MR-chart)"
+)
 }
 }

--- a/tests/testthat/test-public-api-contract.R
+++ b/tests/testthat/test-public-api-contract.R
@@ -132,18 +132,43 @@ test_that("bfh_qic() result$qic_data anhoej.signal is never NA", {
 
 # ----------------------------------------------------------------------------
 # Regression: print.summary removal documentation (update-print-summary-removal-docs)
-# Verificerer at man/bfh_qic.Rd ikke beskriver print.summary som deprecated-med-advarsel
-# og at @examples ikke demonstrerer det fjernede argument.
+# Verificerer at man/bfh_qic.Rd ikke beskriver print.summary som
+# deprecated-med-advarsel og at @examples ikke demonstrerer det fjernede argument.
+# Bruger in-tree man/ saa testen koerer under baade devtools::test() og R CMD check.
 # ----------------------------------------------------------------------------
 
+.rd_path_bfh_qic <- function() {
+  # Prioriter installeret pakke; fald tilbage til in-tree man/ (devtools::test)
+  installed <- system.file("man", "bfh_qic.Rd", package = "BFHcharts")
+  if (nzchar(installed) && file.exists(installed)) {
+    return(installed)
+  }
+
+  # In-tree: tests/testthat/ er to niveauer under package root
+  pkg_root_candidate <- tryCatch(
+    normalizePath(file.path(test_path(), "..", ".."), mustWork = FALSE),
+    error = function(e) NULL
+  )
+  if (!is.null(pkg_root_candidate)) {
+    candidate <- file.path(pkg_root_candidate, "man", "bfh_qic.Rd")
+    if (file.exists(candidate)) {
+      return(candidate)
+    }
+  }
+  NULL
+}
+
 test_that("bfh_qic Rd does not describe print.summary as 'deprecated, will warn'", {
-  rd_path <- system.file("man", "bfh_qic.Rd", package = "BFHcharts")
-  skip_if(nchar(rd_path) == 0, "Package not installed — run devtools::install()")
+  rd_path <- .rd_path_bfh_qic()
+  skip_if(is.null(rd_path), "Cannot locate man/bfh_qic.Rd")
 
   rd_content <- readLines(rd_path, warn = FALSE)
   expect_false(
     any(grepl("deprecated, will warn", rd_content, fixed = TRUE)),
-    info = "Rd still contains legacy 'deprecated, will warn' phrasing for print.summary"
+    info = paste0(
+      "Rd still contains legacy 'deprecated, will warn' ",
+      "phrasing for print.summary"
+    )
   )
   expect_false(
     any(grepl("triggers deprecation warning", rd_content, fixed = TRUE)),
@@ -152,19 +177,19 @@ test_that("bfh_qic Rd does not describe print.summary as 'deprecated, will warn'
 })
 
 test_that("bfh_qic Rd examples do not demonstrate print.summary = TRUE", {
-  rd_path <- system.file("man", "bfh_qic.Rd", package = "BFHcharts")
-  skip_if(nchar(rd_path) == 0, "Package not installed — run devtools::install()")
+  rd_path <- .rd_path_bfh_qic()
+  skip_if(is.null(rd_path), "Cannot locate man/bfh_qic.Rd")
 
   rd_lines <- readLines(rd_path, warn = FALSE)
 
-  # Find the \examples{} block
+  # Find the \\examples{} block
   examples_start <- which(grepl("^\\\\examples\\{", rd_lines))
   if (length(examples_start) == 0) skip("No \\examples{} block found in Rd")
 
   examples_section <- rd_lines[examples_start:length(rd_lines)]
   expect_false(
     any(grepl("print.summary\\s*=\\s*TRUE", examples_section, perl = TRUE)),
-    info = "Rd examples still demonstrate print.summary = TRUE (removed in v0.11.0)"
+    info = "Rd examples demonstrate print.summary = TRUE (removed in v0.11.0)"
   )
 })
 
@@ -174,8 +199,8 @@ test_that("bfh_qic Rd examples do not demonstrate print.summary = TRUE", {
 # ----------------------------------------------------------------------------
 
 test_that("bfh_qic Rd documents all validated chart types", {
-  rd_path <- system.file("man", "bfh_qic.Rd", package = "BFHcharts")
-  skip_if(nchar(rd_path) == 0, "Package not installed — run devtools::install()")
+  rd_path <- .rd_path_bfh_qic()
+  skip_if(is.null(rd_path), "Cannot locate man/bfh_qic.Rd")
 
   rd_content <- paste(readLines(rd_path, warn = FALSE), collapse = "\n")
 

--- a/tests/testthat/test-public-api-contract.R
+++ b/tests/testthat/test-public-api-contract.R
@@ -129,3 +129,60 @@ test_that("bfh_qic() result$qic_data anhoej.signal is never NA", {
     info = "anhoej.signal contains NA values (should always be TRUE/FALSE)"
   )
 })
+
+# ----------------------------------------------------------------------------
+# Regression: print.summary removal documentation (update-print-summary-removal-docs)
+# Verificerer at man/bfh_qic.Rd ikke beskriver print.summary som deprecated-med-advarsel
+# og at @examples ikke demonstrerer det fjernede argument.
+# ----------------------------------------------------------------------------
+
+test_that("bfh_qic Rd does not describe print.summary as 'deprecated, will warn'", {
+  rd_path <- system.file("man", "bfh_qic.Rd", package = "BFHcharts")
+  skip_if(nchar(rd_path) == 0, "Package not installed — run devtools::install()")
+
+  rd_content <- readLines(rd_path, warn = FALSE)
+  expect_false(
+    any(grepl("deprecated, will warn", rd_content, fixed = TRUE)),
+    info = "Rd still contains legacy 'deprecated, will warn' phrasing for print.summary"
+  )
+  expect_false(
+    any(grepl("triggers deprecation warning", rd_content, fixed = TRUE)),
+    info = "Rd still describes print.summary as triggering deprecation warning"
+  )
+})
+
+test_that("bfh_qic Rd examples do not demonstrate print.summary = TRUE", {
+  rd_path <- system.file("man", "bfh_qic.Rd", package = "BFHcharts")
+  skip_if(nchar(rd_path) == 0, "Package not installed — run devtools::install()")
+
+  rd_lines <- readLines(rd_path, warn = FALSE)
+
+  # Find the \examples{} block
+  examples_start <- which(grepl("^\\\\examples\\{", rd_lines))
+  if (length(examples_start) == 0) skip("No \\examples{} block found in Rd")
+
+  examples_section <- rd_lines[examples_start:length(rd_lines)]
+  expect_false(
+    any(grepl("print.summary\\s*=\\s*TRUE", examples_section, perl = TRUE)),
+    info = "Rd examples still demonstrate print.summary = TRUE (removed in v0.11.0)"
+  )
+})
+
+# ----------------------------------------------------------------------------
+# Regression: chart type documentation completeness (complete-chart-type-public-docs)
+# Verificerer at alle typer i CHART_TYPES_EN er dokumenteret i man/bfh_qic.Rd.
+# ----------------------------------------------------------------------------
+
+test_that("bfh_qic Rd documents all validated chart types", {
+  rd_path <- system.file("man", "bfh_qic.Rd", package = "BFHcharts")
+  skip_if(nchar(rd_path) == 0, "Package not installed — run devtools::install()")
+
+  rd_content <- paste(readLines(rd_path, warn = FALSE), collapse = "\n")
+
+  for (t in BFHcharts:::CHART_TYPES_EN) {
+    expect_true(
+      grepl(paste0("\\b", t, "\\b"), rd_content, perl = TRUE),
+      info = paste("Chart type", t, "missing from bfh_qic.Rd")
+    )
+  }
+})


### PR DESCRIPTION
## Sammendrag

Konsolideret docs-cleanup PR der adresserer to dokumentationsdriver i `bfh_qic()`:

1. **`print.summary` doc-drift** (OpenSpec: `update-print-summary-removal-docs`): Roxygen sagde "DEPRECATED, will warn", men `build_bfh_qic_return()` hard-errorer siden v0.11.0. `@examples` 20-22 demonstrerede aktivt det fjernede argument.
2. **Manglende charttyper i public docs** (OpenSpec: `complete-chart-type-public-docs`): `@param chart_type` listede kun 9 af 12 typer som validering accepterer. `mr` (Moving Range), `pp` (Laney-P) og `up` (Laney-U) var ikke dokumenteret.

Code review reference: Claude statisk + Codex runtime, 2026-04-29

## Ændringer

- `R/bfh_qic.R`:
  - `@param chart_type` lister nu alle 12 typer fra `CHART_TYPES_EN`
  - `@details Chart Types` har entries for alle 12, inkl. Laney-guidance for over-dispersion
  - `@param print.summary` opdateret fra "DEPRECATED... will warn" → "REMOVED in v0.11.0... raises an error" + migrationsinstruktion
  - `@return` fjernet to forældede legacy-format-bullets
  - Examples 20-22 omskrevet til moderne S3 API (`result$summary`, `result$qic_data`)
  - Examples 23-24 tilføjet for `pp` og `mr`-paret-med-`i`
- `man/bfh_qic.Rd`: regenereret via `devtools::document()`
- `tests/testthat/test-public-api-contract.R`: 3 regressionstests tilføjet med `.rd_path_bfh_qic()`-helper der finder Rd in-tree (virker både `devtools::test()` og `R CMD check`)
- `NEWS.md`: `(development)` section med entries for begge ændringer

## Test plan

- [x] `devtools::test()`: PASS 29, FAIL 0, WARN 0, SKIP 1 (pre-existing installeret-pakke-test)
- [x] `devtools::check()`: 0 errors, 1 pre-existing warning (non-ASCII), 1 note (`.git`)
- [x] `?bfh_qic` viser opdateret dokumentation uden "deprecated, will warn"
- [x] Alle 12 chart-typer matches i Rd-fil