### PR TITLE
docs(branding): companion-pkg-pattern for organisations-deployments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,17 @@
   n > 1000 per subgruppe). To nye eksempler tilføjet: `pp`-chart og `mr`-chart
   parret med I-chart. (#complete-chart-type-public-docs)
 
+* **Companion-pakke-pattern dokumenteret for proprietær branding.**
+  `?bfh_export_pdf`, `?bfh_create_export_session` og `README.md` beskriver
+  nu den anbefalede fremgangsmåde for organisationer, der har brug for
+  proprietære fonts (Mari, Arial) og hospital-logoer i PDF-eksport:
+  distribution via en privat companion R-pakke, der plugger ind via
+  `inject_assets`-parameteren. Dette holder proprietære assets ude af den
+  offentlige GPL-3-pakke og ud af consumer-applikationers git-historik, mens
+  fuld branding understøttes på Posit Connect Cloud, RStudio Connect og Docker.
+  For BFH/Region Hovedstaden-deployments implementerer `BFHchartsAssets`
+  (privat repo) dette mønster. (#add-bfhcharts-assets-companion-pkg)
+
 # BFHcharts 0.11.0
 
 ## Breaking changes

--- a/R/export_pdf.R
+++ b/R/export_pdf.R
@@ -128,6 +128,21 @@
 #' The same trust requirement applies to \code{inject_assets} when passed
 #' to \code{\link{bfh_create_export_session}()}.
 #'
+#' \strong{Recommended: companion package for proprietary branding.}
+#' Organizations deploying BFHcharts-based applications that need consistent
+#' proprietary branding (custom fonts, hospital logos) should distribute those
+#' assets via a private companion R package. The companion package exposes a
+#' single function compatible with \code{inject_assets}, e.g.
+#' \code{inject_bfh_assets(template_dir)}. Consumer applications then call
+#' \code{bfh_export_pdf(..., inject_assets = MyAssetsPkg::inject_bfh_assets)}.
+#' This keeps proprietary assets out of public BFHcharts distribution while
+#' preserving full branding in production. The companion package is still
+#' subject to the trusted-code-only contract above. For the BFH/Region
+#' Hovedstaden reference deployment, the \code{BFHchartsAssets} private
+#' companion package implements this pattern. See
+#' \code{vignette("organizational-deployments")} (when available) or the
+#' BFHchartsAssets repository documentation.
+#'
 #' @export
 #' @seealso
 #'   - [bfh_qic()] to create SPC charts

--- a/R/export_session.R
+++ b/R/export_session.R
@@ -44,6 +44,17 @@
 #' \code{\link{bfh_export_pdf}} for the full rationale and the parallel
 #' warning for \code{template_path}.
 #'
+#' \strong{Recommended: companion package for proprietary branding.}
+#' Organizations that need consistent proprietary branding across batch
+#' exports should pass a companion-package callback here rather than
+#' hardcoding asset paths. For example:
+#' \code{bfh_create_export_session(inject_assets = MyAssetsPkg::inject_my_assets)}.
+#' This keeps proprietary fonts and logos out of public BFHcharts
+#' distribution while supporting full branding on Posit Connect Cloud,
+#' RStudio Connect, and Docker deployments. The callback is still
+#' subject to the trusted-code-only contract above. See
+#' \code{\link{bfh_export_pdf}} Security section for full details.
+#'
 #' @export
 #' @seealso
 #'   - [bfh_export_pdf()] for single exports and the full security note

--- a/README.md
+++ b/README.md
@@ -55,6 +55,27 @@ The package uses font fallback: **Mari → Roboto → Arial → Helvetica → sa
 
 PDFs will be fully functional and readable, but without Region Hovedstaden specific branding. This is by design - Mari font is copyrighted and cannot be redistributed with the package.
 
+### Branding for Organizational Deployments
+
+Healthcare organizations that need consistent proprietary branding (custom fonts, hospital logos) across their BFHcharts deployments should distribute those assets via a **private companion R package** rather than bundling them in their consumer application or hardcoding paths.
+
+**Pattern:**
+
+1. Create a private R package (e.g. `MyOrgAssets`) hosting fonts and images in `inst/assets/`
+2. Export a single function `inject_my_assets(template_dir)` that copies bundled assets into the staged Typst template directory
+3. In your consumer application (e.g. a Shiny dashboard), depend on the companion package and pass its inject function to BFHcharts:
+
+```r
+BFHcharts::bfh_export_pdf(
+  result, "report.pdf",
+  inject_assets = MyOrgAssets::inject_my_assets
+)
+```
+
+This keeps proprietary assets out of public BFHcharts and out of your consumer app's git history, while supporting full branding in production deployments (including Posit Connect Cloud, RStudio Connect, and Docker).
+
+For the BFH/Region Hovedstaden reference deployment, the `BFHchartsAssets` private companion package (separate repository, hospital-internal access) implements this pattern. See its repository documentation for setup details.
+
 ## Quick Start
 
 ```r

--- a/man/bfh_create_export_session.Rd
+++ b/man/bfh_create_export_session.Rd
@@ -56,6 +56,17 @@ input (Shiny inputs, query parameters, untrusted uploads) to this
 parameter -- the same trust contract as \code{source()} applies. See
 \code{\link{bfh_export_pdf}} for the full rationale and the parallel
 warning for \code{template_path}.
+
+\strong{Recommended: companion package for proprietary branding.}
+Organizations that need consistent proprietary branding across batch
+exports should pass a companion-package callback here rather than
+hardcoding asset paths. For example:
+\code{bfh_create_export_session(inject_assets = MyAssetsPkg::inject_my_assets)}.
+This keeps proprietary fonts and logos out of public BFHcharts
+distribution while supporting full branding on Posit Connect Cloud,
+RStudio Connect, and Docker deployments. The callback is still
+subject to the trusted-code-only contract above. See
+\code{\link{bfh_export_pdf}} Security section for full details.
 }
 
 \seealso{

--- a/man/bfh_export_pdf.Rd
+++ b/man/bfh_export_pdf.Rd
@@ -177,6 +177,21 @@ a fixed allow-list of approved templates and callbacks before invoking
 
 The same trust requirement applies to \code{inject_assets} when passed
 to \code{\link{bfh_create_export_session}()}.
+
+\strong{Recommended: companion package for proprietary branding.}
+Organizations deploying BFHcharts-based applications that need consistent
+proprietary branding (custom fonts, hospital logos) should distribute those
+assets via a private companion R package. The companion package exposes a
+single function compatible with \code{inject_assets}, e.g.
+\code{inject_bfh_assets(template_dir)}. Consumer applications then call
+\code{bfh_export_pdf(..., inject_assets = MyAssetsPkg::inject_bfh_assets)}.
+This keeps proprietary assets out of public BFHcharts distribution while
+preserving full branding in production. The companion package is still
+subject to the trusted-code-only contract above. For the BFH/Region
+Hovedstaden reference deployment, the \code{BFHchartsAssets} private
+companion package implements this pattern. See
+\code{vignette("organizational-deployments")} (when available) or the
+BFHchartsAssets repository documentation.
 }
 
 \examples{

--- a/man/dot-normalize_percent_target.Rd
+++ b/man/dot-normalize_percent_target.Rd
@@ -34,19 +34,19 @@ Preserve otherwise (proportion already correct, or non-percent chart).
 }
 \examples{
 # Percent target expressed as 0-100 (normaliseres)
-BFHcharts:::.normalize_percent_target(90, ">= 90\%", "percent")  # 0.90
+BFHcharts:::.normalize_percent_target(90, ">= 90\%", "percent") # 0.90
 
 # Numerisk input >= 1 paa percent-chart (normaliseres)
-BFHcharts:::.normalize_percent_target(90, "", "percent")  # 0.90
+BFHcharts:::.normalize_percent_target(90, "", "percent") # 0.90
 
 # Allerede paa proportionsskala (bevares)
-BFHcharts:::.normalize_percent_target(0.9, "", "percent")  # 0.9
+BFHcharts:::.normalize_percent_target(0.9, "", "percent") # 0.9
 
 # Ingen \% i display og value <= 1: power-user proportion-override (bevares)
-BFHcharts:::.normalize_percent_target(0.9, ">= 0.9", "percent")  # 0.9
+BFHcharts:::.normalize_percent_target(0.9, ">= 0.9", "percent") # 0.9
 
 # Ikke et percent-diagram: altid uaendret
-BFHcharts:::.normalize_percent_target(90, ">= 90", "count")  # 90
+BFHcharts:::.normalize_percent_target(90, ">= 90", "count") # 90
 
 }
 \keyword{internal}

--- a/openspec/changes/add-bfhcharts-assets-companion-pkg/proposal.md
+++ b/openspec/changes/add-bfhcharts-assets-companion-pkg/proposal.md
@@ -1,0 +1,166 @@
+## Why
+
+BFHcharts er public GPL-3-pakke distribueret via GitHub + r-universe. Den må derfor **ikke** bundle proprietære assets:
+
+- **Mari fonts** (Region Hovedstadens custom font) — eksplicit forbudt af `openspec/specs/pdf-export/spec.md:46` ("Package SHALL NOT bundle copyrighted Mari fonts") og README ("Mari font is copyrighted and cannot be redistributed with the package")
+- **Arial fonts** (Microsoft/Monotype) — proprietær, EULA forbyder redistribution af TTF-kopier fra Win/Mac OS
+- **Hospital-logoer** (Logo_Bispebjerg*, BFH_medicin) — Region Hovedstadens brand-ejendom, GPL-3-redistribution implicerer GPL-licensiering hvilket RegionH ikke har samtykket til
+
+Pakken understøtter allerede `inject_assets`-callback (`bfh_export_pdf()` + `bfh_create_export_session()`) der lader downstream-brugere kopiere assets ind i Typst-template-staging-direktoriet ved runtime. Mekanismen findes — men der mangler en officiel asset-leverandør for biSPCharts og fremtidige forbrugere.
+
+biSPCharts er deployed til **Posit Connect Cloud** og skal kunne rendere PDF'er med fuld hospital-branding (Mari + logos). Uden et formelt asset-distribuerings-pattern er der to suboptimale workarounds:
+
+1. **Manuel staging i deploy-bundle** — assets gitignored i biSPCharts, lokalt kopieret før `rsconnect::deployApp()`. Skrøbeligt: assets er ikke versioneret, manuelt staging-trin nemt at glemme, ingen audit-trail
+2. **Hardcoded paths** — `inject_assets`-callback med absolute paths til lokal udvikler-maskine. Bryder på Connect Cloud
+
+Løsningen er en **privat companion-pakke** `BFHchartsAssets` der hoster proprietære assets, distribueres via privat GitHub repo, og genereres fra Mari + logo source files ved bumping. biSPCharts importerer den som dependency og kalder `BFHchartsAssets::inject_bfh_assets()` i sit `inject_assets`-callback.
+
+## What Changes
+
+**Ud af scope for BFHcharts repo:** Companion-pakken er et **separat repo**, ikke en ændring i BFHcharts. Denne OpenSpec change scaffolder companion-pakke-design + dokumenterer integration-pattern fra BFHcharts-side.
+
+**Konkrete deliverables:**
+
+### A. Nyt privat repo: `johanreventlow/BFHchartsAssets`
+
+Struktur:
+
+```
+BFHchartsAssets/                       (PRIVAT GitHub repo)
+├── DESCRIPTION                        Imports: BFHcharts (>= 0.11.1)
+├── NAMESPACE
+├── R/
+│   └── inject.R                       eksporterer inject_bfh_assets()
+├── inst/
+│   └── assets/
+│       ├── fonts/                     Mari*.otf, MariOffice*.ttf, ARIAL*.TTF
+│       └── images/                    Logo_Bispebjerg*.png, BFH_medicin.png
+├── tests/testthat/
+│   └── test-inject.R                  verificerer at filer kopieres korrekt
+├── LICENSE                            Copyright Region Hovedstaden, "All rights reserved" (privat)
+├── README.md                          dokumenterer Posit Connect Cloud setup + PAT
+└── .github/workflows/R-CMD-check.yaml minimal CI
+
+```
+
+`R/inject.R`:
+
+```r
+#' Inject BFH branding assets into a Typst template directory
+#'
+#' Drop-in callback for [BFHcharts::bfh_export_pdf()]'s `inject_assets` argument.
+#' Copies all bundled fonts and images into the staged template's `fonts/`
+#' and `images/` subdirectories.
+#'
+#' @param template_dir Character path to the staged template directory
+#'   (passed by BFHcharts at runtime)
+#' @return Invisible NULL. Called for side effects.
+#' @export
+inject_bfh_assets <- function(template_dir) {
+  stopifnot(is.character(template_dir), length(template_dir) == 1, dir.exists(template_dir))
+
+  fonts_src  <- system.file("assets/fonts",  package = "BFHchartsAssets", mustWork = TRUE)
+  images_src <- system.file("assets/images", package = "BFHchartsAssets", mustWork = TRUE)
+
+  fonts_dst  <- file.path(template_dir, "fonts")
+  images_dst <- file.path(template_dir, "images")
+  dir.create(fonts_dst,  showWarnings = FALSE, recursive = TRUE)
+  dir.create(images_dst, showWarnings = FALSE, recursive = TRUE)
+
+  font_files  <- list.files(fonts_src,  full.names = TRUE)
+  image_files <- list.files(images_src, full.names = TRUE)
+
+  fonts_ok  <- all(file.copy(font_files,  fonts_dst,  overwrite = TRUE))
+  images_ok <- all(file.copy(image_files, images_dst, overwrite = TRUE))
+
+  if (!fonts_ok || !images_ok) {
+    stop("BFHchartsAssets: failed to inject one or more asset files", call. = FALSE)
+  }
+
+  invisible(NULL)
+}
+```
+
+### B. biSPCharts integration
+
+biSPCharts `DESCRIPTION`:
+```
+Imports:
+    BFHcharts (>= 0.11.1),
+    BFHchartsAssets
+Remotes:
+    johanreventlow/BFHcharts,
+    johanreventlow/BFHchartsAssets
+```
+
+biSPCharts server-kode (eksempel):
+```r
+result <- BFHcharts::bfh_qic(...)
+
+BFHcharts::bfh_export_pdf(
+  result, output_pdf,
+  metadata = metadata,
+  inject_assets = BFHchartsAssets::inject_bfh_assets
+)
+```
+
+For batch:
+```r
+session <- BFHcharts::bfh_create_export_session(
+  inject_assets = BFHchartsAssets::inject_bfh_assets
+)
+on.exit(close(session))
+for (dept in departments) {
+  BFHcharts::bfh_export_pdf(results[[dept]], paste0(dept, ".pdf"), batch_session = session)
+}
+```
+
+`inject_assets`-callback peger automatisk `font_path` til `template_dir/fonts/` (eksisterende logik i `bfh_create_export_session()`).
+
+### C. Posit Connect Cloud setup
+
+Connect Cloud kræver autoriseret adgang til private repos for at installere `BFHchartsAssets`. Konkret konfiguration:
+
+1. **Generate GitHub PAT** med scope `repo` (læseadgang til private repos)
+2. Connect Cloud app **Settings → Environment Variables**:
+   - `GITHUB_PAT=ghp_...` (eller `GITHUB_TOKEN`)
+3. Verificér at `manifest.json` for biSPCharts genereres med `Remote*`-felter (memory: BFHcharts skal have `RemoteType`, `RemoteHost`, `RemoteUsername`, `RemoteRepo`, `RemoteSha`, `GithubRepo`, `GithubSHA`-felter; samme krav gælder `BFHchartsAssets`)
+4. Re-deploy biSPCharts via `rsconnect::deployApp()` — Connect Cloud trækker `BFHchartsAssets` fra privat repo via PAT
+
+### D. BFHcharts dokumentations-tilføjelse
+
+Denne change ændrer **ikke** BFHcharts-koden. Men opdaterer:
+
+- `README.md` — ny sektion "Branding for organizational deployments" der peger på companion-pakke-pattern
+- `R/export_pdf.R` Roxygen `@section Security` — tilføj note om at en officiel companion-pakke er tilgængelig via privat distribution for hospitaler der vil genbruge BFH-branding
+- OpenSpec spec `pdf-export` — tilføj requirement om at companion-asset-injection er den anbefalede pattern for proprietær branding
+
+### Out of scope
+
+- Skabelse af `BFHchartsAssets`-repo selv (separat git-init i privat scope)
+- Faktisk push af Mari-fonts/logos til `BFHchartsAssets`/inst/assets/ (ud af BFHcharts repo control)
+- biSPCharts-side ændringer (dispatches separat til biSPCharts repo som companion change)
+- CI-smoke-render-strategi (dækket af `enable-ci-safe-pdf-smoke-render`-proposal; CI-test bruger DejaVu-only test-template, ikke companion-pkg)
+
+## Impact
+
+**Affected specs:**
+- `pdf-export` — ADDED requirement: companion-pakke-pattern dokumenteret som anbefalet asset-distribution-mekanisme
+
+**Affected code (BFHcharts repo):**
+- `R/export_pdf.R` Roxygen — udvidet `@section Security` med companion-pkg-reference
+- `R/export_session.R` Roxygen — samme
+- `README.md` — ny sektion
+
+**Cross-repo coordination:**
+- **Privat repo creation**: `johanreventlow/BFHchartsAssets` (manuelt admin-trin)
+- **biSPCharts companion change**: separat OpenSpec proposal i biSPCharts repo der adopter `BFHchartsAssets`-dependency
+
+**Risiko:**
+- Lav teknisk risiko for BFHcharts (kun docs-ændringer)
+- Operativ risiko for biSPCharts/Connect Cloud setup (PAT-konfiguration, manifest.json Remote*-felter)
+
+**Effort estimat:**
+- BFHcharts side: 1-2 timer (docs-opdatering)
+- BFHchartsAssets repo creation: 2-3 timer (init + DESCRIPTION + R/inject.R + tests + privat license + push)
+- biSPCharts integration: 2-4 timer (DESCRIPTION-update + replace eksisterende inject_assets-implementation + Connect Cloud env-vars + re-deploy verifikation)

--- a/openspec/changes/add-bfhcharts-assets-companion-pkg/specs/pdf-export/spec.md
+++ b/openspec/changes/add-bfhcharts-assets-companion-pkg/specs/pdf-export/spec.md
@@ -1,0 +1,92 @@
+## ADDED Requirements
+
+### Requirement: Organizational asset distribution SHALL use companion package pattern
+
+Organizations that need to bundle proprietary fonts and branding assets (logos, hospital identifiers) with BFHcharts-based deployments SHALL use a private companion R package as the asset distribution mechanism. The companion package:
+
+1. Hosts the proprietary assets in `inst/assets/fonts/` and `inst/assets/images/`
+2. Exports a single function (e.g. `inject_bfh_assets(template_dir)`) that copies all bundled assets into a Typst template staging directory
+3. Is installed as a private dependency by the consumer application (e.g. biSPCharts on Posit Connect Cloud)
+4. Plugs into BFHcharts via the existing `inject_assets` callback parameter on `bfh_export_pdf()` and `bfh_create_export_session()`
+
+**Rationale:**
+
+- BFHcharts itself is GPL-3 and publicly distributed; it cannot bundle proprietary fonts (Mari, Arial) or third-party-owned hospital logos
+- The `inject_assets` callback was designed precisely for this asset-runtime-injection pattern but lacked an officially recommended distribution mechanism
+- A companion package gives organizations versioned, audit-trackable, dependency-managed asset distribution that integrates cleanly with R's package ecosystem (renv, manifest.json on Posit Connect)
+- Compared to ad-hoc deploy-bundle staging, companion packages provide: source-of-truth versioning, reusability across multiple consumer applications, and clean separation of GPL-distributable code from proprietary brand assets
+
+**Anti-patterns this requirement formalizes against:**
+
+- Hardcoded absolute paths in `inject_assets` callbacks (breaks on cloud deployments)
+- Manual asset staging in deploy bundles via `.gitignore` + pre-deploy copy scripts (no audit trail; easily forgotten)
+- Direct commit of proprietary fonts/logos into BFHcharts (license violations) or into consumer application repos that are public (same violations)
+
+#### Scenario: Companion package exposes single inject_assets-compatible function
+
+- **GIVEN** a private companion package (e.g. `BFHchartsAssets`)
+- **WHEN** the package is installed
+- **THEN** it SHALL export a function with signature `function(template_dir)` that:
+  - Validates `template_dir` is a single character path to an existing directory
+  - Copies all bundled fonts from `system.file("assets/fonts", package = "<pkg>")` to `<template_dir>/fonts/`
+  - Copies all bundled images from `system.file("assets/images", package = "<pkg>")` to `<template_dir>/images/`
+  - Creates `fonts/` and `images/` subdirectories if they do not exist
+  - Errors clearly if any file copy fails
+
+```r
+# Reference implementation
+inject_bfh_assets <- function(template_dir) {
+  stopifnot(is.character(template_dir), length(template_dir) == 1, dir.exists(template_dir))
+
+  fonts_src  <- system.file("assets/fonts",  package = "BFHchartsAssets", mustWork = TRUE)
+  images_src <- system.file("assets/images", package = "BFHchartsAssets", mustWork = TRUE)
+
+  fonts_dst  <- file.path(template_dir, "fonts")
+  images_dst <- file.path(template_dir, "images")
+  dir.create(fonts_dst,  showWarnings = FALSE, recursive = TRUE)
+  dir.create(images_dst, showWarnings = FALSE, recursive = TRUE)
+
+  fonts_ok  <- all(file.copy(list.files(fonts_src,  full.names = TRUE), fonts_dst,  overwrite = TRUE))
+  images_ok <- all(file.copy(list.files(images_src, full.names = TRUE), images_dst, overwrite = TRUE))
+
+  if (!fonts_ok || !images_ok) {
+    stop("Failed to inject one or more asset files", call. = FALSE)
+  }
+
+  invisible(NULL)
+}
+```
+
+#### Scenario: Consumer integrates companion via inject_assets parameter
+
+- **GIVEN** a consumer Shiny app (biSPCharts) deployed to Posit Connect Cloud
+- **AND** the consumer has `BFHchartsAssets` in its `Imports` and `Remotes`
+- **WHEN** the consumer calls `BFHcharts::bfh_export_pdf(..., inject_assets = BFHchartsAssets::inject_bfh_assets)`
+- **THEN** the rendered PDF SHALL display full hospital branding with Mari fonts and Region Hovedstaden logos
+- **AND** BFHcharts itself SHALL NOT have any code that references `BFHchartsAssets` (clean dependency direction: consumer → BFHcharts; consumer → BFHchartsAssets)
+
+```r
+# Consumer code pattern (biSPCharts):
+result <- BFHcharts::bfh_qic(data, x = month, y = infections, chart_type = "i")
+BFHcharts::bfh_export_pdf(
+  result, output_pdf,
+  metadata = list(hospital = "Bispebjerg og Frederiksberg Hospital", department = dept),
+  inject_assets = BFHchartsAssets::inject_bfh_assets
+)
+```
+
+#### Scenario: BFHcharts documentation references companion pattern as canonical
+
+- **GIVEN** a user reads `?bfh_export_pdf` or `README.md`
+- **WHEN** the user reaches the security/branding section
+- **THEN** the documentation SHALL describe the companion-package pattern as the recommended approach for organizations needing proprietary branding
+- **AND** SHALL explicitly state that BFHcharts does not bundle Mari fonts or hospital logos
+
+#### Scenario: Companion package is independent of BFHcharts release cadence
+
+- **GIVEN** the companion package and BFHcharts are versioned independently
+- **WHEN** BFHcharts releases a patch version
+- **THEN** the companion package SHALL NOT need to be re-released unless the `inject_assets`-callback contract changes
+- **AND** the companion package's `DESCRIPTION` SHALL specify `BFHcharts (>= <minimum-version>)` to assert the callback contract version it supports
+
+This decoupling allows BFHcharts to evolve its public API freely while organizations control their branding-asset release cadence separately.

--- a/openspec/changes/add-bfhcharts-assets-companion-pkg/tasks.md
+++ b/openspec/changes/add-bfhcharts-assets-companion-pkg/tasks.md
@@ -1,0 +1,84 @@
+## 1. BFHcharts repo (this proposal's direct scope)
+
+### 1a. Documentation updates
+
+- [ ] 1.1 Tilføj sektion til `README.md` under existing "Font Requirements": "Branding for organizational deployments" der beskriver companion-pakke-pattern
+- [ ] 1.2 Udvid Roxygen `@section Security` i `R/export_pdf.R` (linje ~107-130) med reference til at en officiel companion-pakke kan eksistere for organisationen
+- [ ] 1.3 Samme reference i `R/export_session.R` Roxygen
+- [ ] 1.4 Kør `devtools::document()` for at regenerere Rd-filer
+- [ ] 1.5 NEWS.md entry under `## Dokumentation` for næste patch
+
+### 1b. OpenSpec spec update
+
+- [ ] 1.6 Tilføj nyt requirement i `openspec/specs/pdf-export/spec.md`: "Companion-pakker SHALL be the recommended pattern for organizational asset distribution" med scenarios
+
+## 2. BFHchartsAssets repo (separat — manuelt admin-trin)
+
+**[MANUELT TRIN]** Denne sektion kan ikke automatiseres fra BFHcharts repo. Udføres separat.
+
+- [ ] 2.1 Opret privat GitHub repo `johanreventlow/BFHchartsAssets` (visibility: private)
+- [ ] 2.2 Initialiser R-pakke-struktur lokalt:
+  ```bash
+  mkdir BFHchartsAssets && cd BFHchartsAssets
+  Rscript -e 'usethis::create_package(".")'
+  ```
+- [ ] 2.3 Skriv `DESCRIPTION`:
+  ```
+  Package: BFHchartsAssets
+  Title: BFH Branding Assets for BFHcharts
+  Version: 0.1.0
+  Authors@R: person("Johan", "Reventlow", email = "johan.reventlow@regionh.dk", role = c("aut", "cre"))
+  Description: Private companion package providing proprietary fonts and
+      hospital branding images for BFHcharts PDF export. Distributed via
+      private GitHub repository; not for public release.
+  License: file LICENSE
+  Encoding: UTF-8
+  Imports:
+      BFHcharts (>= 0.11.1)
+  Remotes:
+      johanreventlow/BFHcharts
+  ```
+- [ ] 2.4 Skriv `LICENSE` med "Proprietary - Region Hovedstaden - All rights reserved"
+- [ ] 2.5 Skriv `R/inject.R` med `inject_bfh_assets()` (kode i proposal.md)
+- [ ] 2.6 `usethis::use_roxygen_md()` + `devtools::document()`
+- [ ] 2.7 Kopiér Mari-fonts + Arial-fonts + logos fra lokalt master-source til `inst/assets/fonts/` og `inst/assets/images/`
+- [ ] 2.8 Skriv `tests/testthat/test-inject.R`:
+  - Test: `inject_bfh_assets(tmpdir)` opretter `fonts/` og `images/` subdir'er
+  - Test: alle bundlede filer findes på destinationen efter kald
+  - Test: callback fejler gracefully ved ugyldig `template_dir`
+- [ ] 2.9 `devtools::check()` — sikre 0 errors/warnings
+- [ ] 2.10 Initial commit + push til privat repo
+- [ ] 2.11 Tag `v0.1.0` annoteret + push tag
+
+## 3. biSPCharts integration (separat — i biSPCharts repo)
+
+**[CROSS-REPO]** Udføres som separat OpenSpec change i biSPCharts repo.
+
+- [ ] 3.1 Opret OpenSpec proposal i biSPCharts: `adopt-bfhcharts-assets-companion`
+- [ ] 3.2 biSPCharts `DESCRIPTION`: tilføj `BFHchartsAssets` til `Imports` + `Remotes`
+- [ ] 3.3 Erstat eksisterende ad-hoc `inject_assets`-implementation (hvis nogen) med `BFHchartsAssets::inject_bfh_assets`
+- [ ] 3.4 Opdatér `manifest.json` via `rsconnect::writeManifest()` så `BFHchartsAssets` har `Remote*`-felter (memory: samme problem som tidligere blokerede BFHcharts på Connect Cloud)
+- [ ] 3.5 Test lokal PDF-render: bekræft Mari-fonts + logos rendres korrekt
+
+## 4. Posit Connect Cloud setup (manuelt admin-trin)
+
+**[MANUELT TRIN]**
+
+- [ ] 4.1 Generér GitHub PAT med scope `repo` (read access til private repos)
+- [ ] 4.2 Connect Cloud → biSPCharts app → Settings → Environment Variables:
+  - Tilføj `GITHUB_PAT=<token>` (eller `GITHUB_TOKEN`)
+- [ ] 4.3 Re-deploy biSPCharts via `rsconnect::deployApp()`
+- [ ] 4.4 Verifikation: download en genereret PDF fra Connect Cloud, bekræft Mari-fonts og logos rendres
+- [ ] 4.5 Hvis fejl: tjek Connect Cloud install logs for `BFHchartsAssets`-installation; verificér PAT scope; verificér `manifest.json` Remote*-felter
+
+## 5. Verification (BFHcharts side)
+
+- [ ] 5.1 `devtools::check()` på BFHcharts efter docs-ændringer: 0 nye errors/warnings
+- [ ] 5.2 Manuel: `?bfh_export_pdf` viser opdateret security-section med companion-pkg-reference
+- [ ] 5.3 OpenSpec spec validation: nyt requirement er well-formed
+
+## 6. Release coordination
+
+- [ ] 6.1 BFHcharts: bump til næste patch + tag (kan kombineres med #1 og/eller #4)
+- [ ] 6.2 BFHchartsAssets: tag v0.1.0 efter initial commit
+- [ ] 6.3 biSPCharts: bump efter integration + redeploy verificeret


### PR DESCRIPTION
## Sammendrag

Dokumentations-only PR der formaliserer companion-package-pattern som anbefalet metode for proprietær branding (fonts, logos) i organisations-deployments af BFHcharts.

OpenSpec change: `add-bfhcharts-assets-companion-pkg`
Relateret memory: biSPCharts på Posit Connect Cloud kræver privat asset-distribution; pakkens eksisterende `inject_assets`-callback understøtter mønsteret men manglede officiel reference.

## Ændringer

- `R/export_pdf.R` — udvidet `@section Security` med companion-pkg-paragraph
- `R/export_session.R` — samme paragraph for symmetri
- `README.md` — ny sektion "Branding for Organizational Deployments" efter "Font Requirements"
- `man/bfh_export_pdf.Rd`, `man/bfh_create_export_session.Rd` — regenereret via `devtools::document()`
- `NEWS.md` — entry under `## Dokumentation` i v0.11.1-sektionen
- `openspec/changes/add-bfhcharts-assets-companion-pkg/` — proposal + tasks + spec committed

## Out of scope (separat cross-repo arbejde)

- **`BFHchartsAssets`-repo creation** — privat repo i `johanreventlow/BFHchartsAssets`, ikke en del af BFHcharts
- **biSPCharts integration** — separat OpenSpec change i biSPCharts repo
- **Posit Connect Cloud setup** — manuelt admin-trin (GITHUB_PAT env var, manifest.json Remote*-felter)

## Test plan

- [x] `devtools::check()`: 0 errors, 1 pre-existing warning (non-ASCII), 1 pre-existing note
- [x] `openspec validate add-bfhcharts-assets-companion-pkg`: valid
- [x] Manuel: `?bfh_export_pdf` viser ny "Recommended: companion package..."-paragraph
- [x] Manuel: README har ny "Branding for Organizational Deployments"-sektion