### PR TITLE
chore(openspec): archive 5 completed changes from code review 2026-04-29

### DIFF
--- a/openspec/changes/archive/2026-04-29-add-bfhcharts-assets-companion-pkg/proposal.md
+++ b/openspec/changes/archive/2026-04-29-add-bfhcharts-assets-companion-pkg/proposal.md
@@ -1,0 +1,166 @@
+## Why
+
+BFHcharts er public GPL-3-pakke distribueret via GitHub + r-universe. Den må derfor **ikke** bundle proprietære assets:
+
+- **Mari fonts** (Region Hovedstadens custom font) — eksplicit forbudt af `openspec/specs/pdf-export/spec.md:46` ("Package SHALL NOT bundle copyrighted Mari fonts") og README ("Mari font is copyrighted and cannot be redistributed with the package")
+- **Arial fonts** (Microsoft/Monotype) — proprietær, EULA forbyder redistribution af TTF-kopier fra Win/Mac OS
+- **Hospital-logoer** (Logo_Bispebjerg*, BFH_medicin) — Region Hovedstadens brand-ejendom, GPL-3-redistribution implicerer GPL-licensiering hvilket RegionH ikke har samtykket til
+
+Pakken understøtter allerede `inject_assets`-callback (`bfh_export_pdf()` + `bfh_create_export_session()`) der lader downstream-brugere kopiere assets ind i Typst-template-staging-direktoriet ved runtime. Mekanismen findes — men der mangler en officiel asset-leverandør for biSPCharts og fremtidige forbrugere.
+
+biSPCharts er deployed til **Posit Connect Cloud** og skal kunne rendere PDF'er med fuld hospital-branding (Mari + logos). Uden et formelt asset-distribuerings-pattern er der to suboptimale workarounds:
+
+1. **Manuel staging i deploy-bundle** — assets gitignored i biSPCharts, lokalt kopieret før `rsconnect::deployApp()`. Skrøbeligt: assets er ikke versioneret, manuelt staging-trin nemt at glemme, ingen audit-trail
+2. **Hardcoded paths** — `inject_assets`-callback med absolute paths til lokal udvikler-maskine. Bryder på Connect Cloud
+
+Løsningen er en **privat companion-pakke** `BFHchartsAssets` der hoster proprietære assets, distribueres via privat GitHub repo, og genereres fra Mari + logo source files ved bumping. biSPCharts importerer den som dependency og kalder `BFHchartsAssets::inject_bfh_assets()` i sit `inject_assets`-callback.
+
+## What Changes
+
+**Ud af scope for BFHcharts repo:** Companion-pakken er et **separat repo**, ikke en ændring i BFHcharts. Denne OpenSpec change scaffolder companion-pakke-design + dokumenterer integration-pattern fra BFHcharts-side.
+
+**Konkrete deliverables:**
+
+### A. Nyt privat repo: `johanreventlow/BFHchartsAssets`
+
+Struktur:
+
+```
+BFHchartsAssets/                       (PRIVAT GitHub repo)
+├── DESCRIPTION                        Imports: BFHcharts (>= 0.11.1)
+├── NAMESPACE
+├── R/
+│   └── inject.R                       eksporterer inject_bfh_assets()
+├── inst/
+│   └── assets/
+│       ├── fonts/                     Mari*.otf, MariOffice*.ttf, ARIAL*.TTF
+│       └── images/                    Logo_Bispebjerg*.png, BFH_medicin.png
+├── tests/testthat/
+│   └── test-inject.R                  verificerer at filer kopieres korrekt
+├── LICENSE                            Copyright Region Hovedstaden, "All rights reserved" (privat)
+├── README.md                          dokumenterer Posit Connect Cloud setup + PAT
+└── .github/workflows/R-CMD-check.yaml minimal CI
+
+```
+
+`R/inject.R`:
+
+```r
+#' Inject BFH branding assets into a Typst template directory
+#'
+#' Drop-in callback for [BFHcharts::bfh_export_pdf()]'s `inject_assets` argument.
+#' Copies all bundled fonts and images into the staged template's `fonts/`
+#' and `images/` subdirectories.
+#'
+#' @param template_dir Character path to the staged template directory
+#'   (passed by BFHcharts at runtime)
+#' @return Invisible NULL. Called for side effects.
+#' @export
+inject_bfh_assets <- function(template_dir) {
+  stopifnot(is.character(template_dir), length(template_dir) == 1, dir.exists(template_dir))
+
+  fonts_src  <- system.file("assets/fonts",  package = "BFHchartsAssets", mustWork = TRUE)
+  images_src <- system.file("assets/images", package = "BFHchartsAssets", mustWork = TRUE)
+
+  fonts_dst  <- file.path(template_dir, "fonts")
+  images_dst <- file.path(template_dir, "images")
+  dir.create(fonts_dst,  showWarnings = FALSE, recursive = TRUE)
+  dir.create(images_dst, showWarnings = FALSE, recursive = TRUE)
+
+  font_files  <- list.files(fonts_src,  full.names = TRUE)
+  image_files <- list.files(images_src, full.names = TRUE)
+
+  fonts_ok  <- all(file.copy(font_files,  fonts_dst,  overwrite = TRUE))
+  images_ok <- all(file.copy(image_files, images_dst, overwrite = TRUE))
+
+  if (!fonts_ok || !images_ok) {
+    stop("BFHchartsAssets: failed to inject one or more asset files", call. = FALSE)
+  }
+
+  invisible(NULL)
+}
+```
+
+### B. biSPCharts integration
+
+biSPCharts `DESCRIPTION`:
+```
+Imports:
+    BFHcharts (>= 0.11.1),
+    BFHchartsAssets
+Remotes:
+    johanreventlow/BFHcharts,
+    johanreventlow/BFHchartsAssets
+```
+
+biSPCharts server-kode (eksempel):
+```r
+result <- BFHcharts::bfh_qic(...)
+
+BFHcharts::bfh_export_pdf(
+  result, output_pdf,
+  metadata = metadata,
+  inject_assets = BFHchartsAssets::inject_bfh_assets
+)
+```
+
+For batch:
+```r
+session <- BFHcharts::bfh_create_export_session(
+  inject_assets = BFHchartsAssets::inject_bfh_assets
+)
+on.exit(close(session))
+for (dept in departments) {
+  BFHcharts::bfh_export_pdf(results[[dept]], paste0(dept, ".pdf"), batch_session = session)
+}
+```
+
+`inject_assets`-callback peger automatisk `font_path` til `template_dir/fonts/` (eksisterende logik i `bfh_create_export_session()`).
+
+### C. Posit Connect Cloud setup
+
+Connect Cloud kræver autoriseret adgang til private repos for at installere `BFHchartsAssets`. Konkret konfiguration:
+
+1. **Generate GitHub PAT** med scope `repo` (læseadgang til private repos)
+2. Connect Cloud app **Settings → Environment Variables**:
+   - `GITHUB_PAT=ghp_...` (eller `GITHUB_TOKEN`)
+3. Verificér at `manifest.json` for biSPCharts genereres med `Remote*`-felter (memory: BFHcharts skal have `RemoteType`, `RemoteHost`, `RemoteUsername`, `RemoteRepo`, `RemoteSha`, `GithubRepo`, `GithubSHA`-felter; samme krav gælder `BFHchartsAssets`)
+4. Re-deploy biSPCharts via `rsconnect::deployApp()` — Connect Cloud trækker `BFHchartsAssets` fra privat repo via PAT
+
+### D. BFHcharts dokumentations-tilføjelse
+
+Denne change ændrer **ikke** BFHcharts-koden. Men opdaterer:
+
+- `README.md` — ny sektion "Branding for organizational deployments" der peger på companion-pakke-pattern
+- `R/export_pdf.R` Roxygen `@section Security` — tilføj note om at en officiel companion-pakke er tilgængelig via privat distribution for hospitaler der vil genbruge BFH-branding
+- OpenSpec spec `pdf-export` — tilføj requirement om at companion-asset-injection er den anbefalede pattern for proprietær branding
+
+### Out of scope
+
+- Skabelse af `BFHchartsAssets`-repo selv (separat git-init i privat scope)
+- Faktisk push af Mari-fonts/logos til `BFHchartsAssets`/inst/assets/ (ud af BFHcharts repo control)
+- biSPCharts-side ændringer (dispatches separat til biSPCharts repo som companion change)
+- CI-smoke-render-strategi (dækket af `enable-ci-safe-pdf-smoke-render`-proposal; CI-test bruger DejaVu-only test-template, ikke companion-pkg)
+
+## Impact
+
+**Affected specs:**
+- `pdf-export` — ADDED requirement: companion-pakke-pattern dokumenteret som anbefalet asset-distribution-mekanisme
+
+**Affected code (BFHcharts repo):**
+- `R/export_pdf.R` Roxygen — udvidet `@section Security` med companion-pkg-reference
+- `R/export_session.R` Roxygen — samme
+- `README.md` — ny sektion
+
+**Cross-repo coordination:**
+- **Privat repo creation**: `johanreventlow/BFHchartsAssets` (manuelt admin-trin)
+- **biSPCharts companion change**: separat OpenSpec proposal i biSPCharts repo der adopter `BFHchartsAssets`-dependency
+
+**Risiko:**
+- Lav teknisk risiko for BFHcharts (kun docs-ændringer)
+- Operativ risiko for biSPCharts/Connect Cloud setup (PAT-konfiguration, manifest.json Remote*-felter)
+
+**Effort estimat:**
+- BFHcharts side: 1-2 timer (docs-opdatering)
+- BFHchartsAssets repo creation: 2-3 timer (init + DESCRIPTION + R/inject.R + tests + privat license + push)
+- biSPCharts integration: 2-4 timer (DESCRIPTION-update + replace eksisterende inject_assets-implementation + Connect Cloud env-vars + re-deploy verifikation)

--- a/openspec/changes/archive/2026-04-29-add-bfhcharts-assets-companion-pkg/specs/pdf-export/spec.md
+++ b/openspec/changes/archive/2026-04-29-add-bfhcharts-assets-companion-pkg/specs/pdf-export/spec.md
@@ -1,0 +1,92 @@
+## ADDED Requirements
+
+### Requirement: Organizational asset distribution SHALL use companion package pattern
+
+For organizations that need to bundle proprietary fonts and branding assets (logos, hospital identifiers) with BFHcharts-based deployments, the asset distribution SHALL use a private companion R package pattern. BFHcharts itself SHALL NOT bundle proprietary assets, and consumer applications SHALL NOT hardcode absolute paths to assets in `inject_assets` callbacks. The companion package SHALL:
+
+1. Hosts the proprietary assets in `inst/assets/fonts/` and `inst/assets/images/`
+2. Exports a single function (e.g. `inject_bfh_assets(template_dir)`) that copies all bundled assets into a Typst template staging directory
+3. Is installed as a private dependency by the consumer application (e.g. biSPCharts on Posit Connect Cloud)
+4. Plugs into BFHcharts via the existing `inject_assets` callback parameter on `bfh_export_pdf()` and `bfh_create_export_session()`
+
+**Rationale:**
+
+- BFHcharts itself is GPL-3 and publicly distributed; it cannot bundle proprietary fonts (Mari, Arial) or third-party-owned hospital logos
+- The `inject_assets` callback was designed precisely for this asset-runtime-injection pattern but lacked an officially recommended distribution mechanism
+- A companion package gives organizations versioned, audit-trackable, dependency-managed asset distribution that integrates cleanly with R's package ecosystem (renv, manifest.json on Posit Connect)
+- Compared to ad-hoc deploy-bundle staging, companion packages provide: source-of-truth versioning, reusability across multiple consumer applications, and clean separation of GPL-distributable code from proprietary brand assets
+
+**Anti-patterns this requirement formalizes against:**
+
+- Hardcoded absolute paths in `inject_assets` callbacks (breaks on cloud deployments)
+- Manual asset staging in deploy bundles via `.gitignore` + pre-deploy copy scripts (no audit trail; easily forgotten)
+- Direct commit of proprietary fonts/logos into BFHcharts (license violations) or into consumer application repos that are public (same violations)
+
+#### Scenario: Companion package exposes single inject_assets-compatible function
+
+- **GIVEN** a private companion package (e.g. `BFHchartsAssets`)
+- **WHEN** the package is installed
+- **THEN** it SHALL export a function with signature `function(template_dir)` that:
+  - Validates `template_dir` is a single character path to an existing directory
+  - Copies all bundled fonts from `system.file("assets/fonts", package = "<pkg>")` to `<template_dir>/fonts/`
+  - Copies all bundled images from `system.file("assets/images", package = "<pkg>")` to `<template_dir>/images/`
+  - Creates `fonts/` and `images/` subdirectories if they do not exist
+  - Errors clearly if any file copy fails
+
+```r
+# Reference implementation
+inject_bfh_assets <- function(template_dir) {
+  stopifnot(is.character(template_dir), length(template_dir) == 1, dir.exists(template_dir))
+
+  fonts_src  <- system.file("assets/fonts",  package = "BFHchartsAssets", mustWork = TRUE)
+  images_src <- system.file("assets/images", package = "BFHchartsAssets", mustWork = TRUE)
+
+  fonts_dst  <- file.path(template_dir, "fonts")
+  images_dst <- file.path(template_dir, "images")
+  dir.create(fonts_dst,  showWarnings = FALSE, recursive = TRUE)
+  dir.create(images_dst, showWarnings = FALSE, recursive = TRUE)
+
+  fonts_ok  <- all(file.copy(list.files(fonts_src,  full.names = TRUE), fonts_dst,  overwrite = TRUE))
+  images_ok <- all(file.copy(list.files(images_src, full.names = TRUE), images_dst, overwrite = TRUE))
+
+  if (!fonts_ok || !images_ok) {
+    stop("Failed to inject one or more asset files", call. = FALSE)
+  }
+
+  invisible(NULL)
+}
+```
+
+#### Scenario: Consumer integrates companion via inject_assets parameter
+
+- **GIVEN** a consumer Shiny app (biSPCharts) deployed to Posit Connect Cloud
+- **AND** the consumer has `BFHchartsAssets` in its `Imports` and `Remotes`
+- **WHEN** the consumer calls `BFHcharts::bfh_export_pdf(..., inject_assets = BFHchartsAssets::inject_bfh_assets)`
+- **THEN** the rendered PDF SHALL display full hospital branding with Mari fonts and Region Hovedstaden logos
+- **AND** BFHcharts itself SHALL NOT have any code that references `BFHchartsAssets` (clean dependency direction: consumer → BFHcharts; consumer → BFHchartsAssets)
+
+```r
+# Consumer code pattern (biSPCharts):
+result <- BFHcharts::bfh_qic(data, x = month, y = infections, chart_type = "i")
+BFHcharts::bfh_export_pdf(
+  result, output_pdf,
+  metadata = list(hospital = "Bispebjerg og Frederiksberg Hospital", department = dept),
+  inject_assets = BFHchartsAssets::inject_bfh_assets
+)
+```
+
+#### Scenario: BFHcharts documentation references companion pattern as canonical
+
+- **GIVEN** a user reads `?bfh_export_pdf` or `README.md`
+- **WHEN** the user reaches the security/branding section
+- **THEN** the documentation SHALL describe the companion-package pattern as the recommended approach for organizations needing proprietary branding
+- **AND** SHALL explicitly state that BFHcharts does not bundle Mari fonts or hospital logos
+
+#### Scenario: Companion package is independent of BFHcharts release cadence
+
+- **GIVEN** the companion package and BFHcharts are versioned independently
+- **WHEN** BFHcharts releases a patch version
+- **THEN** the companion package SHALL NOT need to be re-released unless the `inject_assets`-callback contract changes
+- **AND** the companion package's `DESCRIPTION` SHALL specify `BFHcharts (>= <minimum-version>)` to assert the callback contract version it supports
+
+This decoupling allows BFHcharts to evolve its public API freely while organizations control their branding-asset release cadence separately.

--- a/openspec/changes/archive/2026-04-29-add-bfhcharts-assets-companion-pkg/tasks.md
+++ b/openspec/changes/archive/2026-04-29-add-bfhcharts-assets-companion-pkg/tasks.md
@@ -1,0 +1,84 @@
+## 1. BFHcharts repo (this proposal's direct scope)
+
+### 1a. Documentation updates
+
+- [ ] 1.1 Tilføj sektion til `README.md` under existing "Font Requirements": "Branding for organizational deployments" der beskriver companion-pakke-pattern
+- [ ] 1.2 Udvid Roxygen `@section Security` i `R/export_pdf.R` (linje ~107-130) med reference til at en officiel companion-pakke kan eksistere for organisationen
+- [ ] 1.3 Samme reference i `R/export_session.R` Roxygen
+- [ ] 1.4 Kør `devtools::document()` for at regenerere Rd-filer
+- [ ] 1.5 NEWS.md entry under `## Dokumentation` for næste patch
+
+### 1b. OpenSpec spec update
+
+- [ ] 1.6 Tilføj nyt requirement i `openspec/specs/pdf-export/spec.md`: "Companion-pakker SHALL be the recommended pattern for organizational asset distribution" med scenarios
+
+## 2. BFHchartsAssets repo (separat — manuelt admin-trin)
+
+**[MANUELT TRIN]** Denne sektion kan ikke automatiseres fra BFHcharts repo. Udføres separat.
+
+- [ ] 2.1 Opret privat GitHub repo `johanreventlow/BFHchartsAssets` (visibility: private)
+- [ ] 2.2 Initialiser R-pakke-struktur lokalt:
+  ```bash
+  mkdir BFHchartsAssets && cd BFHchartsAssets
+  Rscript -e 'usethis::create_package(".")'
+  ```
+- [ ] 2.3 Skriv `DESCRIPTION`:
+  ```
+  Package: BFHchartsAssets
+  Title: BFH Branding Assets for BFHcharts
+  Version: 0.1.0
+  Authors@R: person("Johan", "Reventlow", email = "johan.reventlow@regionh.dk", role = c("aut", "cre"))
+  Description: Private companion package providing proprietary fonts and
+      hospital branding images for BFHcharts PDF export. Distributed via
+      private GitHub repository; not for public release.
+  License: file LICENSE
+  Encoding: UTF-8
+  Imports:
+      BFHcharts (>= 0.11.1)
+  Remotes:
+      johanreventlow/BFHcharts
+  ```
+- [ ] 2.4 Skriv `LICENSE` med "Proprietary - Region Hovedstaden - All rights reserved"
+- [ ] 2.5 Skriv `R/inject.R` med `inject_bfh_assets()` (kode i proposal.md)
+- [ ] 2.6 `usethis::use_roxygen_md()` + `devtools::document()`
+- [ ] 2.7 Kopiér Mari-fonts + Arial-fonts + logos fra lokalt master-source til `inst/assets/fonts/` og `inst/assets/images/`
+- [ ] 2.8 Skriv `tests/testthat/test-inject.R`:
+  - Test: `inject_bfh_assets(tmpdir)` opretter `fonts/` og `images/` subdir'er
+  - Test: alle bundlede filer findes på destinationen efter kald
+  - Test: callback fejler gracefully ved ugyldig `template_dir`
+- [ ] 2.9 `devtools::check()` — sikre 0 errors/warnings
+- [ ] 2.10 Initial commit + push til privat repo
+- [ ] 2.11 Tag `v0.1.0` annoteret + push tag
+
+## 3. biSPCharts integration (separat — i biSPCharts repo)
+
+**[CROSS-REPO]** Udføres som separat OpenSpec change i biSPCharts repo.
+
+- [ ] 3.1 Opret OpenSpec proposal i biSPCharts: `adopt-bfhcharts-assets-companion`
+- [ ] 3.2 biSPCharts `DESCRIPTION`: tilføj `BFHchartsAssets` til `Imports` + `Remotes`
+- [ ] 3.3 Erstat eksisterende ad-hoc `inject_assets`-implementation (hvis nogen) med `BFHchartsAssets::inject_bfh_assets`
+- [ ] 3.4 Opdatér `manifest.json` via `rsconnect::writeManifest()` så `BFHchartsAssets` har `Remote*`-felter (memory: samme problem som tidligere blokerede BFHcharts på Connect Cloud)
+- [ ] 3.5 Test lokal PDF-render: bekræft Mari-fonts + logos rendres korrekt
+
+## 4. Posit Connect Cloud setup (manuelt admin-trin)
+
+**[MANUELT TRIN]**
+
+- [ ] 4.1 Generér GitHub PAT med scope `repo` (read access til private repos)
+- [ ] 4.2 Connect Cloud → biSPCharts app → Settings → Environment Variables:
+  - Tilføj `GITHUB_PAT=<token>` (eller `GITHUB_TOKEN`)
+- [ ] 4.3 Re-deploy biSPCharts via `rsconnect::deployApp()`
+- [ ] 4.4 Verifikation: download en genereret PDF fra Connect Cloud, bekræft Mari-fonts og logos rendres
+- [ ] 4.5 Hvis fejl: tjek Connect Cloud install logs for `BFHchartsAssets`-installation; verificér PAT scope; verificér `manifest.json` Remote*-felter
+
+## 5. Verification (BFHcharts side)
+
+- [ ] 5.1 `devtools::check()` på BFHcharts efter docs-ændringer: 0 nye errors/warnings
+- [ ] 5.2 Manuel: `?bfh_export_pdf` viser opdateret security-section med companion-pkg-reference
+- [ ] 5.3 OpenSpec spec validation: nyt requirement er well-formed
+
+## 6. Release coordination
+
+- [ ] 6.1 BFHcharts: bump til næste patch + tag (kan kombineres med #1 og/eller #4)
+- [ ] 6.2 BFHchartsAssets: tag v0.1.0 efter initial commit
+- [ ] 6.3 biSPCharts: bump efter integration + redeploy verificeret

--- a/openspec/changes/archive/2026-04-29-cleanup-temp-dir-ownership-check/proposal.md
+++ b/openspec/changes/archive/2026-04-29-cleanup-temp-dir-ownership-check/proposal.md
@@ -1,0 +1,100 @@
+## Why
+
+Claude code review 2026-04-29 (OPPORTUNISTIC, lav severity, høj confidence) fandt at `prepare_temp_workspace()` i `R/utils_export_helpers.R:213-223` indeholder en ownership-check der praktisk talt aldrig udløses:
+
+```r
+if (.Platform$OS.type == "unix") {
+  dir_info <- file.info(temp_dir)
+  current_uid <- suppressWarnings(as.integer(Sys.getenv("UID")))
+  if (length(current_uid) > 0 && !is.na(current_uid) && current_uid > 0) {
+    if (dir_info$uid != current_uid) {
+      unlink(temp_dir, recursive = TRUE)
+      stop("Temp directory ownership mismatch (possible security issue)", call. = FALSE)
+    }
+  }
+}
+```
+
+**Problem:** `Sys.getenv("UID")` returnerer typisk `""` på Unix-systemer fordi `UID` er en shell-intern variabel der **ikke** automatisk eksporteres til child processes. Verificeret: i en standard non-shell R-session (Rscript, RStudio, knitr, Shiny app, GitHub Actions runner, RStudio Server) er `UID` ikke i environment.
+
+**Konsekvens:**
+
+- `current_uid` bliver `integer(0)` eller `NA_integer_`
+- Guard-betingelsen `length(current_uid) > 0 && !is.na(current_uid) && current_uid > 0` udløses ikke
+- Ownership-check skipes silently
+- Kommentaren over koden ("Forhindrer andre processer adgang til eksportens midlertidige filer") henviser til `Sys.chmod(0700)`-linjen lige ovenfor — som ER den faktiske beskyttelse
+
+**Reel sikkerhed:** `tempfile()` bruger pr-bruger `tempdir()` (typisk `/tmp/RtmpXXX/` med UID-isolation fra OS), kombineret med `Sys.chmod(temp_dir, mode = "0700")` der eksplicit fjerner group/other-permissions. Ownership-checken tilføjer ingen reel beskyttelse oven på dette.
+
+**Hvorfor det er et problem:**
+
+- Misvisende defense-in-depth giver falsk fornemmelse af sikkerhed
+- Tester der antager at checken virker (fx fuzz-tests af UID-konfusion) vil aldrig se `stop()`-grenen og kan fejlagtigt mark security-coverage som "tested"
+- Vedligeholdelses-byrde: fremtidige reviewers skal genopdage at koden er død
+
+**Hvorfor missede Codex det:** Codex' review fokuserede på runtime-verificeret SPC-logik. Statisk analyse af "død guard" kræver kendskab til Unix env-var-konventioner.
+
+## What Changes
+
+- **NON-BREAKING** — implementations-ændring uden API-impact
+- **Foretrukken løsning:** Erstat `Sys.getenv("UID")` med en metode der pålideligt returnerer det effektive UID i R-session, eller fjern ownership-checken hvis den ikke kan implementeres robust:
+
+  **Option 1: Brug `Sys.info()`:**
+  ```r
+  current_user <- Sys.info()[["effective_user"]]
+  if (!is.null(current_user) && nzchar(current_user)) {
+    dir_info <- file.info(temp_dir)
+    # On Unix, file.info()$uid returns numeric UID; convert via system()
+    # eller skip — Sys.info gives username, ikke numeric UID
+  }
+  ```
+  Men `Sys.info()` returnerer username, ikke numeric UID — så vi skal alligevel mappe via fx `system("id -u", intern = TRUE)` for sammenligning. Det indfører subprocess.
+
+  **Option 2 (anbefales): Fjern checken**
+
+  - `tempfile()` + `Sys.chmod(0700)` er den korrekte og tilstrækkelige beskyttelse
+  - Erstat det døde branch med en præcis kommentar om hvorfor `tempdir()` + 0700 er sufficient
+  - Reducerer kompleksitet uden at miste reel security
+  - Symmetrisk med `bfh_create_export_session()` (`R/export_session.R:62`) der allerede kun bruger `Sys.chmod(0700)` uden ownership-check
+
+- Alternativt **Option 3 (compromise): Behold checken men gør den robust:**
+  - Brug `system2("id", "-u", stdout = TRUE)` til at hente numeric UID pålideligt
+  - Vurder om subprocess-cost er værd at betale for en yderst usandsynlig threat (nogen har UID-spoofet `/tmp/RtmpXXX/`-ejer mellem `tempfile()` og vores check, hvilket ville kræve symlink-race + race-condition-windows)
+  - Sandsynligvis ikke værd
+
+**Anbefaling:** Option 2 (fjern død kode + opdatér kommentar)
+
+## Impact
+
+**Affected specs:**
+- `pdf-export` — MODIFIED requirement: temp directory protection relies on tempfile + Sys.chmod, not ownership check
+
+**Affected code:**
+- `R/utils_export_helpers.R:213-223` — fjern `if (.Platform$OS.type == "unix") { ... }`-blok
+- Erstat med kommentar:
+  ```r
+  # Sikkerhed: tempfile() leverer en per-bruger isoleret sti i tempdir(),
+  # og Sys.chmod(0700) fjerner group/other-permissions. Yderligere
+  # ownership-validering via Sys.getenv("UID") er upålidelig (UID er
+  # shell-intern og typisk ikke eksporteret til R-processer).
+  ```
+
+**Affected tests:**
+- Fjern eventuelt eksisterende tests der mocker `Sys.getenv("UID")` for at trigger ownership-mismatch-grenen — de tester død kode
+- Verificér at `test-harden-export-pipeline-security.R` stadig dækker faktisk beskyttelse (tempfile + 0700)
+- Optional ny test: verificér at temp-dir har mode 0700 efter `prepare_temp_workspace()` på Unix:
+  ```r
+  test_that("temp dir has 0700 permissions on Unix", {
+    skip_on_os(c("windows"))
+    ws <- prepare_temp_workspace(NULL)
+    on.exit(unlink(ws$temp_dir, recursive = TRUE))
+    mode <- file.info(ws$temp_dir)$mode
+    expect_equal(as.integer(mode) %% 8^3, as.integer(strtoi("700", 8L)))
+  })
+  ```
+
+**Risiko:** Meget lav. Fjerner død kode, faktisk security uændret.
+
+**Effort estimat:** 15-20 minutter inkl. test-justering.
+
+**Bonus:** Når man alligevel rører området, kan man tilføje en kommentar i `bfh_create_export_session()` der eksplicit forklarer at ownership-check bevidst er udeladt af samme grund.

--- a/openspec/changes/archive/2026-04-29-cleanup-temp-dir-ownership-check/specs/pdf-export/spec.md
+++ b/openspec/changes/archive/2026-04-29-cleanup-temp-dir-ownership-check/specs/pdf-export/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Temp directory protection SHALL rely on tempfile() + Sys.chmod(0700)
+
+The temp directory created by `prepare_temp_workspace()` for PDF export SHALL be protected against other-user access by:
+
+1. Use of `tempfile()` for path generation, which produces a path under per-user `tempdir()` (OS-isolated)
+2. `Sys.chmod(temp_dir, mode = "0700", use_umask = FALSE)` to remove group/other read/write/execute permissions
+
+The implementation SHALL NOT rely on `Sys.getenv("UID")`-based ownership validation, because `UID` is a shell-internal environment variable that is typically not exported to non-interactive R sessions (Rscript, RStudio Server, knitr, Shiny apps, GitHub Actions runners). Such checks evaluate as `integer(0)` or `NA_integer_` and silently skip without ever firing the protective error branch — providing misleading defense-in-depth without actual protection.
+
+**Rationale:**
+
+- `tempfile()` + `Sys.chmod(0700)` is the canonical and sufficient mechanism in R for per-user temp directory isolation
+- Adding an unreliable check creates a false sense of security and increases maintenance burden
+- This requirement aligns `prepare_temp_workspace()` with the simpler implementation already in `bfh_create_export_session()` (which uses only `Sys.chmod(0700)`)
+
+#### Scenario: Temp directory has 0700 mode on Unix
+
+- **GIVEN** `prepare_temp_workspace(NULL)` is called on a Unix system
+- **WHEN** the function returns
+- **THEN** `file.info(temp_dir)$mode` SHALL have permission bits `0700`
+- **AND** group/other SHALL have no read/write/execute permission
+
+```r
+test_that("prepare_temp_workspace creates 0700 directory on Unix", {
+  skip_on_os(c("windows"))
+  ws <- prepare_temp_workspace(NULL)
+  on.exit(unlink(ws$temp_dir, recursive = TRUE))
+  mode_octal <- as.integer(file.info(ws$temp_dir)$mode) %% (8^3)
+  expect_equal(mode_octal, strtoi("700", 8L))
+})
+```
+
+#### Scenario: Temp directory path is under tempdir()
+
+- **GIVEN** `prepare_temp_workspace(NULL)` is called
+- **WHEN** the function returns
+- **THEN** `temp_dir` SHALL start with `tempdir()` (per-user isolated parent)
+
+```r
+test_that("temp_dir is under tempdir()", {
+  ws <- prepare_temp_workspace(NULL)
+  on.exit(unlink(ws$temp_dir, recursive = TRUE))
+  expect_true(startsWith(
+    normalizePath(ws$temp_dir, mustWork = FALSE),
+    normalizePath(tempdir(), mustWork = TRUE)
+  ))
+})
+```
+
+#### Scenario: Implementation does not rely on Sys.getenv("UID")
+
+- **GIVEN** the source of `R/utils_export_helpers.R`
+- **WHEN** the file is read
+- **THEN** the implementation SHALL NOT contain `Sys.getenv("UID")` calls or UID-based ownership comparisons in `prepare_temp_workspace()` or any related helper
+- **AND** any prior ownership-check code SHALL be replaced with an inline comment documenting why `tempfile()` + `Sys.chmod(0700)` is sufficient
+
+```r
+# Verification (regression test):
+test_that("prepare_temp_workspace does not use Sys.getenv UID check", {
+  src_path <- system.file("R", "utils_export_helpers.R", package = "BFHcharts")
+  if (nchar(src_path) == 0) skip("source not installed")
+  src <- readLines(src_path)
+  expect_false(any(grepl('Sys.getenv\\("UID"\\)', src)))
+})
+```

--- a/openspec/changes/archive/2026-04-29-cleanup-temp-dir-ownership-check/tasks.md
+++ b/openspec/changes/archive/2026-04-29-cleanup-temp-dir-ownership-check/tasks.md
@@ -1,0 +1,44 @@
+## 1. Code cleanup
+
+- [ ] 1.1 Fjern `if (.Platform$OS.type == "unix") { ... }`-blok i `R/utils_export_helpers.R:213-223`
+- [ ] 1.2 Erstat med kommentar der forklarer faktisk beskyttelse:
+  ```r
+  # Sikkerhed: tempfile() leverer en per-bruger isoleret sti i tempdir(),
+  # og Sys.chmod(0700) fjerner group/other-permissions. Yderligere
+  # ownership-validering via Sys.getenv("UID") er upålidelig (UID er
+  # shell-intern og typisk ikke eksporteret til R-processer), så vi
+  # forlader os på de to ovenstående mekanismer.
+  ```
+- [ ] 1.3 Verificér konsistens: `bfh_create_export_session()` (`R/export_session.R:62`) bruger allerede kun `Sys.chmod(0700)` uden ownership-check — tilføj samme inline-kommentar der hvis ikke allerede til stede
+
+## 2. Test cleanup
+
+- [ ] 2.1 Søg efter eksisterende tests der mocker `Sys.getenv("UID")`:
+  ```bash
+  grep -rn "Sys.getenv.*UID\|UID.*ownership" tests/
+  ```
+- [ ] 2.2 Hvis fundet: fjern dem (de tester nu fjernet kode)
+- [ ] 2.3 Tilføj ny test i `tests/testthat/test-harden-export-pipeline-security.R`:
+  ```r
+  test_that("prepare_temp_workspace creates 0700-mode temp directory on Unix", {
+    skip_on_os(c("windows"))
+    ws <- prepare_temp_workspace(NULL)
+    on.exit(unlink(ws$temp_dir, recursive = TRUE))
+    mode_octal <- as.integer(file.info(ws$temp_dir)$mode) %% (8^3)
+    expect_equal(mode_octal, as.integer(strtoi("700", 8L)),
+      info = "temp dir must be 0700 to prevent other-user access")
+  })
+  ```
+- [ ] 2.4 Verificér at eksisterende `test-security-*.R` ikke depender på fjernede error-branch
+
+## 3. Verification
+
+- [ ] 3.1 `devtools::test()` — alle tests passerer
+- [ ] 3.2 `devtools::check()` — ingen nye WARN/ERROR
+- [ ] 3.3 Manuel: kør `prepare_temp_workspace(NULL)` interaktivt på Linux/macOS, verificér mode 0700
+- [ ] 3.4 Statisk: `grep -rn "Sys.getenv.*UID" R/` returnerer intet
+
+## 4. Release
+
+- [ ] 4.1 NEWS.md entry under `## Interne ændringer` for næste patch-version (kort note: "Fjernet ineffektiv ownership-check i temp-dir-staging; faktisk beskyttelse via tempfile() + Sys.chmod(0700) uændret")
+- [ ] 4.2 Bump `DESCRIPTION` til næste patch (kan kombineres med proposal #2/#3)

--- a/openspec/changes/archive/2026-04-29-complete-chart-type-public-docs/proposal.md
+++ b/openspec/changes/archive/2026-04-29-complete-chart-type-public-docs/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+Codex code review 2026-04-29 (OPPORTUNISTIC, høj confidence) fandt at `bfh_qic()` Roxygen-dokumentationen ikke beskriver alle gyldige `chart_type`-værdier som validering accepterer.
+
+**Fakta:**
+
+- `R/chart_types.R:21` definerer `CHART_TYPES_EN <- c("run", "i", "mr", "p", "pp", "u", "up", "c", "g", "xbar", "s", "t")` (12 typer)
+- `R/utils_bfh_qic_helpers.R:218-223` (`validate_bfh_qic_inputs()`) validerer mod denne fulde liste
+- `R/bfh_qic.R:23` (`@param chart_type`) lister kun: `"run", "i", "p", "c", "u", "xbar", "s", "t", "g"` (9 typer)
+- `R/bfh_qic.R:75-83` (`@details Chart Types`) lister samme reducerede sæt
+
+**Manglende fra public docs:**
+- `mr` — Moving Range chart (paret med I-chart, ikke nævnt isoleret)
+- `pp` — P-prime chart (Laney-justeret proportions)
+- `up` — U-prime chart (Laney-justeret rates)
+
+**Konsekvens:**
+- API-discovery er ufuldstændig — brugere der søger efter "Laney" eller "moving range" via `?bfh_qic` finder ingenting
+- Onboarding-friktion: brugere må læse kildekoden for at finde alle typer
+- Denominator-validering (`R/utils_helpers.R:269`) refererer korrekt til `pp` og `up`, men deres eksistens er usynlig i public docs
+
+## What Changes
+
+- **NON-BREAKING** — kun dokumentation
+- Opdatér `R/bfh_qic.R` `@param chart_type` (linje 23): tilføj `"mr"`, `"pp"`, `"up"` til listen
+- Opdatér `@details Chart Types` (linje 75-83): tilføj nye sektioner:
+  - **mr**: Moving Range chart (paired with I-chart, measures point-to-point variability)
+  - **pp**: P-prime chart (Laney-adjusted proportions for over-dispersion in large samples)
+  - **up**: U-prime chart (Laney-adjusted rates for over-dispersion in large samples)
+- Tilføj kort note om hvornår Laney-varianter er passende:
+  > Use `pp` / `up` instead of `p` / `u` when you have very large denominators (`n > 1000` per subgroup) and standard control limits become artificially tight due to over-dispersion. See qicharts2 documentation for details.
+- Opdatér `@details Denominator Contract` (linje 90-105) for at konsistent inkludere `pp`, `up` (allerede listet — verify only)
+- Tilføj 2 nye eksempler i `@examples`-sektionen:
+  - Eksempel: `chart_type = "pp"` med stort denominator
+  - Eksempel: `chart_type = "mr"` paret med en I-chart
+- Kør `devtools::document()` for at re-generere `man/bfh_qic.Rd`
+
+**Out of scope:**
+- Vignettes / longform-tutorials for nye typer — kan tilføjes separat hvis efterspørgsel
+- Ændring af `auto_detect_chart_type()` (hvis funktionen findes) — ingen detection logic ændres
+
+## Impact
+
+**Affected specs:**
+- `public-api` — MODIFIED requirement: chart_type documentation reflects all validated types
+
+**Affected code:**
+- `R/bfh_qic.R` — Roxygen `@param chart_type`, `@details Chart Types`, `@examples`
+- `man/bfh_qic.Rd` — auto-genereret efter `devtools::document()`
+
+**Affected tests:**
+- Optional regression: `tests/testthat/test-public-api-contract.R` — verificér at alle entries i `CHART_TYPES_EN` også optræder i Rd-filen
+
+**Risiko:** Ingen runtime-impact.
+
+**Effort estimat:** 30 minutter inkl. nye eksempler + R CMD check.
+
+**Kombinations-mulighed:** Kan committes sammen med proposal #2 (`update-print-summary-removal-docs`) som én docs-cleanup PR.

--- a/openspec/changes/archive/2026-04-29-complete-chart-type-public-docs/specs/public-api/spec.md
+++ b/openspec/changes/archive/2026-04-29-complete-chart-type-public-docs/specs/public-api/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Public functions SHALL document all values their input validators accept
+
+Public exported functions whose parameters are validated against an enumerated set of allowed values SHALL document **all** allowed values in the user-facing roxygen `@param` and `@details` blocks. Discrepancies between validator-accepted values and documented values SHALL be treated as documentation bugs.
+
+**Rationale:**
+- API discovery via `?function_name` must surface the full feature surface
+- Hidden parameter values force users to read source code
+- Inconsistency between validator and docs creates maintenance debt and erodes trust
+
+This requirement specifically addresses the `chart_type` parameter of `bfh_qic()`, but applies to any future enumerated parameters (e.g., `y_axis_unit`, `agg.fun`, `language`).
+
+#### Scenario: chart_type roxygen lists all validated types
+
+- **GIVEN** the validator at `R/utils_bfh_qic_helpers.R:218-223` accepts the set defined by `CHART_TYPES_EN` in `R/chart_types.R:21`
+- **WHEN** a user reads `?bfh_qic`
+- **THEN** the `@param chart_type` description SHALL list every value in that set: `"run"`, `"i"`, `"mr"`, `"p"`, `"pp"`, `"u"`, `"up"`, `"c"`, `"g"`, `"xbar"`, `"s"`, `"t"`
+- **AND** the `@details Chart Types` block SHALL provide a one-line description for each type
+
+```r
+# Verification (regression test):
+test_that("bfh_qic Rd documents all validated chart types", {
+  rd_path <- system.file("man", "bfh_qic.Rd", package = "BFHcharts")
+  skip_if(nchar(rd_path) == 0)
+  rd_content <- paste(readLines(rd_path), collapse = "\n")
+  for (t in BFHcharts:::CHART_TYPES_EN) {
+    expect_true(grepl(paste0("\\b", t, "\\b"), rd_content),
+                info = paste("Chart type", t, "missing from Rd"))
+  }
+})
+```
+
+#### Scenario: Laney-adjusted variants describe over-dispersion use case
+
+- **GIVEN** chart types `"pp"` and `"up"` exist as Laney-adjusted variants of `"p"` and `"u"`
+- **WHEN** a user reads `?bfh_qic`
+- **THEN** the documentation SHALL identify `"pp"` and `"up"` as Laney-adjusted variants
+- **AND** SHALL provide guidance on when to use them (over-dispersion with very large denominators) so users can choose the appropriate variant without consulting external sources
+
+```
+**pp**: P-prime chart (Laney-adjusted proportions) — use instead of `p`
+when denominators are very large (n > 1000 per subgroup) and standard
+control limits become artificially tight due to over-dispersion.
+
+**up**: U-prime chart (Laney-adjusted rates) — same rationale as `pp`,
+applied to count rates.
+```
+
+#### Scenario: Moving Range chart documented as I-chart pair
+
+- **GIVEN** chart type `"mr"` exists as the Moving Range counterpart to the I-chart
+- **WHEN** a user reads `?bfh_qic`
+- **THEN** the documentation SHALL identify `"mr"` as a Moving Range chart
+- **AND** SHALL note its typical pairing with an I-chart for full process variation analysis
+
+```
+**mr**: Moving Range chart — measures point-to-point variability.
+Typically paired with an I-chart to characterize both process level
+(I) and short-term variation (MR).
+```

--- a/openspec/changes/archive/2026-04-29-complete-chart-type-public-docs/tasks.md
+++ b/openspec/changes/archive/2026-04-29-complete-chart-type-public-docs/tasks.md
@@ -1,0 +1,51 @@
+## 1. Roxygen update
+
+- [ ] 1.1 Opdatér `@param chart_type` (`R/bfh_qic.R:23`) til at inkludere alle 12 typer fra `CHART_TYPES_EN`
+- [ ] 1.2 Opdatér `@details Chart Types`-blokken (`R/bfh_qic.R:75-83`) — tilføj sektioner for:
+  - `mr`: Moving Range chart
+  - `pp`: P-prime (Laney-adjusted proportions)
+  - `up`: U-prime (Laney-adjusted rates)
+- [ ] 1.3 Tilføj kort guidance om Laney-varianter under over-dispersion (~2 linjer)
+- [ ] 1.4 Verificér at `@details Denominator Contract`-tabellen allerede dækker `pp` + `up` (den gør)
+
+## 2. Examples
+
+- [ ] 2.1 Tilføj eksempel for `chart_type = "pp"` med stort denominator (n > 1000)
+- [ ] 2.2 Tilføj eksempel for `chart_type = "mr"` paret med I-chart (vis hvordan to charts kan kombineres)
+- [ ] 2.3 Wrap nye eksempler i eksisterende `\dontrun{}`-blok
+
+## 3. Re-generate Rd
+
+- [ ] 3.1 Kør `devtools::document()`
+- [ ] 3.2 Bekræft at `man/bfh_qic.Rd` indeholder alle 12 chart-types
+- [ ] 3.3 Commit `man/bfh_qic.Rd` sammen med `R/bfh_qic.R`
+
+## 4. Regression test (optional)
+
+- [ ] 4.1 Tilføj test i `tests/testthat/test-public-api-contract.R`:
+  ```r
+  test_that("bfh_qic Rd documents all validated chart types", {
+    rd_path <- system.file("man", "bfh_qic.Rd", package = "BFHcharts")
+    skip_if(nchar(rd_path) == 0)
+    rd_content <- paste(readLines(rd_path), collapse = "\n")
+    expected_types <- BFHcharts:::CHART_TYPES_EN
+    for (t in expected_types) {
+      expect_true(
+        grepl(paste0("\\b", t, "\\b"), rd_content),
+        info = paste("Chart type", t, "missing from Rd")
+      )
+    }
+  })
+  ```
+
+## 5. Verification
+
+- [ ] 5.1 `devtools::check()` passes
+- [ ] 5.2 Manuel: `?bfh_qic` viser alle chart types
+- [ ] 5.3 Manuel: kør nye eksempler interaktivt — bekræft at de fungerer
+- [ ] 5.4 Cross-check at biSPCharts-app eksponerer samme chart-type-liste (eller flag mismatch som separat issue)
+
+## 6. Release
+
+- [ ] 6.1 NEWS.md entry under `## Documentation` for næste patch-version (kan kombineres med proposal #2)
+- [ ] 6.2 Bump `DESCRIPTION` til næste patch

--- a/openspec/changes/archive/2026-04-29-enable-ci-safe-pdf-smoke-render/proposal.md
+++ b/openspec/changes/archive/2026-04-29-enable-ci-safe-pdf-smoke-render/proposal.md
@@ -1,0 +1,95 @@
+## Why
+
+Begge code reviews 2026-04-29 (Claude statisk + Codex runtime) flaggede at `.github/workflows/pdf-smoke.yaml` er disabled (`pdf-smoke.yaml.disabled`, commit `c798142`). Den var oprindeligt designet som PR-blocking gate for end-to-end Typst/Quarto-pipeline-regressioner.
+
+Codex' anden runtime-undersøgelse identificerede de **konkrete årsager** til at workflowet ikke kan blive grøn:
+
+**1. Untracked template assets:**
+
+```
+$ git ls-files inst/templates/typst/bfh-template
+inst/templates/typst/bfh-template/bfh-template.typ
+```
+
+Lokalt findes også `inst/templates/typst/bfh-template/fonts/` og `images/` — men de er **untracked**. Bekræftes af `git status` ved session-start: `?? inst/templates/typst/bfh-template/images/`. CI-checkout får kun `bfh-template.typ`, ingen Mari-fonts og ingen logo-billeder.
+
+**2. Workflow env-var ikke sat:**
+
+`pdf-smoke.yaml.disabled` header siger:
+```
+... installerer open fallback-fonts (DejaVu, Liberation, Noto, Roboto)
+og sætter dem som font_path-override i render_smoke.R via env-var
+BFHCHARTS_SMOKE_FONT_PATH.
+```
+
+Men workflow-stepsene installerer fonts via `apt-get` og kører `fc-cache`, **uden** at sætte `BFHCHARTS_SMOKE_FONT_PATH`. `tests/smoke/render_smoke.R:80` læser denne env-var — når den er tom, falder den tilbage til default-adfærd (`ignore_system_fonts = TRUE`), hvilket forhindrer Typst i at bruge de apt-installerede fonts.
+
+**3. Mari-font-strategi:**
+
+Mari er proprietær og kan ikke commits til public repo. Pakkens egen font-fallback-chain (Mari → Roboto → Arial → Helvetica → sans-serif) er designet netop til scenarier hvor Mari ikke er tilgængelig — men kun hvis Typst faktisk kan se fallbacks.
+
+**Korrekt analyse:** PDF-smoke kan blive grøn på CI **hvis** font-strategien er CI-eksplicit. Den nuværende disable er et bevidst kompromis fordi første aktiverings-forsøg ikke loadede fallback-fonts korrekt — ikke fordi det er principielt umuligt.
+
+**Cost-benefit:**
+- **Cost ved ikke at have PR-gate:** Typst/Quarto-pipeline-regressioner (template-syntax, escape-bugs, asset-paths) lander på main og fanges først ved næste manuelle render eller ugentlig cron i `render-tests.yaml`. Codex' runtime-tests bestod 3/3 lokalt → pipelinen virker, så regressions-risiko er reel
+- **Cost ved at fikse:** ~2-4 timer arbejde, ingen breaking changes, ingen nye dependencies
+
+## What Changes
+
+- **NON-BREAKING** — kun CI-konfiguration og test-asset-staging
+- Beslutning: enten **(A) font-fallback-only** eller **(B) bundled-test-fonts**. Forslag: **A først, B kun hvis A insufficient**
+
+### Strategi A: Font-fallback only (foretrukket — enklere)
+
+1. **Track template assets der mangler i git:**
+   - Verificér at `inst/templates/typst/bfh-template/fonts/` indeholder kun licens-kompatible fonts (ingen Mari) — hvis ja, track. Hvis Mari ligger der, ekskludér via `.gitignore` og dokumentér hvor den kommer fra ved lokal udvikling
+   - Track `inst/templates/typst/bfh-template/images/` (logo-assets der ikke er proprietære)
+2. **Fix workflow env-var:**
+   - I `pdf-smoke.yaml`, tilføj efter `apt-get install`-step:
+     ```yaml
+     - name: Set font path for smoke render
+       run: |
+         echo "BFHCHARTS_SMOKE_FONT_PATH=/usr/share/fonts/truetype" >> $GITHUB_ENV
+     ```
+   - ELLER alternativt: ændre `tests/smoke/render_smoke.R` til at sætte `ignore_system_fonts = FALSE` på CI (detect via `Sys.getenv("CI") == "true"`), så Typst kan bruge apt-installerede fonts uden eksplicit path
+3. **Reactivate workflow:**
+   - Rename `pdf-smoke.yaml.disabled` → `pdf-smoke.yaml`
+   - Verificér at workflowet bliver grøn på en test-PR før merge
+
+### Strategi B: Bundled test fonts (fallback hvis A ikke er nok)
+
+Hvis A ikke giver grøn CI (fx fordi `bfh-template.typ` har hardcoded font-names der ikke er installerede):
+
+1. Tilføj minimal test-template `tests/smoke/test-template.typ` der kun bruger `set text(font: "DejaVu Sans")`
+2. `render_smoke.R` bruger denne test-template via `template_path`-argument på CI
+3. `bfh-template.typ` med Mari-fonts forbliver kun brugt lokalt + via `BFHcharts:::system.file()` i produktion
+
+**Out of scope:**
+- Visuel regression med Mari-fonts på CI — håndteres allerede af `vdiffr` (skipped on CI for platform-specific font rendering) og manuel review
+- Branch-protection-konfiguration på GitHub — kræver manuel admin-handling dokumenteret i tasks
+- Replikering af proprietære Mari-fonts i CI — udelukket pga. licens
+
+## Impact
+
+**Affected specs:**
+- `test-infrastructure` — MODIFIED requirement: PR-blocking PDF render gate SHALL be CI-safe via deterministic font fallback strategy
+
+**Affected code:**
+- `.github/workflows/pdf-smoke.yaml.disabled` → `.github/workflows/pdf-smoke.yaml` (rename + fix font env-var step)
+- `tests/smoke/render_smoke.R` — optional: tilføj CI-detect for `ignore_system_fonts = FALSE`-override
+- `inst/templates/typst/bfh-template/` — track legitimate assets (verify Mari ikke commits)
+- Eventuelt: `tests/smoke/test-template.typ` (kun hvis Strategi B nødvendig)
+- `.gitignore` — eksplicit ekskludér Mari-font-filer ved navn hvis de tidligere lå untracked
+
+**Branch-protection (manuelt admin-step):**
+- Settings → Branches → main + develop → Require status checks → tilføj `pdf-smoke (ubuntu-latest)`
+
+**Risiko:**
+- Lav teknisk risiko (CI-only ændring, intet runtime-impact)
+- Procesmæssig risiko: workflowet kan stadig fejle initialt indtil rigtig kombination af `font_path` + `ignore_system_fonts` er fundet. Mitigér via test-PR før branch-protection aktiveres
+
+**Effort estimat:**
+- Strategi A: 2-4 timer (asset-staging + workflow-fix + test-PR-iteration)
+- Strategi B: +2-3 timer (separat test-template)
+
+**Effort matches priority:** FIX SOON, ikke FIX NOW. Kan ligge i næste sprint.

--- a/openspec/changes/archive/2026-04-29-enable-ci-safe-pdf-smoke-render/specs/test-infrastructure/spec.md
+++ b/openspec/changes/archive/2026-04-29-enable-ci-safe-pdf-smoke-render/specs/test-infrastructure/spec.md
@@ -1,0 +1,89 @@
+## ADDED Requirements
+
+### Requirement: PR-blocking PDF render gate SHALL be CI-safe via deterministic fallback fonts
+
+A PR-blocking GitHub Actions workflow SHALL execute end-to-end PDF rendering on every pull request to `main` and `develop`. The workflow SHALL be deterministically green when the package code is correct, despite the proprietary Mari font not being installable on CI.
+
+**Rationale:**
+
+- End-to-end Typst/Quarto pipeline regressions (template syntax, escape bugs, asset paths, font-fallback wiring) cannot be caught by unit tests of R code alone
+- Without a PR gate, regressions land on `main` and are caught only by weekly cron renders or manual verification — too slow to block bad merges
+- Mari font is proprietary and cannot be redistributed in a public repository; CI must rely on legally redistributable fallback fonts
+- Disabling the workflow (current state: `pdf-smoke.yaml.disabled`) leaves an exposed gap that both code reviews flagged
+
+**CI font strategy contract:**
+
+The workflow SHALL satisfy one of the following CI-safe configurations:
+
+**Option A (preferred):** Use system-installed open fallback fonts via `apt-get install`, point `BFHCHARTS_SMOKE_FONT_PATH` env var to their installation path, and let the package's existing font-fallback chain (Mari → Roboto → Arial → Helvetica → sans-serif) resolve to a system font. Requires `ignore_system_fonts = FALSE` OR explicit `font_path` to apt-installed fonts.
+
+**Option B (fallback):** Use a minimal CI-only Typst test-template (`tests/smoke/test-template.typ`) that hardcodes only universal open fonts (e.g., DejaVu Sans). The production `bfh-template.typ` is not exercised on CI but still used in production where Mari is available.
+
+**Asset bundling contract:**
+
+- Template files in `inst/templates/typst/bfh-template/` SHALL be tracked in git **except** files identified as proprietary (Mari fonts)
+- Proprietary font filenames SHALL be explicitly excluded via `.gitignore`
+- Non-proprietary assets (logos, open fonts, images) SHALL be tracked so CI checkout can reproduce the rendering environment
+
+#### Scenario: PDF smoke workflow is enabled and required
+
+- **GIVEN** the GitHub repository
+- **WHEN** a developer inspects `.github/workflows/`
+- **THEN** `pdf-smoke.yaml` SHALL exist (not `.disabled`)
+- **AND** the workflow SHALL be configured as a required status check on the `main` and `develop` branches via branch protection
+
+#### Scenario: Smoke workflow renders against legally redistributable fonts
+
+- **GIVEN** the smoke workflow runs on a fresh GitHub-hosted Ubuntu runner
+- **WHEN** the workflow installs system fonts via `apt-get install fonts-dejavu fonts-liberation fonts-noto`
+- **THEN** the env var `BFHCHARTS_SMOKE_FONT_PATH` SHALL point to a directory those fonts are installed in
+- **AND** `tests/smoke/render_smoke.R` SHALL pass `font_path = Sys.getenv("BFHCHARTS_SMOKE_FONT_PATH")` to `bfh_export_pdf()`
+- **AND** `bfh_export_pdf()` SHALL successfully compile a PDF that is non-empty and has at least 1 page
+
+```r
+# tests/smoke/render_smoke.R contract:
+font_path_override <- Sys.getenv("BFHCHARTS_SMOKE_FONT_PATH", unset = NA_character_)
+stopifnot(!is.na(font_path_override) || !is_ci())  # CI must set the env var
+
+result <- bfh_qic(test_data, ...)
+out_pdf <- tempfile(fileext = ".pdf")
+bfh_export_pdf(
+  result, out_pdf,
+  font_path = if (!is.na(font_path_override)) font_path_override else NULL
+)
+
+stopifnot(file.exists(out_pdf))
+stopifnot(file.info(out_pdf)$size > 0)
+stopifnot(pdftools::pdf_info(out_pdf)$pages >= 1)
+```
+
+#### Scenario: Proprietary fonts excluded from git
+
+- **GIVEN** developer adds a Mari-licensed font to the local template directory
+- **WHEN** the developer runs `git status`
+- **THEN** the Mari font file SHALL appear as ignored (via `.gitignore` pattern)
+- **AND** SHALL NOT be accidentally committed via `git add inst/`
+
+```gitignore
+# Excerpt from .gitignore
+inst/templates/typst/bfh-template/fonts/Mari*.ttf
+inst/templates/typst/bfh-template/fonts/Mari*.otf
+```
+
+#### Scenario: Workflow header documentation matches actual implementation
+
+- **GIVEN** `.github/workflows/pdf-smoke.yaml` header comment claims a font strategy
+- **WHEN** a maintainer reads the workflow header
+- **THEN** the documented strategy SHALL match what the workflow steps actually do
+- **AND** any env vars referenced in the header SHALL actually be set by a workflow step
+- **AND** drift between header and steps SHALL be treated as a documentation bug requiring fix
+
+This scenario specifically prevents the regression where the prior `pdf-smoke.yaml.disabled` header described setting `BFHCHARTS_SMOKE_FONT_PATH` while no workflow step actually exported it.
+
+#### Scenario: Workflow failure uploads diagnostic artifacts
+
+- **GIVEN** the smoke workflow fails (non-zero exit code from `Rscript tests/smoke/render_smoke.R`)
+- **WHEN** the workflow finishes
+- **THEN** `actions/upload-artifact@v4` SHALL upload generated `.pdf`, `.typ`, and `.tex.log` files
+- **AND** the artifact name SHALL include `${{ github.run_id }}` for unique identification
+- **AND** retention SHALL be at least 7 days

--- a/openspec/changes/archive/2026-04-29-enable-ci-safe-pdf-smoke-render/tasks.md
+++ b/openspec/changes/archive/2026-04-29-enable-ci-safe-pdf-smoke-render/tasks.md
@@ -1,0 +1,73 @@
+## 0. Pre-investigation (BLOCKING for strategy choice)
+
+- [ ] 0.1 Inspect `inst/templates/typst/bfh-template/fonts/` lokalt — list filnavne + licenser:
+  - Mari fonts (proprietær): SKAL IKKE committes
+  - DejaVu/Roboto/etc: kan committes hvis licens tillader (typisk OFL/Apache)
+- [ ] 0.2 Inspect `inst/templates/typst/bfh-template/images/` — verificér at intet er proprietært
+- [ ] 0.3 Læs `bfh-template.typ` — identificér hvilke font-names der hardcodes (fx `set text(font: "Mari")`); afgør om Strategi A er tilstrækkelig
+- [ ] 0.4 Beslutning: Strategi A (font-fallback) eller Strategi B (bundled test-template). Dokumentér valg i PR-beskrivelsen
+
+## 1. Asset-staging (Strategi A)
+
+- [ ] 1.1 Track ikke-proprietære filer i `inst/templates/typst/bfh-template/`:
+  ```bash
+  git add inst/templates/typst/bfh-template/images/
+  git add inst/templates/typst/bfh-template/fonts/<licens-tilladte filer>
+  ```
+- [ ] 1.2 Tilføj eksplicit `.gitignore`-entry for proprietære fonts:
+  ```
+  inst/templates/typst/bfh-template/fonts/Mari*.ttf
+  inst/templates/typst/bfh-template/fonts/Mari*.otf
+  ```
+- [ ] 1.3 Dokumentér i `inst/templates/typst/bfh-template/README.md` (ny) hvor Mari-fonts kommer fra ved lokal udvikling og hvordan eksterne developers håndterer fallback
+
+## 2. Workflow-fix
+
+- [ ] 2.1 Rename `.github/workflows/pdf-smoke.yaml.disabled` → `.github/workflows/pdf-smoke.yaml`
+- [ ] 2.2 Tilføj font-path env-step efter `apt-get install`:
+  ```yaml
+  - name: Configure smoke render font path
+    run: |
+      # /usr/share/fonts er hvor apt-installerede fonts ligger
+      echo "BFHCHARTS_SMOKE_FONT_PATH=/usr/share/fonts" >> $GITHUB_ENV
+      # Verify fonts are reachable
+      fc-list | head -20
+    shell: bash
+  ```
+- [ ] 2.3 Verificér at `tests/smoke/render_smoke.R` korrekt læser `BFHCHARTS_SMOKE_FONT_PATH` og videregiver til `bfh_export_pdf(..., font_path = ...)`
+- [ ] 2.4 Optional: i `render_smoke.R`, tilføj CI-detection:
+  ```r
+  is_ci <- Sys.getenv("CI", unset = "") != ""
+  ignore_fonts <- !is_ci  # på CI: brug system fonts; lokalt: ignore for konsistens
+  bfh_export_pdf(..., ignore_system_fonts = ignore_fonts)
+  ```
+
+## 3. Test-PR-iteration
+
+- [ ] 3.1 Open test-PR med ovenstående ændringer mod `develop`
+- [ ] 3.2 Verificér at `pdf-smoke (ubuntu-latest)`-job bliver grøn
+- [ ] 3.3 Hvis fejler: download `pdf-smoke-failures-<run_id>` artifact og diagnosticér (typisk Typst font-error eller manglende asset)
+- [ ] 3.4 Iterér på Strategi A; hvis fortsat fejler efter 2-3 forsøg, eskalér til Strategi B
+
+## 4. Strategi B (kun hvis 3.4 kræver det)
+
+- [ ] 4.1 Opret `tests/smoke/test-template.typ` — minimal Typst-template der kun bruger universelle fonts (`set text(font: "DejaVu Sans")`)
+- [ ] 4.2 Modificér `render_smoke.R` til at bruge denne test-template via `template_path`-argument når `Sys.getenv("CI") == "true"`
+- [ ] 4.3 Re-test PR — verificér grøn
+
+## 5. Branch protection (MANUELT TRIN)
+
+- [ ] 5.1 **[MANUELT TRIN]** GitHub admin: Settings → Branches → Branch protection rules → main + develop → Require status checks → tilføj `pdf-smoke (ubuntu-latest)`
+- [ ] 5.2 Dokumentér ændringen i `CONTRIBUTING.md` eller PR-template
+
+## 6. Documentation
+
+- [ ] 6.1 Opdatér `tests/smoke/render_smoke.R` header-kommentar med faktisk CI-strategi (efter strategi-valg)
+- [ ] 6.2 NEWS.md entry under `## CI` for næste patch-version
+- [ ] 6.3 Opdatér `pdf-smoke.yaml` header-kommentar så den matcher det faktiske workflow (fjern den misvisende sætning om `BFHCHARTS_SMOKE_FONT_PATH` hvis den ikke længere matcher)
+
+## 7. Verification
+
+- [ ] 7.1 Test-PR mod `develop` har grøn smoke-render i mindst 3 successive runs
+- [ ] 7.2 Dummy-failure test: introducér bevidst Typst-syntax-fejl, verificér at workflowet rød-flagger og artifact-uploader fejler-PDF til debugging
+- [ ] 7.3 Cleanup test-PR efter verification

--- a/openspec/changes/archive/2026-04-29-fix-percent-target-scale-in-analysis/proposal.md
+++ b/openspec/changes/archive/2026-04-29-fix-percent-target-scale-in-analysis/proposal.md
@@ -1,0 +1,67 @@
+## Why
+
+Codex code review 2026-04-29 (FIX NOW, høj severity, runtime-verificeret) fandt at `bfh_generate_analysis()` for percent-charts kan producere klinisk misvisende auto-analysis-tekst.
+
+**Bug-mekanisme:**
+
+1. Bruger kalder `bfh_export_pdf(..., metadata = list(target = ">= 90%"))` på p-chart
+2. `resolve_target("≥ 90%")` parser numerisk værdi til `90` (fjerner `%`-suffix og operator), `direction = "higher"`, `display = ">= 90%"`
+3. `bfh_build_analysis_context()` kopierer `target_value = 90` til kontekst
+4. `centerline` for p-chart med `y_axis_unit = "percent"` er på proportionsskala (fx `0.91`)
+5. `build_fallback_analysis()` evaluerer `goal_met <- centerline >= target_value` → `0.91 >= 90` → `FALSE`
+6. Output: "målet er endnu ikke nået (>= 90%)" — selvom 91% **opfylder** ≥ 90%
+
+**Verificeret runtime (Codex):**
+
+```
+centerline=0.91 target=90 direction=higher
+→ "Niveauet opfylder endnu ikke målet (>= 90%)"
+```
+
+**Klinisk impact:** PDF-rapporter sendt til afdelinger kan vende målvurderingen forkert. En afdeling der reelt opfylder en kvalitetsindikator får automatisk genereret tekst der siger det modsatte. Brugere har ingen synlig indikator om at fejlen findes — analysen ser ud som korrekt narrativ.
+
+**Hvorfor missede statisk review:** Bug findes kun i sammenspil mellem `parse_target_input()` (fjerner `%`), `bfh_build_analysis_context()` (gemmer rå value), og `build_fallback_analysis()` (sammenligner direkte). Hver enkelt funktion er korrekt isoleret. Kræver runtime-tracing eller konkret test-case.
+
+## What Changes
+
+- **NON-BREAKING** for callers der ikke bruger `auto_analysis = TRUE` med percent-targets
+- Normaliser `target_value` til proportionsskala i `bfh_build_analysis_context()` når:
+  - `y_axis_unit == "percent"` AND
+  - `target_display` indeholder literal `"%"` AND
+  - parsed `target_value > 1` (heuristik: scale 0-100 ikke 0-1)
+  
+  Resultat: `target_value` divideres med 100 før lagring. `target_display` bevares uændret ("≥ 90%") til tekst-output.
+
+- Edge cases håndteres eksplicit:
+  - Numerisk input `metadata$target = 90` på percent-chart: normaliseres (samme heuristik værdi > 1)
+  - Numerisk input `metadata$target = 0.9` på percent-chart: efterlades uændret (allerede proportion)
+  - Karakter input `"90%"` uden operator på percent-chart: normaliseres
+  - Karakter input `"≥ 0.9"` (ingen `%` i display): efterlades uændret — tillader power-users at angive proportion direkte
+  - `y_axis_unit != "percent"`: ingen normalisering (bevarer count/rate/time-semantik)
+  - Negative tærskler `target_value <= 0`: ingen normalisering (defensivt — proportions kan ikke være negative; bevar for at fejle synligt et andet sted)
+
+- Tests:
+  - Tilføj `tests/testthat/test-spc_analysis.R` test-blokke for alle ovenstående edge cases
+  - Regression-test: p-chart med `centerline = 0.91`, `target = ">= 90%"` → output indeholder "opfylder målet" (eller language-equivalent)
+  - Regression-test: p-chart med `centerline = 0.85`, `target = "<= 90%"` → "lower" direction goal met
+  - Regression-test: I-chart med `target = ">= 90"` (ingen `%`, ej percent) → uændret adfærd
+
+- NEWS.md entry under `## Bug fixes` for næste minor-bump
+
+## Impact
+
+**Affected specs:**
+- `spc-analysis-api` — MODIFIED requirement: `bfh_build_analysis_context` SHALL normalize percent targets to proportion scale when context's `y_axis_unit` is `"percent"` and target display contains `%`
+
+**Affected code:**
+- `R/spc_analysis.R:157` (`bfh_build_analysis_context`) — tilføj normalisering efter `resolve_target()`-kald, før `target_value` skrives til context
+- `tests/testthat/test-spc_analysis.R` — nye regression-tests (estimat: 5-7 nye `test_that`-blokke)
+- `NEWS.md` — bug fix entry
+
+**Backwards compatibility:**
+- Eksisterende kald med `auto_analysis = FALSE` (default): uændret
+- Eksisterende kald med rate/count/time-charts: uændret (heuristik matcher ikke)
+- Eksisterende kald med percent-chart + numerisk target på proportion-skala (`target = 0.9`): uændret
+- **Adfærdsændring** kun for: percent-chart + percent-formuleret target (string med `%` eller numerisk > 1) + `auto_analysis = TRUE`
+
+**Severity:** Klinisk korrekthed (ikke teknisk gæld). Bør indgå i næste patch-release uden at vente på akkumuleret feature-arbejde.

--- a/openspec/changes/archive/2026-04-29-fix-percent-target-scale-in-analysis/specs/spc-analysis-api/spec.md
+++ b/openspec/changes/archive/2026-04-29-fix-percent-target-scale-in-analysis/specs/spc-analysis-api/spec.md
@@ -1,0 +1,133 @@
+## ADDED Requirements
+
+### Requirement: bfh_build_analysis_context SHALL normalize percent targets to proportion scale
+
+The `bfh_build_analysis_context()` function SHALL detect when a target is expressed in percent format (`y_axis_unit = "percent"` AND target display contains `"%"`) and SHALL normalize the stored `target_value` from 0-100 scale to 0-1 (proportion) scale before placing it in the returned context. This ensures downstream consumers (notably `build_fallback_analysis()`) compare `target_value` against `centerline` on a consistent scale.
+
+**Rationale:**
+
+For percent-formatted SPC charts (p, pp), `qicharts2::qic()` returns `centerline` on the proportion scale (`0.91` for 91%), but `parse_target_input("≥ 90%")` strips the percent suffix and returns the raw numeric `90`. Without normalization, the comparison `centerline >= target_value` evaluates `0.91 >= 90 → FALSE`, producing clinically misleading auto-analysis text such as "målet er endnu ikke nået" when the centerline actually exceeds the percent target.
+
+This bug was identified in Codex code review 2026-04-29 (FIX NOW severity) with runtime verification that `target = ">= 90%"` on a p-chart with `centerline = 0.91` produced the wrong directional verdict.
+
+**Normalization contract:**
+
+| Input | y_axis_unit | target_display contains "%" | parsed target_value | Stored target_value |
+|-------|-------------|----------------------------|---------------------|---------------------|
+| `">= 90%"` | `"percent"` | yes | 90 | **0.90** (normalized) |
+| `90` (numeric) | `"percent"` | no display, value > 1 | 90 | **0.90** (normalized) |
+| `0.9` (numeric) | `"percent"` | no display, value <= 1 | 0.9 | 0.9 (unchanged) |
+| `">= 0.9"` | `"percent"` | no | 0.9 | 0.9 (unchanged) |
+| `">= 90"` | `"count"` | no | 90 | 90 (unchanged) |
+| `"<= 2.5"` | `"rate"` | no | 2.5 | 2.5 (unchanged) |
+
+**Heuristic:**
+- Normalize when `y_axis_unit == "percent"` AND (`target_display` contains literal `"%"` OR (`target_value > 1` AND no operator-prefixed display containing `"%"`-stripped value))
+- Pure proportion inputs (`target = 0.9`, `target = "≥ 0.9"`) are preserved to allow power-users explicit control
+
+**Implementation note:**
+
+A new internal helper `.normalize_percent_target(value, display, y_axis_unit)` SHALL encapsulate the heuristic to enable direct unit testing independent of the full context-build path. The helper SHALL be called once per `bfh_build_analysis_context()` invocation, between `resolve_target()` and context list construction.
+
+The `target_display` field in the returned context SHALL retain the original (un-normalized) string, so user-facing rendered text continues to display "≥ 90%" rather than "≥ 0.90".
+
+#### Scenario: Percent target normalized to proportion scale
+
+- **GIVEN** a p-chart `bfh_qic_result` with `centerline = 0.91`, `y_axis_unit = "percent"`
+- **AND** `metadata$target = ">= 90%"`
+- **WHEN** `bfh_build_analysis_context()` is called
+- **THEN** `context$target_value` SHALL equal `0.90` (not `90`)
+- **AND** `context$target_display` SHALL equal `">= 90%"` (preserved)
+- **AND** `context$target_direction` SHALL equal `"higher"`
+
+```r
+result <- bfh_qic(p_chart_data, ...)  # centerline = 0.91, y_axis_unit = "percent"
+ctx <- bfh_build_analysis_context(result, metadata = list(target = ">= 90%"))
+
+expect_equal(ctx$target_value, 0.90, tolerance = 1e-9)
+expect_equal(ctx$target_display, ">= 90%")
+expect_equal(ctx$target_direction, "higher")
+```
+
+#### Scenario: Higher-is-better goal met after normalization
+
+- **GIVEN** the normalized context from the previous scenario
+- **WHEN** `build_fallback_analysis(ctx, ...)` is called
+- **THEN** the output SHALL describe the goal as met (not "endnu ikke nået")
+
+```r
+ctx <- list(
+  target_value = 0.90, target_direction = "higher",
+  target_display = ">= 90%", y_axis_unit = "percent",
+  centerline = 0.91, ...
+)
+txt <- build_fallback_analysis(ctx, max_chars = 400, language = "da")
+
+expect_match(txt, "opfylder målet|målet.*opfyldt|målet.*nået")
+expect_false(grepl("endnu ikke nået|opfylder ikke", txt))
+```
+
+#### Scenario: Lower-is-better percent target normalized
+
+- **GIVEN** a p-chart with `centerline = 0.03`, `y_axis_unit = "percent"`
+- **AND** `metadata$target = "<= 5%"`
+- **WHEN** `bfh_build_analysis_context()` is called
+- **THEN** `context$target_value` SHALL equal `0.05`
+- **AND** `context$target_direction` SHALL equal `"lower"`
+- **AND** subsequent `build_fallback_analysis()` SHALL describe the goal as met
+
+```r
+ctx <- bfh_build_analysis_context(low_p_result, metadata = list(target = "<= 5%"))
+expect_equal(ctx$target_value, 0.05, tolerance = 1e-9)
+txt <- build_fallback_analysis(ctx, max_chars = 400, language = "da")
+expect_match(txt, "opfylder målet|målet.*opfyldt")
+```
+
+#### Scenario: Numeric percent target normalized when value exceeds 1
+
+- **GIVEN** a p-chart with `y_axis_unit = "percent"`
+- **AND** `metadata$target = 90` (bare numeric, no operator)
+- **WHEN** `bfh_build_analysis_context()` is called
+- **THEN** `context$target_value` SHALL equal `0.90`
+
+```r
+ctx <- bfh_build_analysis_context(p_result, metadata = list(target = 90))
+expect_equal(ctx$target_value, 0.90, tolerance = 1e-9)
+```
+
+#### Scenario: Numeric proportion target preserved on percent chart
+
+- **GIVEN** a p-chart with `y_axis_unit = "percent"`
+- **AND** `metadata$target = 0.9` (numeric, already on proportion scale)
+- **WHEN** `bfh_build_analysis_context()` is called
+- **THEN** `context$target_value` SHALL equal `0.9` (unchanged — heuristic detects value <= 1)
+
+```r
+ctx <- bfh_build_analysis_context(p_result, metadata = list(target = 0.9))
+expect_equal(ctx$target_value, 0.9, tolerance = 1e-9)
+```
+
+#### Scenario: Non-percent chart targets unchanged
+
+- **GIVEN** an i-chart with `y_axis_unit = "count"`
+- **AND** `metadata$target = ">= 90"`
+- **WHEN** `bfh_build_analysis_context()` is called
+- **THEN** `context$target_value` SHALL equal `90` (no normalization — y_axis_unit is not "percent")
+
+```r
+ctx <- bfh_build_analysis_context(i_result, metadata = list(target = ">= 90"))
+expect_equal(ctx$target_value, 90)
+```
+
+#### Scenario: Explicit proportion string preserved
+
+- **GIVEN** a p-chart with `y_axis_unit = "percent"`
+- **AND** `metadata$target = ">= 0.9"` (no `%` in display)
+- **WHEN** `bfh_build_analysis_context()` is called
+- **THEN** `context$target_value` SHALL equal `0.9` (unchanged — display lacks `%`, allows power-user override)
+
+```r
+ctx <- bfh_build_analysis_context(p_result, metadata = list(target = ">= 0.9"))
+expect_equal(ctx$target_value, 0.9, tolerance = 1e-9)
+expect_equal(ctx$target_display, ">= 0.9")
+```

--- a/openspec/changes/archive/2026-04-29-fix-percent-target-scale-in-analysis/tasks.md
+++ b/openspec/changes/archive/2026-04-29-fix-percent-target-scale-in-analysis/tasks.md
@@ -1,0 +1,41 @@
+## 1. Implementation
+
+- [ ] 1.1 Tilføj intern helper `.normalize_percent_target(value, display, y_axis_unit)` i `R/spc_analysis.R` (placeret nær `resolve_target()`)
+- [ ] 1.2 Helper-kontrakt:
+  - Returnerer normaliseret numerisk værdi
+  - Hvis `y_axis_unit == "percent"` AND `display` indeholder `"%"` AND `value > 1`: returner `value / 100`
+  - Ellers: returner `value` uændret
+- [ ] 1.3 Wire helper-kald ind i `bfh_build_analysis_context()` mellem `resolve_target()` og context-list-konstruktion (`R/spc_analysis.R:163-222`)
+- [ ] 1.4 Roxygen for helper med 3-4 examples (percent + display "%", percent + ingen "%", ej percent, allerede proportion)
+
+## 2. Tests
+
+- [ ] 2.1 Test: p-chart, `target = ">= 90%"`, `centerline = 0.91` → analysis indeholder "opfylder målet" (DK) / "goal met" (EN)
+- [ ] 2.2 Test: p-chart, `target = ">= 90%"`, `centerline = 0.85` → "endnu ikke nået"
+- [ ] 2.3 Test: p-chart, `target = "<= 5%"`, `centerline = 0.03` → "lower"-direction goal met
+- [ ] 2.4 Test: p-chart, numerisk `target = 90` → normaliseres til 0.90 internt
+- [ ] 2.5 Test: p-chart, numerisk `target = 0.9` → ikke normaliseret (allerede proportion)
+- [ ] 2.6 Test: p-chart, `target = "≥ 0.9"` (ingen `%` i display) → ikke normaliseret
+- [ ] 2.7 Test: i-chart, `target = ">= 90"` → ingen normalisering (count-skala uændret)
+- [ ] 2.8 Test: rate-chart, `target = "<= 2.5"` → ingen normalisering
+- [ ] 2.9 Test: u-chart med `y_axis_unit = "rate"`, `target = "5%"` → ingen normalisering (rate ej percent)
+- [ ] 2.10 Direkte unit-test af `.normalize_percent_target()` for alle 6 kombinationer (3 input-typer × 2 unit-typer)
+
+## 3. Documentation
+
+- [ ] 3.1 Opdatér `bfh_build_analysis_context()` Roxygen `@details` med "Percent-Target Normalization"-sektion
+- [ ] 3.2 NEWS.md entry under `## Bug fixes` med beskrivelse af scope (kun `auto_analysis = TRUE` på percent-charts) og migration-note (ingen handling påkrævet for korrekt fungerende kald)
+- [ ] 3.3 Eksisterende `metadata$target`-dokumentation i `bfh_export_pdf()` og `bfh_generate_analysis()` — verificér at den nu beskriver normalisering korrekt
+
+## 4. Verification
+
+- [ ] 4.1 `devtools::test()` passes (alle nye + eksisterende tests)
+- [ ] 4.2 `devtools::check()` no new WARN/ERROR
+- [ ] 4.3 Manuel verifikation: konstruér p-chart med 91% centerline + ">= 90%" target, generer PDF, læs auto-analysis-tekst — bekræft at output siger "målet opfyldt"
+- [ ] 4.4 Cross-check at eksisterende statistical-accuracy-tests fortsat passerer (ingen utilsigtet impact på chart-rendering)
+
+## 5. Release
+
+- [ ] 5.1 Bump `DESCRIPTION` til næste patch-version
+- [ ] 5.2 Tag efter merge til main
+- [ ] 5.3 Notify biSPCharts-maintainer hvis sister-app bruger `auto_analysis = TRUE` på percent-indikatorer (klinisk relevans-kontrol)

--- a/openspec/changes/archive/2026-04-29-update-print-summary-removal-docs/proposal.md
+++ b/openspec/changes/archive/2026-04-29-update-print-summary-removal-docs/proposal.md
@@ -1,0 +1,63 @@
+## Why
+
+Begge code reviews 2026-04-29 (Claude statisk + Codex runtime, høj confidence i begge) flaggede uoverensstemmelse mellem dokumentation og implementering for `bfh_qic()`'s `print.summary`-parameter.
+
+**Status quo:**
+
+- `R/utils_bfh_qic_helpers.R:101-110` — `build_bfh_qic_return()` **hard-errorer** når `print.summary = TRUE`:
+  ```
+  print.summary = TRUE has been removed in v0.11.0. ...
+  ```
+- `NEWS.md` v0.11.0 dokumenterer korrekt fjernelsen under `## Breaking changes`
+- `R/bfh_qic.R:46` (Roxygen `@param print.summary`) siger fortsat:
+  ```
+  \strong{DEPRECATED.} ... When TRUE, triggers deprecation warning and
+  returns legacy list(plot, summary) format.
+  ```
+- `R/bfh_qic.R:58-59` (Roxygen `@return`) lister fortsat:
+  ```
+  - print.summary = TRUE: list(plot = ggplot, summary = data.frame) (deprecated, will warn)
+  - Both TRUE: list(data = data.frame, summary = data.frame) (deprecated, will warn)
+  ```
+- `@examples` linje 443, 464, 485 demonstrerer aktivt `print.summary = TRUE` (alle wrappet i `\dontrun{}` så R CMD check ikke knækker)
+- `man/bfh_qic.Rd` (auto-genereret) reflekterer den forældede Roxygen
+
+**Konsekvens:** Brugere der læser pakke-dokumentation (Roxygen, `?bfh_qic`, online dokumentation, vignettes) får besked om at `print.summary = TRUE` er deprecated men virker. Når de kalder med argumentet får de en hard error. Spild af brugerens tid + dårlig developer experience.
+
+## What Changes
+
+- **NON-BREAKING** — kun dokumentation
+- Opdatér `R/bfh_qic.R` Roxygen `@param print.summary`:
+  - Fjern "DEPRECATED ... When TRUE, triggers deprecation warning"
+  - Erstat med "REMOVED in v0.11.0. Calling with `print.summary = TRUE` raises an error. Use `return.data = TRUE` and access `result$qic_summary`, or use the default `bfh_qic_result` object and access `result$summary` directly."
+- Opdatér `@return` (linje 51-60):
+  - Fjern entries for `print.summary = TRUE` og `Both TRUE`
+  - Behold kun:
+    - Default (`return.data = FALSE`): `bfh_qic_result` S3-objekt
+    - `return.data = TRUE`: data.frame (legacy)
+- Fjern eller opdatér `@examples`:
+  - Eksempel 20 (linje ~440-450): Fjern `print.summary = TRUE`-kald. Erstat med `result <- bfh_qic(...)` + `result$summary` for at vise samme funktionalitet via det moderne API.
+  - Eksempel 21 (linje ~460-475): Samme — vis at `return.data = TRUE` returnerer data.frame; for at få summary brug `bfh_qic_result$summary`.
+  - Eksempel 22 (linje ~480-490): Opdatér til at bruge default S3-objekt + `result$summary`.
+- Kør `devtools::document()` for at re-generere `man/bfh_qic.Rd`
+- Backwards-compatibility: parameteret bevares stadig i funktionssignaturen (med `print.summary = FALSE` default) for at fange `print.summary = TRUE`-kald og give beskrivende fejl. Det er allerede implementeret korrekt — denne proposal ændrer ikke runtime-adfærden.
+
+**Ud af scope:**
+- Fjernelse af `print.summary`-parameteret fra signaturen helt. Det er en breaking change og kan vente til næste major-bump (post-1.0). Den nuværende soft-removal (parameter accepteret men hard-error på `TRUE`) giver klar fejlbesked og er korrekt for pre-1.0.
+
+## Impact
+
+**Affected specs:**
+- `public-api` — MODIFIED requirement: documentation reflects removed parameters
+
+**Affected code:**
+- `R/bfh_qic.R` — Roxygen-blokken (linje 14-152 og examples-sektion)
+- `man/bfh_qic.Rd` — auto-genereret efter `devtools::document()`
+
+**Affected tests:**
+- Ingen runtime tests — `print.summary = TRUE` rejser allerede error som forventet
+- Optional: tilføj én test der verificerer at `?bfh_qic` (eller hjælpe-tekst) ikke længere indeholder strengen "deprecated, will warn"
+
+**Risiko:** Meget lav. Dokumentationsændring uden adfærdsændring.
+
+**Effort estimat:** 30-45 minutter inkl. `devtools::document()` og R CMD check.

--- a/openspec/changes/archive/2026-04-29-update-print-summary-removal-docs/specs/public-api/spec.md
+++ b/openspec/changes/archive/2026-04-29-update-print-summary-removal-docs/specs/public-api/spec.md
@@ -1,0 +1,77 @@
+## MODIFIED Requirements
+
+### Requirement: Exported functions SHALL have comprehensive documentation
+
+All exported functions SHALL include complete roxygen2 documentation with examples.
+
+**Rationale:**
+- Users need clear documentation for public API functions
+- Examples demonstrate expected usage patterns
+- Parameter documentation prevents misuse
+- **Documentation SHALL stay synchronized with implementation; parameters that have been removed or whose behavior has changed SHALL have their documentation updated in the same release as the code change.**
+
+**Documentation freshness contract:**
+
+When a parameter's runtime behavior changes (e.g., from "deprecated with warning" to "removed with hard error"), the following SHALL be updated together:
+
+1. `@param` description (current behavior, not historical)
+2. `@return` description (only currently supported return shapes)
+3. `@examples` (no demonstrations of removed parameters, even within `\dontrun{}`)
+4. `man/<function>.Rd` (regenerated via `devtools::document()`)
+5. `NEWS.md` entry describing the doc-implementation alignment
+
+#### Scenario: Function documentation includes required sections
+
+**Given** an exported function
+**When** `devtools::document()` is run
+**Then** the function SHALL have @title, @description, @param, @return, @examples
+**And** documentation SHALL be accessible via `?function_name`
+
+**Required sections:**
+```r
+#' Extract SPC Statistics from QIC Summary
+#'
+#' Extracts statistical process control metrics from a qic summary data frame.
+#'
+#' @param summary Data frame with SPC statistics (from bfh_qic result$summary)
+#' @return List with SPC statistics: runs_expected, runs_actual, crossings_expected, crossings_actual, outliers_expected, outliers_actual
+#' @export
+#' @examples
+#' \dontrun{
+#' result <- bfh_qic(data, x = date, y = value, chart_type = "i")
+#' stats <- bfh_extract_spc_stats(result$summary)
+#' }
+```
+
+#### Scenario: Removed parameters reflect removal status in current docs
+
+- **GIVEN** a parameter that has been removed from runtime behavior in a prior release (e.g., `print.summary` removed in v0.11.0)
+- **WHEN** the user reads `?bfh_qic` or `man/bfh_qic.Rd`
+- **THEN** the `@param` description SHALL state that calling with the removed argument value raises an error
+- **AND** SHALL provide migration instructions to the supported equivalent
+- **AND** SHALL NOT describe the parameter as "deprecated with warning" if the runtime now hard-errors
+
+```r
+# After update, ?bfh_qic should NOT contain:
+#   "When TRUE, triggers deprecation warning"
+# It SHALL contain:
+#   "Calling with print.summary = TRUE raises an error"
+#   "Use return.data = TRUE and access result$qic_summary, or use the
+#    default bfh_qic_result object and access result$summary directly."
+```
+
+#### Scenario: @examples never demonstrate removed parameters
+
+- **GIVEN** a function with examples in roxygen
+- **WHEN** the package is built
+- **THEN** no `@examples` block SHALL pass a value to a parameter that triggers a hard error at runtime
+- **AND** this SHALL hold even when the example is wrapped in `\dontrun{}` (since `\dontrun` examples are still copy-pasted by users)
+
+```r
+# Verification: regression test in test-public-api-contract.R
+test_that("bfh_qic Rd does not advertise removed print.summary as deprecated", {
+  rd_content <- readLines(system.file("man", "bfh_qic.Rd", package = "BFHcharts"))
+  expect_false(any(grepl("deprecated, will warn", rd_content, fixed = TRUE)))
+  expect_false(any(grepl("print.summary = TRUE", rd_content, fixed = TRUE)))
+})
+```

--- a/openspec/changes/archive/2026-04-29-update-print-summary-removal-docs/tasks.md
+++ b/openspec/changes/archive/2026-04-29-update-print-summary-removal-docs/tasks.md
@@ -1,0 +1,49 @@
+## 1. Roxygen update
+
+- [ ] 1.1 Opdatér `@param print.summary` i `R/bfh_qic.R:46`:
+  - Fjern "DEPRECATED ... triggers deprecation warning"
+  - Erstat med text der reflekterer hard-error i v0.11.0 + migration-instruktion
+- [ ] 1.2 Opdatér `@return` (linje 51-60) — fjern entries for `print.summary = TRUE` og `Both TRUE`
+- [ ] 1.3 Opdatér `@details` hvis der refereres til `print.summary` i return-routing-beskrivelsen
+
+## 2. Examples cleanup
+
+- [ ] 2.1 Eksempel 20 (linje ~440-450, "Get summary statistics with Danish column names"):
+  - Fjern `print.summary = TRUE`-argument
+  - Skift til `result <- bfh_qic(...)` (default S3-objekt)
+  - Erstat `result$plot` + `result$summary` udtryk forbliver gyldige (samme felt-navne)
+- [ ] 2.2 Eksempel 21 (linje ~460-475, "Get both raw data and summary"):
+  - Fjern `print.summary = TRUE`-argument
+  - Skift til to separate kald: ét med `return.data = TRUE` for data.frame, ét med default for summary; ELLER
+  - Vis at default S3-objekt har både `result$qic_data` og `result$summary` (anbefales — illustrerer moderne API)
+- [ ] 2.3 Eksempel 22 (linje ~480-490, "Use summary for reporting"):
+  - Fjern `print.summary = TRUE`-argument
+  - Anvend default S3-objekt + `result$summary` direkte
+
+## 3. Re-generate Rd
+
+- [ ] 3.1 Kør `devtools::document()`
+- [ ] 3.2 Verificér at `man/bfh_qic.Rd` ikke længere indeholder strengen "deprecated, will warn"
+- [ ] 3.3 Commit `man/bfh_qic.Rd`-ændringen sammen med `R/bfh_qic.R`
+
+## 4. Verification
+
+- [ ] 4.1 `devtools::check()` passes (ingen R CMD check WARN/ERROR)
+- [ ] 4.2 Manuel: `?bfh_qic` viser opdateret dokumentation uden "deprecated, will warn"
+- [ ] 4.3 Manuel: kør et af de opdaterede eksempler interaktivt — bekræft at det giver forventet output uden fejl
+- [ ] 4.4 Optional regression-test (nyt test_that-blok i `tests/testthat/test-public-api-contract.R`):
+  ```r
+  test_that("bfh_qic Roxygen does not advertise removed print.summary as deprecated", {
+    rd_path <- system.file("man", "bfh_qic.Rd", package = "BFHcharts")
+    if (nchar(rd_path) > 0 && file.exists(rd_path)) {
+      content <- readLines(rd_path)
+      expect_false(any(grepl("deprecated, will warn", content, fixed = TRUE)))
+    }
+  })
+  ```
+
+## 5. Release
+
+- [ ] 5.1 NEWS.md entry under `## Documentation` for næste patch-version
+- [ ] 5.2 Bump `DESCRIPTION` til næste patch (kan kombineres med proposal #1)
+- [ ] 5.3 Tag efter merge

--- a/openspec/specs/pdf-export/spec.md
+++ b/openspec/specs/pdf-export/spec.md
@@ -406,3 +406,160 @@ for (dept in departments) {
 **Then** the session tmpdir SHALL be removed
 **And** subsequent use of the session SHALL raise an error
 
+### Requirement: Temp directory protection SHALL rely on tempfile() + Sys.chmod(0700)
+
+The temp directory created by `prepare_temp_workspace()` for PDF export SHALL be protected against other-user access by:
+
+1. Use of `tempfile()` for path generation, which produces a path under per-user `tempdir()` (OS-isolated)
+2. `Sys.chmod(temp_dir, mode = "0700", use_umask = FALSE)` to remove group/other read/write/execute permissions
+
+The implementation SHALL NOT rely on `Sys.getenv("UID")`-based ownership validation, because `UID` is a shell-internal environment variable that is typically not exported to non-interactive R sessions (Rscript, RStudio Server, knitr, Shiny apps, GitHub Actions runners). Such checks evaluate as `integer(0)` or `NA_integer_` and silently skip without ever firing the protective error branch — providing misleading defense-in-depth without actual protection.
+
+**Rationale:**
+
+- `tempfile()` + `Sys.chmod(0700)` is the canonical and sufficient mechanism in R for per-user temp directory isolation
+- Adding an unreliable check creates a false sense of security and increases maintenance burden
+- This requirement aligns `prepare_temp_workspace()` with the simpler implementation already in `bfh_create_export_session()` (which uses only `Sys.chmod(0700)`)
+
+#### Scenario: Temp directory has 0700 mode on Unix
+
+- **GIVEN** `prepare_temp_workspace(NULL)` is called on a Unix system
+- **WHEN** the function returns
+- **THEN** `file.info(temp_dir)$mode` SHALL have permission bits `0700`
+- **AND** group/other SHALL have no read/write/execute permission
+
+```r
+test_that("prepare_temp_workspace creates 0700 directory on Unix", {
+  skip_on_os(c("windows"))
+  ws <- prepare_temp_workspace(NULL)
+  on.exit(unlink(ws$temp_dir, recursive = TRUE))
+  mode_octal <- as.integer(file.info(ws$temp_dir)$mode) %% (8^3)
+  expect_equal(mode_octal, strtoi("700", 8L))
+})
+```
+
+#### Scenario: Temp directory path is under tempdir()
+
+- **GIVEN** `prepare_temp_workspace(NULL)` is called
+- **WHEN** the function returns
+- **THEN** `temp_dir` SHALL start with `tempdir()` (per-user isolated parent)
+
+```r
+test_that("temp_dir is under tempdir()", {
+  ws <- prepare_temp_workspace(NULL)
+  on.exit(unlink(ws$temp_dir, recursive = TRUE))
+  expect_true(startsWith(
+    normalizePath(ws$temp_dir, mustWork = FALSE),
+    normalizePath(tempdir(), mustWork = TRUE)
+  ))
+})
+```
+
+#### Scenario: Implementation does not rely on Sys.getenv("UID")
+
+- **GIVEN** the source of `R/utils_export_helpers.R`
+- **WHEN** the file is read
+- **THEN** the implementation SHALL NOT contain `Sys.getenv("UID")` calls or UID-based ownership comparisons in `prepare_temp_workspace()` or any related helper
+- **AND** any prior ownership-check code SHALL be replaced with an inline comment documenting why `tempfile()` + `Sys.chmod(0700)` is sufficient
+
+```r
+# Verification (regression test):
+test_that("prepare_temp_workspace does not use Sys.getenv UID check", {
+  src_path <- system.file("R", "utils_export_helpers.R", package = "BFHcharts")
+  if (nchar(src_path) == 0) skip("source not installed")
+  src <- readLines(src_path)
+  expect_false(any(grepl('Sys.getenv\\("UID"\\)', src)))
+})
+```
+
+### Requirement: Organizational asset distribution SHALL use companion package pattern
+
+For organizations that need to bundle proprietary fonts and branding assets (logos, hospital identifiers) with BFHcharts-based deployments, the asset distribution SHALL use a private companion R package pattern. BFHcharts itself SHALL NOT bundle proprietary assets, and consumer applications SHALL NOT hardcode absolute paths to assets in `inject_assets` callbacks. The companion package SHALL:
+
+1. Hosts the proprietary assets in `inst/assets/fonts/` and `inst/assets/images/`
+2. Exports a single function (e.g. `inject_bfh_assets(template_dir)`) that copies all bundled assets into a Typst template staging directory
+3. Is installed as a private dependency by the consumer application (e.g. biSPCharts on Posit Connect Cloud)
+4. Plugs into BFHcharts via the existing `inject_assets` callback parameter on `bfh_export_pdf()` and `bfh_create_export_session()`
+
+**Rationale:**
+
+- BFHcharts itself is GPL-3 and publicly distributed; it cannot bundle proprietary fonts (Mari, Arial) or third-party-owned hospital logos
+- The `inject_assets` callback was designed precisely for this asset-runtime-injection pattern but lacked an officially recommended distribution mechanism
+- A companion package gives organizations versioned, audit-trackable, dependency-managed asset distribution that integrates cleanly with R's package ecosystem (renv, manifest.json on Posit Connect)
+- Compared to ad-hoc deploy-bundle staging, companion packages provide: source-of-truth versioning, reusability across multiple consumer applications, and clean separation of GPL-distributable code from proprietary brand assets
+
+**Anti-patterns this requirement formalizes against:**
+
+- Hardcoded absolute paths in `inject_assets` callbacks (breaks on cloud deployments)
+- Manual asset staging in deploy bundles via `.gitignore` + pre-deploy copy scripts (no audit trail; easily forgotten)
+- Direct commit of proprietary fonts/logos into BFHcharts (license violations) or into consumer application repos that are public (same violations)
+
+#### Scenario: Companion package exposes single inject_assets-compatible function
+
+- **GIVEN** a private companion package (e.g. `BFHchartsAssets`)
+- **WHEN** the package is installed
+- **THEN** it SHALL export a function with signature `function(template_dir)` that:
+  - Validates `template_dir` is a single character path to an existing directory
+  - Copies all bundled fonts from `system.file("assets/fonts", package = "<pkg>")` to `<template_dir>/fonts/`
+  - Copies all bundled images from `system.file("assets/images", package = "<pkg>")` to `<template_dir>/images/`
+  - Creates `fonts/` and `images/` subdirectories if they do not exist
+  - Errors clearly if any file copy fails
+
+```r
+# Reference implementation
+inject_bfh_assets <- function(template_dir) {
+  stopifnot(is.character(template_dir), length(template_dir) == 1, dir.exists(template_dir))
+
+  fonts_src  <- system.file("assets/fonts",  package = "BFHchartsAssets", mustWork = TRUE)
+  images_src <- system.file("assets/images", package = "BFHchartsAssets", mustWork = TRUE)
+
+  fonts_dst  <- file.path(template_dir, "fonts")
+  images_dst <- file.path(template_dir, "images")
+  dir.create(fonts_dst,  showWarnings = FALSE, recursive = TRUE)
+  dir.create(images_dst, showWarnings = FALSE, recursive = TRUE)
+
+  fonts_ok  <- all(file.copy(list.files(fonts_src,  full.names = TRUE), fonts_dst,  overwrite = TRUE))
+  images_ok <- all(file.copy(list.files(images_src, full.names = TRUE), images_dst, overwrite = TRUE))
+
+  if (!fonts_ok || !images_ok) {
+    stop("Failed to inject one or more asset files", call. = FALSE)
+  }
+
+  invisible(NULL)
+}
+```
+
+#### Scenario: Consumer integrates companion via inject_assets parameter
+
+- **GIVEN** a consumer Shiny app (biSPCharts) deployed to Posit Connect Cloud
+- **AND** the consumer has `BFHchartsAssets` in its `Imports` and `Remotes`
+- **WHEN** the consumer calls `BFHcharts::bfh_export_pdf(..., inject_assets = BFHchartsAssets::inject_bfh_assets)`
+- **THEN** the rendered PDF SHALL display full hospital branding with Mari fonts and Region Hovedstaden logos
+- **AND** BFHcharts itself SHALL NOT have any code that references `BFHchartsAssets` (clean dependency direction: consumer → BFHcharts; consumer → BFHchartsAssets)
+
+```r
+# Consumer code pattern (biSPCharts):
+result <- BFHcharts::bfh_qic(data, x = month, y = infections, chart_type = "i")
+BFHcharts::bfh_export_pdf(
+  result, output_pdf,
+  metadata = list(hospital = "Bispebjerg og Frederiksberg Hospital", department = dept),
+  inject_assets = BFHchartsAssets::inject_bfh_assets
+)
+```
+
+#### Scenario: BFHcharts documentation references companion pattern as canonical
+
+- **GIVEN** a user reads `?bfh_export_pdf` or `README.md`
+- **WHEN** the user reaches the security/branding section
+- **THEN** the documentation SHALL describe the companion-package pattern as the recommended approach for organizations needing proprietary branding
+- **AND** SHALL explicitly state that BFHcharts does not bundle Mari fonts or hospital logos
+
+#### Scenario: Companion package is independent of BFHcharts release cadence
+
+- **GIVEN** the companion package and BFHcharts are versioned independently
+- **WHEN** BFHcharts releases a patch version
+- **THEN** the companion package SHALL NOT need to be re-released unless the `inject_assets`-callback contract changes
+- **AND** the companion package's `DESCRIPTION` SHALL specify `BFHcharts (>= <minimum-version>)` to assert the callback contract version it supports
+
+This decoupling allows BFHcharts to evolve its public API freely while organizations control their branding-asset release cadence separately.
+

--- a/openspec/specs/public-api/spec.md
+++ b/openspec/specs/public-api/spec.md
@@ -177,6 +177,17 @@ All exported functions SHALL include complete roxygen2 documentation with exampl
 - Users need clear documentation for public API functions
 - Examples demonstrate expected usage patterns
 - Parameter documentation prevents misuse
+- **Documentation SHALL stay synchronized with implementation; parameters that have been removed or whose behavior has changed SHALL have their documentation updated in the same release as the code change.**
+
+**Documentation freshness contract:**
+
+When a parameter's runtime behavior changes (e.g., from "deprecated with warning" to "removed with hard error"), the following SHALL be updated together:
+
+1. `@param` description (current behavior, not historical)
+2. `@return` description (only currently supported return shapes)
+3. `@examples` (no demonstrations of removed parameters, even within `\dontrun{}`)
+4. `man/<function>.Rd` (regenerated via `devtools::document()`)
+5. `NEWS.md` entry describing the doc-implementation alignment
 
 #### Scenario: Function documentation includes required sections
 
@@ -199,6 +210,39 @@ All exported functions SHALL include complete roxygen2 documentation with exampl
 #' result <- bfh_qic(data, x = date, y = value, chart_type = "i")
 #' stats <- bfh_extract_spc_stats(result$summary)
 #' }
+```
+
+#### Scenario: Removed parameters reflect removal status in current docs
+
+- **GIVEN** a parameter that has been removed from runtime behavior in a prior release (e.g., `print.summary` removed in v0.11.0)
+- **WHEN** the user reads `?bfh_qic` or `man/bfh_qic.Rd`
+- **THEN** the `@param` description SHALL state that calling with the removed argument value raises an error
+- **AND** SHALL provide migration instructions to the supported equivalent
+- **AND** SHALL NOT describe the parameter as "deprecated with warning" if the runtime now hard-errors
+
+```r
+# After update, ?bfh_qic should NOT contain:
+#   "When TRUE, triggers deprecation warning"
+# It SHALL contain:
+#   "Calling with print.summary = TRUE raises an error"
+#   "Use return.data = TRUE and access result$qic_summary, or use the
+#    default bfh_qic_result object and access result$summary directly."
+```
+
+#### Scenario: @examples never demonstrate removed parameters
+
+- **GIVEN** a function with examples in roxygen
+- **WHEN** the package is built
+- **THEN** no `@examples` block SHALL pass a value to a parameter that triggers a hard error at runtime
+- **AND** this SHALL hold even when the example is wrapped in `\dontrun{}` (since `\dontrun` examples are still copy-pasted by users)
+
+```r
+# Verification: regression test in test-public-api-contract.R
+test_that("bfh_qic Rd does not advertise removed print.summary as deprecated", {
+  rd_content <- readLines(system.file("man", "bfh_qic.Rd", package = "BFHcharts"))
+  expect_false(any(grepl("deprecated, will warn", rd_content, fixed = TRUE)))
+  expect_false(any(grepl("print.summary = TRUE", rd_content, fixed = TRUE)))
+})
 ```
 
 ### Requirement: Public functions SHALL support language selection via language parameter
@@ -257,4 +301,64 @@ expect_error(
 **When** the function resolves the key with `language = "en"`
 **Then** it SHALL return the Danish string
 **And** SHALL emit a single warning per session for that key
+
+### Requirement: Public functions SHALL document all values their input validators accept
+
+Public exported functions whose parameters are validated against an enumerated set of allowed values SHALL document **all** allowed values in the user-facing roxygen `@param` and `@details` blocks. Discrepancies between validator-accepted values and documented values SHALL be treated as documentation bugs.
+
+**Rationale:**
+- API discovery via `?function_name` must surface the full feature surface
+- Hidden parameter values force users to read source code
+- Inconsistency between validator and docs creates maintenance debt and erodes trust
+
+This requirement specifically addresses the `chart_type` parameter of `bfh_qic()`, but applies to any future enumerated parameters (e.g., `y_axis_unit`, `agg.fun`, `language`).
+
+#### Scenario: chart_type roxygen lists all validated types
+
+- **GIVEN** the validator at `R/utils_bfh_qic_helpers.R:218-223` accepts the set defined by `CHART_TYPES_EN` in `R/chart_types.R:21`
+- **WHEN** a user reads `?bfh_qic`
+- **THEN** the `@param chart_type` description SHALL list every value in that set: `"run"`, `"i"`, `"mr"`, `"p"`, `"pp"`, `"u"`, `"up"`, `"c"`, `"g"`, `"xbar"`, `"s"`, `"t"`
+- **AND** the `@details Chart Types` block SHALL provide a one-line description for each type
+
+```r
+# Verification (regression test):
+test_that("bfh_qic Rd documents all validated chart types", {
+  rd_path <- system.file("man", "bfh_qic.Rd", package = "BFHcharts")
+  skip_if(nchar(rd_path) == 0)
+  rd_content <- paste(readLines(rd_path), collapse = "\n")
+  for (t in BFHcharts:::CHART_TYPES_EN) {
+    expect_true(grepl(paste0("\\b", t, "\\b"), rd_content),
+                info = paste("Chart type", t, "missing from Rd"))
+  }
+})
+```
+
+#### Scenario: Laney-adjusted variants describe over-dispersion use case
+
+- **GIVEN** chart types `"pp"` and `"up"` exist as Laney-adjusted variants of `"p"` and `"u"`
+- **WHEN** a user reads `?bfh_qic`
+- **THEN** the documentation SHALL identify `"pp"` and `"up"` as Laney-adjusted variants
+- **AND** SHALL provide guidance on when to use them (over-dispersion with very large denominators) so users can choose the appropriate variant without consulting external sources
+
+```
+**pp**: P-prime chart (Laney-adjusted proportions) — use instead of `p`
+when denominators are very large (n > 1000 per subgroup) and standard
+control limits become artificially tight due to over-dispersion.
+
+**up**: U-prime chart (Laney-adjusted rates) — same rationale as `pp`,
+applied to count rates.
+```
+
+#### Scenario: Moving Range chart documented as I-chart pair
+
+- **GIVEN** chart type `"mr"` exists as the Moving Range counterpart to the I-chart
+- **WHEN** a user reads `?bfh_qic`
+- **THEN** the documentation SHALL identify `"mr"` as a Moving Range chart
+- **AND** SHALL note its typical pairing with an I-chart for full process variation analysis
+
+```
+**mr**: Moving Range chart — measures point-to-point variability.
+Typically paired with an I-chart to characterize both process level
+(I) and short-term variation (MR).
+```
 

--- a/openspec/specs/spc-analysis-api/spec.md
+++ b/openspec/specs/spc-analysis-api/spec.md
@@ -361,3 +361,135 @@ txt <- build_fallback_analysis(ctx, ...)
 expect_match(txt, "3 observationer")
 ```
 
+### Requirement: bfh_build_analysis_context SHALL normalize percent targets to proportion scale
+
+The `bfh_build_analysis_context()` function SHALL detect when a target is expressed in percent format (`y_axis_unit = "percent"` AND target display contains `"%"`) and SHALL normalize the stored `target_value` from 0-100 scale to 0-1 (proportion) scale before placing it in the returned context. This ensures downstream consumers (notably `build_fallback_analysis()`) compare `target_value` against `centerline` on a consistent scale.
+
+**Rationale:**
+
+For percent-formatted SPC charts (p, pp), `qicharts2::qic()` returns `centerline` on the proportion scale (`0.91` for 91%), but `parse_target_input("≥ 90%")` strips the percent suffix and returns the raw numeric `90`. Without normalization, the comparison `centerline >= target_value` evaluates `0.91 >= 90 → FALSE`, producing clinically misleading auto-analysis text such as "målet er endnu ikke nået" when the centerline actually exceeds the percent target.
+
+This bug was identified in Codex code review 2026-04-29 (FIX NOW severity) with runtime verification that `target = ">= 90%"` on a p-chart with `centerline = 0.91` produced the wrong directional verdict.
+
+**Normalization contract:**
+
+| Input | y_axis_unit | target_display contains "%" | parsed target_value | Stored target_value |
+|-------|-------------|----------------------------|---------------------|---------------------|
+| `">= 90%"` | `"percent"` | yes | 90 | **0.90** (normalized) |
+| `90` (numeric) | `"percent"` | no display, value > 1 | 90 | **0.90** (normalized) |
+| `0.9` (numeric) | `"percent"` | no display, value <= 1 | 0.9 | 0.9 (unchanged) |
+| `">= 0.9"` | `"percent"` | no | 0.9 | 0.9 (unchanged) |
+| `">= 90"` | `"count"` | no | 90 | 90 (unchanged) |
+| `"<= 2.5"` | `"rate"` | no | 2.5 | 2.5 (unchanged) |
+
+**Heuristic:**
+- Normalize when `y_axis_unit == "percent"` AND (`target_display` contains literal `"%"` OR (`target_value > 1` AND no operator-prefixed display containing `"%"`-stripped value))
+- Pure proportion inputs (`target = 0.9`, `target = "≥ 0.9"`) are preserved to allow power-users explicit control
+
+**Implementation note:**
+
+A new internal helper `.normalize_percent_target(value, display, y_axis_unit)` SHALL encapsulate the heuristic to enable direct unit testing independent of the full context-build path. The helper SHALL be called once per `bfh_build_analysis_context()` invocation, between `resolve_target()` and context list construction.
+
+The `target_display` field in the returned context SHALL retain the original (un-normalized) string, so user-facing rendered text continues to display "≥ 90%" rather than "≥ 0.90".
+
+#### Scenario: Percent target normalized to proportion scale
+
+- **GIVEN** a p-chart `bfh_qic_result` with `centerline = 0.91`, `y_axis_unit = "percent"`
+- **AND** `metadata$target = ">= 90%"`
+- **WHEN** `bfh_build_analysis_context()` is called
+- **THEN** `context$target_value` SHALL equal `0.90` (not `90`)
+- **AND** `context$target_display` SHALL equal `">= 90%"` (preserved)
+- **AND** `context$target_direction` SHALL equal `"higher"`
+
+```r
+result <- bfh_qic(p_chart_data, ...)  # centerline = 0.91, y_axis_unit = "percent"
+ctx <- bfh_build_analysis_context(result, metadata = list(target = ">= 90%"))
+
+expect_equal(ctx$target_value, 0.90, tolerance = 1e-9)
+expect_equal(ctx$target_display, ">= 90%")
+expect_equal(ctx$target_direction, "higher")
+```
+
+#### Scenario: Higher-is-better goal met after normalization
+
+- **GIVEN** the normalized context from the previous scenario
+- **WHEN** `build_fallback_analysis(ctx, ...)` is called
+- **THEN** the output SHALL describe the goal as met (not "endnu ikke nået")
+
+```r
+ctx <- list(
+  target_value = 0.90, target_direction = "higher",
+  target_display = ">= 90%", y_axis_unit = "percent",
+  centerline = 0.91, ...
+)
+txt <- build_fallback_analysis(ctx, max_chars = 400, language = "da")
+
+expect_match(txt, "opfylder målet|målet.*opfyldt|målet.*nået")
+expect_false(grepl("endnu ikke nået|opfylder ikke", txt))
+```
+
+#### Scenario: Lower-is-better percent target normalized
+
+- **GIVEN** a p-chart with `centerline = 0.03`, `y_axis_unit = "percent"`
+- **AND** `metadata$target = "<= 5%"`
+- **WHEN** `bfh_build_analysis_context()` is called
+- **THEN** `context$target_value` SHALL equal `0.05`
+- **AND** `context$target_direction` SHALL equal `"lower"`
+- **AND** subsequent `build_fallback_analysis()` SHALL describe the goal as met
+
+```r
+ctx <- bfh_build_analysis_context(low_p_result, metadata = list(target = "<= 5%"))
+expect_equal(ctx$target_value, 0.05, tolerance = 1e-9)
+txt <- build_fallback_analysis(ctx, max_chars = 400, language = "da")
+expect_match(txt, "opfylder målet|målet.*opfyldt")
+```
+
+#### Scenario: Numeric percent target normalized when value exceeds 1
+
+- **GIVEN** a p-chart with `y_axis_unit = "percent"`
+- **AND** `metadata$target = 90` (bare numeric, no operator)
+- **WHEN** `bfh_build_analysis_context()` is called
+- **THEN** `context$target_value` SHALL equal `0.90`
+
+```r
+ctx <- bfh_build_analysis_context(p_result, metadata = list(target = 90))
+expect_equal(ctx$target_value, 0.90, tolerance = 1e-9)
+```
+
+#### Scenario: Numeric proportion target preserved on percent chart
+
+- **GIVEN** a p-chart with `y_axis_unit = "percent"`
+- **AND** `metadata$target = 0.9` (numeric, already on proportion scale)
+- **WHEN** `bfh_build_analysis_context()` is called
+- **THEN** `context$target_value` SHALL equal `0.9` (unchanged — heuristic detects value <= 1)
+
+```r
+ctx <- bfh_build_analysis_context(p_result, metadata = list(target = 0.9))
+expect_equal(ctx$target_value, 0.9, tolerance = 1e-9)
+```
+
+#### Scenario: Non-percent chart targets unchanged
+
+- **GIVEN** an i-chart with `y_axis_unit = "count"`
+- **AND** `metadata$target = ">= 90"`
+- **WHEN** `bfh_build_analysis_context()` is called
+- **THEN** `context$target_value` SHALL equal `90` (no normalization — y_axis_unit is not "percent")
+
+```r
+ctx <- bfh_build_analysis_context(i_result, metadata = list(target = ">= 90"))
+expect_equal(ctx$target_value, 90)
+```
+
+#### Scenario: Explicit proportion string preserved
+
+- **GIVEN** a p-chart with `y_axis_unit = "percent"`
+- **AND** `metadata$target = ">= 0.9"` (no `%` in display)
+- **WHEN** `bfh_build_analysis_context()` is called
+- **THEN** `context$target_value` SHALL equal `0.9` (unchanged — display lacks `%`, allows power-user override)
+
+```r
+ctx <- bfh_build_analysis_context(p_result, metadata = list(target = ">= 0.9"))
+expect_equal(ctx$target_value, 0.9, tolerance = 1e-9)
+expect_equal(ctx$target_display, ">= 0.9")
+```
+

--- a/openspec/specs/test-infrastructure/spec.md
+++ b/openspec/specs/test-infrastructure/spec.md
@@ -377,3 +377,91 @@ of the `test_that()` block.
 **Then** the canonical helpers SHALL reside in `tests/testthat/helper-skip.R`
 **And** no test SHALL define its own bespoke skip logic for these categories
 
+### Requirement: PR-blocking PDF render gate SHALL be CI-safe via deterministic fallback fonts
+
+A PR-blocking GitHub Actions workflow SHALL execute end-to-end PDF rendering on every pull request to `main` and `develop`. The workflow SHALL be deterministically green when the package code is correct, despite the proprietary Mari font not being installable on CI.
+
+**Rationale:**
+
+- End-to-end Typst/Quarto pipeline regressions (template syntax, escape bugs, asset paths, font-fallback wiring) cannot be caught by unit tests of R code alone
+- Without a PR gate, regressions land on `main` and are caught only by weekly cron renders or manual verification — too slow to block bad merges
+- Mari font is proprietary and cannot be redistributed in a public repository; CI must rely on legally redistributable fallback fonts
+- Disabling the workflow (current state: `pdf-smoke.yaml.disabled`) leaves an exposed gap that both code reviews flagged
+
+**CI font strategy contract:**
+
+The workflow SHALL satisfy one of the following CI-safe configurations:
+
+**Option A (preferred):** Use system-installed open fallback fonts via `apt-get install`, point `BFHCHARTS_SMOKE_FONT_PATH` env var to their installation path, and let the package's existing font-fallback chain (Mari → Roboto → Arial → Helvetica → sans-serif) resolve to a system font. Requires `ignore_system_fonts = FALSE` OR explicit `font_path` to apt-installed fonts.
+
+**Option B (fallback):** Use a minimal CI-only Typst test-template (`tests/smoke/test-template.typ`) that hardcodes only universal open fonts (e.g., DejaVu Sans). The production `bfh-template.typ` is not exercised on CI but still used in production where Mari is available.
+
+**Asset bundling contract:**
+
+- Template files in `inst/templates/typst/bfh-template/` SHALL be tracked in git **except** files identified as proprietary (Mari fonts)
+- Proprietary font filenames SHALL be explicitly excluded via `.gitignore`
+- Non-proprietary assets (logos, open fonts, images) SHALL be tracked so CI checkout can reproduce the rendering environment
+
+#### Scenario: PDF smoke workflow is enabled and required
+
+- **GIVEN** the GitHub repository
+- **WHEN** a developer inspects `.github/workflows/`
+- **THEN** `pdf-smoke.yaml` SHALL exist (not `.disabled`)
+- **AND** the workflow SHALL be configured as a required status check on the `main` and `develop` branches via branch protection
+
+#### Scenario: Smoke workflow renders against legally redistributable fonts
+
+- **GIVEN** the smoke workflow runs on a fresh GitHub-hosted Ubuntu runner
+- **WHEN** the workflow installs system fonts via `apt-get install fonts-dejavu fonts-liberation fonts-noto`
+- **THEN** the env var `BFHCHARTS_SMOKE_FONT_PATH` SHALL point to a directory those fonts are installed in
+- **AND** `tests/smoke/render_smoke.R` SHALL pass `font_path = Sys.getenv("BFHCHARTS_SMOKE_FONT_PATH")` to `bfh_export_pdf()`
+- **AND** `bfh_export_pdf()` SHALL successfully compile a PDF that is non-empty and has at least 1 page
+
+```r
+# tests/smoke/render_smoke.R contract:
+font_path_override <- Sys.getenv("BFHCHARTS_SMOKE_FONT_PATH", unset = NA_character_)
+stopifnot(!is.na(font_path_override) || !is_ci())  # CI must set the env var
+
+result <- bfh_qic(test_data, ...)
+out_pdf <- tempfile(fileext = ".pdf")
+bfh_export_pdf(
+  result, out_pdf,
+  font_path = if (!is.na(font_path_override)) font_path_override else NULL
+)
+
+stopifnot(file.exists(out_pdf))
+stopifnot(file.info(out_pdf)$size > 0)
+stopifnot(pdftools::pdf_info(out_pdf)$pages >= 1)
+```
+
+#### Scenario: Proprietary fonts excluded from git
+
+- **GIVEN** developer adds a Mari-licensed font to the local template directory
+- **WHEN** the developer runs `git status`
+- **THEN** the Mari font file SHALL appear as ignored (via `.gitignore` pattern)
+- **AND** SHALL NOT be accidentally committed via `git add inst/`
+
+```gitignore
+# Excerpt from .gitignore
+inst/templates/typst/bfh-template/fonts/Mari*.ttf
+inst/templates/typst/bfh-template/fonts/Mari*.otf
+```
+
+#### Scenario: Workflow header documentation matches actual implementation
+
+- **GIVEN** `.github/workflows/pdf-smoke.yaml` header comment claims a font strategy
+- **WHEN** a maintainer reads the workflow header
+- **THEN** the documented strategy SHALL match what the workflow steps actually do
+- **AND** any env vars referenced in the header SHALL actually be set by a workflow step
+- **AND** drift between header and steps SHALL be treated as a documentation bug requiring fix
+
+This scenario specifically prevents the regression where the prior `pdf-smoke.yaml.disabled` header described setting `BFHCHARTS_SMOKE_FONT_PATH` while no workflow step actually exported it.
+
+#### Scenario: Workflow failure uploads diagnostic artifacts
+
+- **GIVEN** the smoke workflow fails (non-zero exit code from `Rscript tests/smoke/render_smoke.R`)
+- **WHEN** the workflow finishes
+- **THEN** `actions/upload-artifact@v4` SHALL upload generated `.pdf`, `.typ`, and `.tex.log` files
+- **AND** the artifact name SHALL include `${{ github.run_id }}` for unique identification
+- **AND** retention SHALL be at least 7 days
+


### PR DESCRIPTION
## Sammendrag

Arkiverer 5 OpenSpec changes der er implementeret og merged via PRs #260-#264.

## Arkiverede changes

| Slug | Implementation PR |
|------|-------------------|
| cleanup-temp-dir-ownership-check | #260 |
| update-print-summary-removal-docs | #261 |
| complete-chart-type-public-docs | #261 |
| fix-percent-target-scale-in-analysis | #262 |
| add-bfhcharts-assets-companion-pkg | #263 |
| enable-ci-safe-pdf-smoke-render | #264 |

## Spec-opdateringer

`openspec archive` har applied requirement-deltas til:

- `openspec/specs/pdf-export/spec.md` (+ 2 added: temp-dir protection, organizational asset distribution)
- `openspec/specs/public-api/spec.md` (+ 1 added, ~ 1 modified: documentation freshness, validator-docs alignment)
- `openspec/specs/spc-analysis-api/spec.md` (+ 1 added: percent-target normalization)
- `openspec/specs/test-infrastructure/spec.md` (+ 1 added: CI-safe PDF smoke render)

## Bemærkning om task-state

Task-checkbokse i de individuelle changes' `tasks.md` er ikke opdateret af implementations-agenterne (de fokuserede på kode + tests). Funktionel implementation er dog komplet og verificeret via merged PRs + grøn CI inkl. live `pdf-smoke (ubuntu-latest)` på #264.

## Test plan

- [x] `openspec archive` validation (alle 5 changes valideret med spec-deltas applied)
- [x] Specs i `openspec/specs/` opdateret korrekt
- [x] Archive directories oprettet under `openspec/changes/archive/2026-04-29-*`
- [x] Underliggende implementations-PRs merged til develop