### PR TITLE
Release v0.14.1: fix typst escape

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BFHcharts
 Title: SPC Visualization for Healthcare Quality Improvement
-Version: 0.14.0
+Version: 0.14.1
 Authors@R: c(
     person(
       "Johan", "Reventlow",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# BFHcharts 0.14.1
+
+## Bug fixes
+
+* `escape_typst_string()` over-escapede `<` og `>` med backslash i Typst
+  string-literal-kontekst. Da `\<` og `\>` ikke er valide Typst-string-escapes,
+  bevarede Typst backslashen literalt i PDF-output (fx `p \< 0.05` i stedet
+  for `p < 0.05`). Paavirkede metadatafelter `hospital`, `department`,
+  `details`, `author` og `data_definition`. Fixet ved at lade `<` og `>`
+  passere uaendret - de er almindelige tegn i Typst string literals og kan
+  ikke terminere strengen.
+
 # BFHcharts 0.14.0
 
 ## Nye features

--- a/R/utils_typst.R
+++ b/R/utils_typst.R
@@ -523,13 +523,12 @@ escape_typst_string <- function(s) {
   # perl-regex \\x00 matcher NUL uden at skulle indlejre literal NUL i kildefil.
   s <- gsub("\\x00", "", s, perl = TRUE)
 
-  # Escape backslashes and quotes
+  # Escape backslashes and quotes (only valid escapes in Typst string literals
+  # are \\, \", \n, \r, \t, \u{...}; control chars handled above).
+  # Other characters - including < and > - pass through unchanged: they are
+  # ordinary characters inside a string literal and cannot terminate it.
   s <- gsub("\\\\", "\\\\\\\\", s)
   s <- gsub('"', '\\\\"', s)
-
-  # Escape Typst special characters
-  s <- gsub("<", "\\\\<", s)
-  s <- gsub(">", "\\\\>", s)
 
   return(s)
 }

--- a/tests/testthat/test-harden-export-pipeline-security.R
+++ b/tests/testthat/test-harden-export-pipeline-security.R
@@ -258,10 +258,29 @@ test_that("escape_typst_string bevarer eksisterende escaping af backslash og anf
   expect_true(grepl('\\"', result, fixed = TRUE))
 })
 
-test_that("escape_typst_string bevarer eksisterende escaping af < og >", {
-  result <- BFHcharts:::escape_typst_string("a<b>c")
-  expect_true(grepl("\\<", result, fixed = TRUE))
-  expect_true(grepl("\\>", result, fixed = TRUE))
+test_that("escape_typst_string lader < og > passere uaendret (string-literal kontekst)", {
+  # < og > er almindelige tegn i Typst string literals - de kan ikke terminere
+  # strengen, og tidligere `\<` / `\>` escapes var invalide Typst-escapes som
+  # blev gengivet med literal backslash i PDF (fx "p \< 0.05").
+  expect_equal(BFHcharts:::escape_typst_string("a<b>c"), "a<b>c")
+})
+
+test_that("escape_typst_string bevarer realistisk klinisk tekst med < og >", {
+  # Regression: sikrer at indholdsfelter (hospital, department, details, author,
+  # data_definition, chart_title) ikke faar literal backslash i PDF-output.
+  expect_equal(
+    BFHcharts:::escape_typst_string("p < 0.05 og n > 30"),
+    "p < 0.05 og n > 30"
+  )
+})
+
+test_that("escape_typst_string bevarer kombineret < > og quote-escaping", {
+  # Kombineret realistisk input: backslash + quote skal stadig escapes,
+  # men < og > skal ikke faa literal backslash.
+  expect_equal(
+    BFHcharts:::escape_typst_string("p < 0.05 (\"primary\")"),
+    "p < 0.05 (\\\"primary\\\")"
+  )
 })
 
 test_that("escape_typst_string haandterer NULL og tom streng", {


### PR DESCRIPTION
## Summary

Patch release v0.14.1 — bug fix only.

Includes PR #276: drops invalid `\<` and `\>` escapes in `escape_typst_string()` that produced literal backslashes in PDF metadata fields.

## Changes

- v0.14.0 → v0.14.1 (PATCH)
- See `NEWS.md` for details

## Test plan

- [x] PR #276 CI all green (R-CMD-check ubuntu/windows/oldrel, lint, pdf-smoke, git-archive-render)
- [x] Manual verification: clinical text with `<`/`>` no longer renders with literal backslash
- [x] Existing test suite passes (vdiffr drift unrelated, tracked in #277)