### PR TITLE
fix(dep-guards): translate Danish messages + add co-location regression

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+# BFHcharts (development)
+
+## Internal changes
+
+* Translate Danish error/warning messages in `R/fct_add_spc_labels.R` to
+  English to match standard R-package convention. Affected: input
+  validation errors and CL/target fallback warning.
+* Add `call. = FALSE` to public-API-boundary `stop()` calls in
+  `add_spc_labels()` so internal call stack is not leaked to user.
+* Add co-location regression test in `tests/testthat/test-dep-guards.R`
+  asserting every `R/*.R` file referencing `BFHtheme::` also calls
+  `.ensure_bfhtheme()`. Catches future drift where new BFHtheme call
+  sites are added without the corresponding guard.
+
 # BFHcharts 0.14.1
 
 ## Bug fixes

--- a/R/fct_add_spc_labels.R
+++ b/R/fct_add_spc_labels.R
@@ -90,11 +90,11 @@ add_spc_labels <- function(
   .ensure_bfhtheme()
   # Input validation ----
   if (!inherits(plot, "gg")) {
-    stop("plot skal v\u00e6re et ggplot object")
+    stop("plot must be a ggplot object", call. = FALSE)
   }
 
   if (!is.data.frame(qic_data)) {
-    stop("qic_data skal v\u00e6re en data.frame")
+    stop("qic_data must be a data frame", call. = FALSE)
   }
 
   # Validate y_axis_unit
@@ -186,7 +186,10 @@ add_spc_labels <- function(
 
   # Valider at vi har mindst en vaerdi ----
   if (is.na(cl_value) && is.na(target_value)) {
-    warning("Ingen CL eller Target v\u00e6rdier fundet i qic_data. Returnerer plot u\u00e6ndret.")
+    warning(
+      "No CL or Target values found in qic_data; returning plot unchanged.",
+      call. = FALSE
+    )
     return(plot)
   }
 

--- a/tests/testthat/test-dep-guards.R
+++ b/tests/testthat/test-dep-guards.R
@@ -81,5 +81,45 @@ test_that(".ensure_bfhtheme() honours custom min_version argument", {
   expect_match(conditionMessage(err), "0.7.0", fixed = TRUE)
 })
 
+# ============================================================================
+# Co-location regression: BFHtheme:: usage requires .ensure_bfhtheme() guard
+# ============================================================================
+# Asserts that every R/*.R file referencing BFHtheme:: also calls
+# .ensure_bfhtheme() in the same file. Catches drift where a new BFHtheme
+# call site is added without the corresponding guard.
+#
+# Excludes utils_dep_guards.R itself (defines the guard) and
+# BFHcharts-package.R (declarative namespace tag, not runtime usage).
+
+test_that("every R/*.R using BFHtheme:: also calls .ensure_bfhtheme()", {
+  pkg_root <- testthat::test_path("..", "..")
+  r_dir <- file.path(pkg_root, "R")
+  skip_if_not(dir.exists(r_dir))
+
+  excluded <- c("utils_dep_guards.R", "BFHcharts-package.R")
+  r_files <- setdiff(list.files(r_dir, pattern = "\\.R$"), excluded)
+
+  offenders <- character()
+  for (f in r_files) {
+    src <- readLines(file.path(r_dir, f), warn = FALSE)
+    # Strip comments to avoid false positives from doc strings/roxygen
+    code <- sub("#.*$", "", src)
+    uses_bfhtheme <- any(grepl("BFHtheme::", code, fixed = TRUE))
+    has_guard <- any(grepl(".ensure_bfhtheme(", code, fixed = TRUE))
+    if (uses_bfhtheme && !has_guard) {
+      offenders <- c(offenders, f)
+    }
+  }
+
+  expect_equal(
+    offenders,
+    character(),
+    info = paste(
+      "Files using BFHtheme:: without .ensure_bfhtheme() co-located:",
+      paste(offenders, collapse = ", ")
+    )
+  )
+})
+
 # Reset cache after this test file so subsequent test files start clean
 withr::defer(BFHcharts:::.reset_dep_guard_cache(), teardown_env())

--- a/tests/testthat/test-fct_add_spc_labels.R
+++ b/tests/testthat/test-fct_add_spc_labels.R
@@ -13,7 +13,8 @@ make_test_data <- function() {
 }
 
 make_test_plot <- function(qic_data = make_test_data()) {
-  ggplot2::ggplot(qic_data, ggplot2::aes(x = x, y = y)) + ggplot2::geom_line()
+  ggplot2::ggplot(qic_data, ggplot2::aes(x = x, y = y)) +
+    ggplot2::geom_line()
 }
 
 
@@ -182,7 +183,7 @@ test_that("returns plot unchanged when both CL and target are NA", {
 
   expect_warning(
     result <- add_spc_labels(p, qic_data, y_axis_unit = "count"),
-    "Ingen CL eller Target"
+    "No CL or Target"
   )
   # Returnerer original plot uaendret
   expect_identical(result, p)
@@ -299,7 +300,8 @@ test_that("CL and target labels do not overlap in NPC space", {
     cl = rep(50.5, 12),
     target = rep(48, 12)
   )
-  p <- ggplot2::ggplot(qic_data, ggplot2::aes(x = x, y = y)) + ggplot2::geom_line()
+  p <- ggplot2::ggplot(qic_data, ggplot2::aes(x = x, y = y)) +
+    ggplot2::geom_line()
 
   result <- add_spc_labels(p, qic_data, y_axis_unit = "count")
   info <- attr(result, "placement_info")
@@ -319,14 +321,16 @@ test_that("placement is stable across different viewport dimensions", {
 
   # Smal viewport
   result_narrow <- add_spc_labels(
-    p, qic_data, y_axis_unit = "count",
+    p, qic_data,
+    y_axis_unit = "count",
     viewport_width = 4, viewport_height = 3
   )
   info_narrow <- attr(result_narrow, "placement_info")
 
   # Bred viewport
   result_wide <- add_spc_labels(
-    p, qic_data, y_axis_unit = "count",
+    p, qic_data,
+    y_axis_unit = "count",
     viewport_width = 10, viewport_height = 5
   )
   info_wide <- attr(result_wide, "placement_info")


### PR DESCRIPTION
## Summary

Code review (Fase 1C) flagged 3 missing `.ensure_bfhtheme()` calls in `fct_add_spc_labels.R` and `utils_add_right_labels_marquee.R`. Audit confirmed **all 3 are already in place upstream** — guards correctly co-located with `BFHtheme::` calls. This PR delivers the follow-up cleanup that emerged during the audit instead:

## Changes

### 1. Translate Danish messages in `R/fct_add_spc_labels.R`

- L93: `"plot skal være et ggplot object"` → `"plot must be a ggplot object"` + `call. = FALSE`
- L97: `"qic_data skal være en data.frame"` → `"qic_data must be a data frame"` + `call. = FALSE`
- L189-191: `"Ingen CL eller Target værdier fundet i qic_data..."` → `"No CL or Target values found in qic_data; returning plot unchanged."` + `call. = FALSE`

### 2. Co-location regression test (`tests/testthat/test-dep-guards.R`)

Greps every `R/*.R` file for `BFHtheme::` references and asserts each containing file also calls `.ensure_bfhtheme()`. Catches future drift.

Excludes:
- `utils_dep_guards.R` (defines the guard)
- `BFHcharts-package.R` (declarative namespace tag, not runtime usage)

### 3. Test updates

- `tests/testthat/test-fct_add_spc_labels.R:185`: expectation updated from `"Ingen CL eller Target"` → `"No CL or Target"`

## Test plan

- [x] `test-dep-guards.R`: 12/12 pass (5 original + 1 new regression test, with 6 inner `expect_equal` assertions in offender list)
- [x] `test-fct_add_spc_labels.R`: 43/43 pass after expectation update
- [x] `test-source-ascii.R`: pass (all replacements pure ASCII, no `\u`-escapes)
- [x] Pre-push hook `PREPUSH_MODE=full` passes (155s, full suite green)

## Why no version bump

Internal-only cleanup. Versioning left at 0.14.1 — entry added under `# BFHcharts (development)` section in NEWS.md so parent agent can reconcile across the 3 parallel Fase 1 PRs.

## Coordination

Sibling PRs:
- Fase 1A: `fix/typst-security-hardening` — security fixes (M1-M3, H1, H2, M18). Will introduce v0.14.2 with `## Breaking changes` (H1 warning→stop on `inject_assets`).
- Fase 1B: `chore/error-message-policy-compliance` — 22 Danish→English translations + 21 `call.=FALSE` additions across utils_bfh_qic_helpers/spc_analysis/utils_npc_mapping/utils_label_helpers/utils_label_formatting.

This PR (1C) does NOT overlap with 1A or 1B file scope.