### PR TITLE
fix(security): harden typst pipeline against injection, RCE, and silent fallbacks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BFHcharts
 Title: SPC Visualization for Healthcare Quality Improvement
-Version: 0.14.1
+Version: 0.14.2
 Authors@R: c(
     person(
       "Johan", "Reventlow",
@@ -42,7 +42,7 @@ Imports:
     rlang,
     svglite
 Suggests:
-    testthat (>= 3.0.0),
+    testthat (>= 3.1.7),
     vdiffr,
     covr,
     pdftools (>= 3.3.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,55 @@
+# BFHcharts 0.14.2
+
+## Breaking changes
+
+* **`inject_assets` from `.GlobalEnv` now errors instead of warning (H1).**
+  `.validate_inject_assets()` previously warned when the supplied function
+  originated from `.GlobalEnv` or a direct child environment. It now
+  hard-errors unless `options(BFHcharts.allow_globalenv_inject = TRUE)` is set.
+  Accepted namespaces are `BFHcharts` and `biSPCharts` by default; companion
+  packages can pass a custom `allowed_namespaces` vector to the internal helper.
+  This prevents privilege-escalation in Shiny deployments where a reactive
+  closure can silently bind a `.GlobalEnv` function to `inject_assets`.
+
+  Migration: move your `inject_assets` callback into a version-controlled
+  package namespace (e.g. `MyOrgAssets::inject_bfh_assets`), or set
+  `options(BFHcharts.allow_globalenv_inject = TRUE)` in development sessions
+  where interactive closures are intentional.
+
+## Nye features
+
+* **`bfh_export_pdf()` gains `restrict_template = FALSE` parameter (H2).**
+  When set to `TRUE`, any non-`NULL` `template_path` is rejected with an
+  error before compilation. Use in deployment contexts where only the packaged
+  BFHcharts template should be compiled, preventing custom-template injection
+  from misconfigured pipelines. Default `FALSE` preserves backward compatibility.
+
+## Bug fixes
+
+* **M1: Flag-allowlist in `.safe_system2_capture()`.** Replaced the
+  `startsWith(arg, "--")` heuristic with an explicit `KNOWN_TYPST_FLAGS`
+  allowlist (`c("--ignore-system-fonts", "--font-path")`). Any double-dash
+  argument not in the allowlist (e.g. a crafted `--rce` value) is now
+  `shQuote()`-d on POSIX systems, preventing command injection via
+  flag-shaped strings.
+
+* **M2: Double-quote rejected in output paths.** `"` was missing from
+  `SHELL_METACHARS_OUTPUT_PATH`. It is now blocked by `validate_export_path()`.
+  Test: `output = 'a".pdf'` is rejected with "disallowed".
+
+* **M3: Packaged-font fallback after invalid `font_path` (silent fallback fixed).**
+  When a user-supplied `font_path` fails directory validation, the compiler
+  previously fell through to system fonts even with `--ignore-system-fonts` set.
+  A new `.detect_packaged_fonts()` helper is now called in both the NULL-input
+  branch and the validation-fail-reset branch, ensuring packaged fonts are
+  always detected when available.
+
+* **M18: `.is_windows()` helper extracted for cross-platform test coverage.**
+  `.Platform$OS.type == "windows"` check moved into a testable `.is_windows()`
+  helper. Tests now use `local_mocked_bindings(.is_windows = ...)` to verify
+  both the Windows early-return path (no `shQuote`) and the POSIX quoting path
+  without requiring a real Windows OS.
+
 # BFHcharts 0.14.1
 
 ## Bug fixes

--- a/R/export_pdf.R
+++ b/R/export_pdf.R
@@ -29,6 +29,18 @@
 #' @param template_path Optional path to a custom Typst template file. When provided,
 #'   this overrides the packaged template. The template must exist and be a valid
 #'   Typst file (.typ). Default is NULL (uses packaged BFH template).
+#' @param restrict_template Logical. When \code{TRUE}, any non-NULL
+#'   \code{template_path} is rejected with an error. Use in deployment contexts
+#'   where the Typst compiler must only process the packaged template.
+#'
+#'   \strong{Threat model:} A custom Typst template is compiled by the Typst
+#'   binary and can read or write arbitrary paths during compilation. This is
+#'   equivalent to \code{source()} in trust requirements. Setting
+#'   \code{restrict_template = TRUE} prevents a compromised configuration
+#'   pipeline from injecting a malicious template via \code{template_path}.
+#'
+#'   Default: \code{FALSE} (backward-compatible -- custom templates are allowed
+#'   unless explicitly restricted).
 #' @param auto_analysis Logical. If TRUE and \code{metadata$analysis} is not provided,
 #'   automatically generates analysis text using \code{bfh_generate_analysis()}.
 #'   Default is FALSE for backward compatibility.
@@ -256,6 +268,7 @@ bfh_export_pdf <- function(x,
                            metadata = list(),
                            template = "bfh-diagram",
                            template_path = NULL,
+                           restrict_template = FALSE,
                            auto_analysis = FALSE,
                            use_ai = FALSE,
                            data_consent = NULL,
@@ -271,6 +284,19 @@ bfh_export_pdf <- function(x,
   # strict_baseline: per-call > session > default(TRUE).
   # missing()-flag fanges FOERST i orchestrator-scopet (NSE-sensitive).
   strict_baseline_supplied <- !missing(strict_baseline)
+
+  # ---- 0. restrict_template guard --------------------------------------------
+  # Threat model: template_path compiles arbitrary Typst code with the privileges
+  # of the calling R session (equivalent to source()). When restrict_template=TRUE,
+  # only the packaged template is allowed, preventing custom-template injection
+  # from untrusted Shiny inputs or API parameters.
+  if (isTRUE(restrict_template) && !is.null(template_path)) {
+    stop(
+      "template_path is not allowed when restrict_template = TRUE. ",
+      "Only the packaged BFHcharts template may be used in this configuration.",
+      call. = FALSE
+    )
+  }
 
   # ---- 1. Input-validering (class, metadata, dpi, font_path, session) --------
   validate_bfh_export_pdf_inputs(
@@ -476,16 +502,30 @@ recalculate_labels_for_export <- function(x, target_width_mm, target_height_mm,
 # INJECT_ASSETS RUNTIME GUARD
 # ============================================================================
 
-# Validate inject_assets argument: must be NULL or a function.
-# Warns (does not error) when the function environment indicates it originates
-# from .GlobalEnv or a direct child, which signals likely accidental exposure
-# (e.g., a Shiny reactive binding a top-level helper to inject_assets).
-# Suppress with options(BFHcharts.allow_globalenv_inject = TRUE) in dev flows.
+# Validate inject_assets argument: must be NULL or a function from a trusted
+# namespace. Errors (does not warn) when the function environment indicates it
+# originates from .GlobalEnv or a direct child, which prevents accidental
+# privilege-escalation vectors in Shiny apps (e.g. a reactive binding a
+# top-level helper to inject_assets).
+#
+# Threat model: inject_assets executes arbitrary code with the privileges of the
+# calling R session. Accepting functions from .GlobalEnv creates an
+# easy-to-trigger RCE vector when the Shiny input pipeline is compromised.
+# Requiring a package namespace enforces that the function is version-controlled
+# and reviewed code, not an ad-hoc closure assembled at runtime.
+#
+# Suppress with options(BFHcharts.allow_globalenv_inject = TRUE) in dev flows
+# where functions are defined interactively.
 #
 # @param fn The inject_assets argument (NULL or function).
+# @param allowed_namespaces Character vector of package namespaces allowed as
+#   the top-level environment. Defaults to BFHcharts and biSPCharts.
 # @return fn invisibly.
 # @noRd
-.validate_inject_assets <- function(fn) {
+.validate_inject_assets <- function(
+  fn,
+  allowed_namespaces = c("BFHcharts", "biSPCharts")
+) {
   if (is.null(fn)) {
     return(invisible(NULL))
   }
@@ -495,19 +535,19 @@ recalculate_labels_for_export <- function(x, target_width_mm, target_height_mm,
 
   if (!isTRUE(getOption(BFHCHARTS_OPT_ALLOW_GLOBALENV_INJECT, default = FALSE))) {
     fn_env <- environment(fn)
-    # Heuristic: warn if function's top-level enclosure is .GlobalEnv.
-    # Functions from a package namespace have topenv() == that namespace.
-    if (!is.null(fn_env) &&
-      (identical(fn_env, globalenv()) ||
-        identical(topenv(fn_env), globalenv()))) {
-      warning(
-        "inject_assets supplied from global environment. ",
-        "Production usage should pass functions from a controlled namespace ",
-        "(e.g., MyOrgAssets::inject_my_assets). ",
-        "If this is intentional in development, suppress with ",
-        "options(BFHcharts.allow_globalenv_inject = TRUE).",
-        call. = FALSE
-      )
+    # Primitives have NULL environment; treat as trusted (they are base R builtins).
+    if (!is.null(fn_env)) {
+      top_name <- environmentName(topenv(fn_env))
+      if (!top_name %in% allowed_namespaces) {
+        stop(
+          "inject_assets must come from a trusted package namespace ",
+          "(e.g., MyOrgAssets::inject_my_assets), not from '", top_name, "'. ",
+          "Accepting functions from arbitrary environments is a privilege-escalation ",
+          "risk in production. If this is intentional in development, suppress with ",
+          "options(BFHcharts.allow_globalenv_inject = TRUE).",
+          call. = FALSE
+        )
+      }
     }
   }
 

--- a/R/utils_path_policy.R
+++ b/R/utils_path_policy.R
@@ -26,7 +26,7 @@ ALLOWED_EXPORT_EXTENSIONS <- c("png", "pdf", "svg", "typ")
 #
 # Kontekst: Codex code review 2026-04-30 finding #10 + advisor-justering
 # efter empirisk verifikation 2026-04-30.
-SHELL_METACHARS_OUTPUT_PATH <- c(";", "|", "<", ">", "`", "\n", "\r")
+SHELL_METACHARS_OUTPUT_PATH <- c(";", "|", "<", ">", "`", "\"", "\n", "\r")
 
 # Metachars der er farlige i shell-kontekst -- bruges KUN til binary-stier
 # (argv[0] til system2()) hvor R's interne wrappers kan re-quote i edge cases.

--- a/R/utils_typst.R
+++ b/R/utils_typst.R
@@ -205,6 +205,36 @@ bfh_create_typst_document <- function(chart_image,
   substr(paste(output, collapse = "\n"), 1L, max)
 }
 
+# Auto-detect packaged fonts in the staged template directory.
+# Looks for a fonts/ subdirectory co-located with the .typ file (the
+# bfh-template directory). Companion packages (e.g. BFHchartsAssets) inject
+# fonts into that directory; without auto-detect they are silently ignored and
+# the compile falls back to system fonts even when --ignore-system-fonts is set.
+# Returns the fonts directory path if fonts are found, NULL otherwise.
+.detect_packaged_fonts <- function(typst_file) {
+  staged_fonts_dir <- file.path(dirname(typst_file), "bfh-template", "fonts")
+  if (!dir.exists(staged_fonts_dir)) {
+    return(NULL)
+  }
+  font_extensions <- c("\\.ttf$", "\\.otf$", "\\.woff$", "\\.woff2$")
+  font_pattern <- paste(font_extensions, collapse = "|")
+  font_files <- list.files(staged_fonts_dir,
+    pattern = font_pattern,
+    ignore.case = TRUE, full.names = FALSE
+  )
+  if (length(font_files) > 0) staged_fonts_dir else NULL
+}
+
+# Explicit allowlist of Typst/Quarto flag arguments that must NOT be shell-quoted.
+# These are the only double-dash flags this package passes to the Typst compiler.
+# Any arg starting with "--" that is NOT in this list is treated as a path/value
+# and will be quoted, preventing RCE via crafted flag-like strings (e.g. --rce).
+KNOWN_TYPST_FLAGS <- c("--ignore-system-fonts", "--font-path")
+
+# Helper: returns TRUE on Windows. Extracted for testability via
+# local_mocked_bindings() -- callers mock .is_windows, not .Platform directly.
+.is_windows <- function() .Platform$OS.type == "windows"
+
 # Wrapper around system2() that ensures path-like arguments are properly
 # shell-quoted when stdout/stderr capture is requested on POSIX systems.
 #
@@ -219,18 +249,20 @@ bfh_create_typst_document <- function(chart_image,
 # literal quotes via shQuote() would corrupt the argument values (Quarto sees
 # the quotes as part of the path). Therefore quoting is POSIX-only.
 #
-# Strategy: On POSIX, apply shQuote() to any arg that does NOT begin with "--"
-# (i.e. path-like positional args). Flag args ("--ignore-system-fonts") are
-# safe as-is; quoting them could break Quarto's flag parser.
+# Strategy: On POSIX, apply shQuote() to any arg that is NOT in the
+# KNOWN_TYPST_FLAGS allowlist. This is stricter than the previous
+# startsWith("--") heuristic: only explicitly approved flags bypass quoting.
+# Flag values following "--font-path" (i.e. the directory path) are NOT flags
+# and will be quoted as expected.
 #
 # The .system2 parameter is the dependency-injection hook inherited from
 # bfh_compile_typst() so mock injection works end-to-end.
 .safe_system2_capture <- function(cmd, args, ..., .system2 = system2) {
-  if (.Platform$OS.type == "windows") {
+  if (.is_windows()) {
     return(.system2(cmd, args = args, ...))
   }
   quoted_args <- vapply(args, function(arg) {
-    if (startsWith(arg, "--")) {
+    if (arg %in% KNOWN_TYPST_FLAGS) {
       arg
     } else {
       shQuote(arg)
@@ -278,7 +310,8 @@ bfh_compile_typst <- function(typst_file, output, font_path = NULL,
   validate_export_path(typst_file)
   validate_export_path(output)
 
-  # Valider font_path hvis angivet
+  # Validate font_path if supplied; reset to NULL on validation failure so that
+  # the auto-detect block below can recover packaged fonts in both branches.
   if (!is.null(font_path)) {
     if (!is.character(font_path) || length(font_path) != 1) {
       stop("font_path must be a single character string", call. = FALSE)
@@ -287,25 +320,17 @@ bfh_compile_typst <- function(typst_file, output, font_path = NULL,
     .check_metachars(font_path)
     if (!dir.exists(font_path)) {
       warning("font_path directory does not exist: ", font_path, call. = FALSE)
-      font_path <- NULL
+      font_path <- NULL # falls through to auto-detect below
     }
-  } else {
-    # Auto-detect fonts/ subdirectory in the staged template tempdir.
-    # Companion packages (e.g. BFHchartsAssets) inject fonts into a fonts/
-    # subdirectory alongside the .typ file. Without auto-detect, these are
-    # silently ignored and the compile falls back to system fonts only.
-    staged_fonts_dir <- file.path(dirname(typst_file), "bfh-template", "fonts")
-    if (dir.exists(staged_fonts_dir)) {
-      font_extensions <- c("\\.ttf$", "\\.otf$", "\\.woff$", "\\.woff2$")
-      font_pattern <- paste(font_extensions, collapse = "|")
-      font_files <- list.files(staged_fonts_dir,
-        pattern = font_pattern,
-        ignore.case = TRUE, full.names = FALSE
-      )
-      if (length(font_files) > 0) {
-        font_path <- staged_fonts_dir
-      }
-    }
+  }
+  # Auto-detect packaged fonts when no (valid) user font_path was supplied.
+  # Covers two cases:
+  #   1. Caller passed font_path = NULL (original behaviour).
+  #   2. Caller passed an invalid font_path that was reset to NULL above.
+  # Without this, a bad user font_path would silently fall back to system fonts
+  # even though --ignore-system-fonts blocks them.
+  if (is.null(font_path)) {
+    font_path <- .detect_packaged_fonts(typst_file)
   }
 
   # Create output directory if needed

--- a/man/bfh_export_pdf.Rd
+++ b/man/bfh_export_pdf.Rd
@@ -10,6 +10,7 @@ bfh_export_pdf(
   metadata = list(),
   template = "bfh-diagram",
   template_path = NULL,
+  restrict_template = FALSE,
   auto_analysis = FALSE,
   use_ai = FALSE,
   data_consent = NULL,
@@ -55,6 +56,19 @@ Supports markdown formatting (bold, italic, line breaks).
 \item{template_path}{Optional path to a custom Typst template file. When provided,
 this overrides the packaged template. The template must exist and be a valid
 Typst file (.typ). Default is NULL (uses packaged BFH template).}
+
+\item{restrict_template}{Logical. When \code{TRUE}, any non-NULL
+\code{template_path} is rejected with an error. Use in deployment contexts
+where the Typst compiler must only process the packaged template.
+
+\strong{Threat model:} A custom Typst template is compiled by the Typst
+binary and can read or write arbitrary paths during compilation. This is
+equivalent to \code{source()} in trust requirements. Setting
+\code{restrict_template = TRUE} prevents a compromised configuration
+pipeline from injecting a malicious template via \code{template_path}.
+
+Default: \code{FALSE} (backward-compatible -- custom templates are allowed
+unless explicitly restricted).}
 
 \item{auto_analysis}{Logical. If TRUE and \code{metadata$analysis} is not provided,
 automatically generates analysis text using \code{bfh_generate_analysis()}.

--- a/tests/testthat/test-harden-export-pipeline-security.R
+++ b/tests/testthat/test-harden-export-pipeline-security.R
@@ -368,3 +368,114 @@ test_that("prepare_temp_workspace bruger ikke Sys.getenv UID-check", {
   src <- readLines(src_path)
   expect_false(any(grepl('Sys\\.getenv\\("UID"\\)', src)))
 })
+
+# ============================================================================
+# 6. M1: KNOWN_TYPST_FLAGS allowlist in .safe_system2_capture
+# ============================================================================
+
+test_that(".safe_system2_capture quotes --rce flag (not in allowlist)", {
+  skip_on_os("windows")
+
+  typst_file <- tempfile(fileext = ".typ")
+  writeLines("#text[rce test]", typst_file)
+  withr::defer(unlink(typst_file))
+  out_pdf <- tempfile(fileext = ".pdf")
+  withr::defer(unlink(out_pdf))
+
+  captured_args <- NULL
+  mock_s2 <- function(command, args, ...) {
+    captured_args <<- args
+    file.create(out_pdf)
+    character(0)
+  }
+
+  # Inject a rogue flag-like arg by temporarily appending to compile_args via
+  # a custom .system2 that intercepts before quoting.
+  # Verify via the KNOWN_TYPST_FLAGS constant: --rce is not in it.
+  expect_false("--rce" %in% BFHcharts:::KNOWN_TYPST_FLAGS)
+
+  # Direct unit test of .safe_system2_capture: --rce must be quoted.
+  BFHcharts:::.safe_system2_capture(
+    "/fake/cmd", c("--rce", typst_file),
+    stdout = FALSE, stderr = FALSE,
+    .system2 = function(command, args, ...) {
+      captured_args <<- args
+      character(0)
+    }
+  )
+
+  # --rce should be wrapped in single quotes (shQuote) since it is not allowlisted
+  rce_arg <- captured_args[1]
+  expect_true(
+    startsWith(rce_arg, "'"),
+    info = paste("--rce must be shell-quoted, got:", rce_arg)
+  )
+})
+
+test_that("KNOWN_TYPST_FLAGS contains exactly the expected flags", {
+  flags <- BFHcharts:::KNOWN_TYPST_FLAGS
+  expect_setequal(flags, c("--ignore-system-fonts", "--font-path"))
+})
+
+# ============================================================================
+# 7. H2: restrict_template parameter on bfh_export_pdf()
+# ============================================================================
+
+test_that("bfh_export_pdf with restrict_template=TRUE rejects custom template_path", {
+  # We need a valid bfh_qic_result to get past the first input validation.
+  # Create a minimal one using the public API.
+  skip_on_cran()
+
+  data <- data.frame(
+    x = seq.Date(as.Date("2022-01-01"), by = "month", length.out = 20),
+    y = rpois(20, 10)
+  )
+  result <- bfh_qic(data,
+    x = x, y = y, chart_type = "i",
+    chart_title = "Test"
+  )
+
+  expect_error(
+    bfh_export_pdf(
+      result,
+      output = tempfile(fileext = ".pdf"),
+      template_path = "/some/custom/template.typ",
+      restrict_template = TRUE
+    ),
+    regexp = "restrict_template"
+  )
+})
+
+test_that("bfh_export_pdf with restrict_template=FALSE allows custom template_path (default behavior)", {
+  # restrict_template=FALSE is the default; validation should not error on template_path
+  # We test only that the restrict_template guard does NOT fire here.
+  # (The actual export may fail due to missing template file -- that is unrelated.)
+  skip_on_cran()
+
+  data <- data.frame(
+    x = seq.Date(as.Date("2022-01-01"), by = "month", length.out = 20),
+    y = rpois(20, 10)
+  )
+  result <- bfh_qic(data,
+    x = x, y = y, chart_type = "i",
+    chart_title = "Test"
+  )
+
+  err <- tryCatch(
+    bfh_export_pdf(
+      result,
+      output = tempfile(fileext = ".pdf"),
+      template_path = "/nonexistent/custom.typ",
+      restrict_template = FALSE
+    ),
+    error = function(e) e
+  )
+
+  # Error should NOT mention restrict_template -- it should be about the missing file
+  if (inherits(err, "error")) {
+    expect_false(
+      grepl("restrict_template", conditionMessage(err)),
+      info = "Error should be about missing template, not restrict_template guard"
+    )
+  }
+})

--- a/tests/testthat/test-harden-export-pipeline-security.R
+++ b/tests/testthat/test-harden-export-pipeline-security.R
@@ -446,6 +446,67 @@ test_that("bfh_export_pdf with restrict_template=TRUE rejects custom template_pa
   )
 })
 
+# ============================================================================
+# 8. M3: bad font_path warns then auto-detects packaged fonts
+# ============================================================================
+
+test_that("bad font_path warns then auto-detects packaged fonts in bfh-template/fonts", {
+  skip_on_cran()
+
+  # Set up a tempdir that mimics the staged workspace layout:
+  #   <tmp>/document.typ          <- typst source file
+  #   <tmp>/bfh-template/fonts/   <- directory .detect_packaged_fonts() scans
+  #   <tmp>/bfh-template/fonts/BFHFont.ttf  <- sentinel font file
+  tmp_dir <- withr::local_tempdir("m3_font_fallback")
+  typst_file <- file.path(tmp_dir, "document.typ")
+  writeLines("#text[m3 test]", typst_file)
+
+  fonts_dir <- file.path(tmp_dir, "bfh-template", "fonts")
+  dir.create(fonts_dir, recursive = TRUE)
+  file.create(file.path(fonts_dir, "BFHFont.ttf"))
+
+  output_pdf <- file.path(tmp_dir, "output.pdf")
+  captured_args <- NULL
+
+  mock_s2 <- function(command, args, ...) {
+    captured_args <<- args
+    # Simulate successful compile by creating the output file
+    file.create(output_pdf)
+    character(0)
+  }
+
+  # Call with a non-existent font_path; should warn AND fall back to packaged fonts
+  expect_warning(
+    BFHcharts:::bfh_compile_typst(
+      typst_file, output_pdf,
+      font_path = "/nonexistent/fonts/dir",
+      .system2 = mock_s2,
+      .quarto_path = "/fake/quarto"
+    ),
+    regexp = "font_path directory does not exist"
+  )
+
+  # --font-path should point to the staged packaged fonts dir, not the bad path
+  expect_true(!is.null(captured_args), info = "mock_s2 must have been called")
+  font_path_idx <- which(captured_args == "--font-path")
+  expect_true(
+    length(font_path_idx) > 0,
+    info = "Compiled args should include --font-path after auto-detect"
+  )
+  if (length(font_path_idx) > 0) {
+    raw_arg <- captured_args[font_path_idx + 1L]
+    # .safe_system2_capture wraps non-flag args with shQuote() on Unix.
+    # Strip outer single or double quotes before comparing paths.
+    actual_font_path <- gsub("^'(.*)'$", "\\1", raw_arg)
+    actual_font_path <- gsub('^"(.*)"$', "\\1", actual_font_path)
+    expect_equal(
+      normalizePath(actual_font_path, mustWork = FALSE),
+      normalizePath(fonts_dir, mustWork = FALSE),
+      info = paste("Expected packaged fonts dir, got:", raw_arg)
+    )
+  }
+})
+
 test_that("bfh_export_pdf with restrict_template=FALSE allows custom template_path (default behavior)", {
   # restrict_template=FALSE is the default; validation should not error on template_path
   # We test only that the restrict_template guard does NOT fire here.

--- a/tests/testthat/test-path-policy.R
+++ b/tests/testthat/test-path-policy.R
@@ -30,8 +30,8 @@ test_that("validate_export_path afviser path traversal med ..", {
 # Kontekst: Codex 2026-04-30 finding #10 / change relax-output-path-policy-parens
 
 test_that("validate_export_path afviser stadig shell-pipeline metacharacters + LF/CR", {
-  # R's system2(stdout=TRUE, stderr=TRUE) shell-mode — disse karakterer kan
-  # bryde shell-parsing eller udfoere kommando-substitution.
+  # R's system2(stdout=TRUE, stderr=TRUE) shell-mode -- these characters can
+  # break shell parsing or trigger command substitution.
   expect_error(validate_export_path("out; rm -rf /"), "disallowed")
   expect_error(validate_export_path("out | cat /etc/passwd"), "disallowed")
   expect_error(validate_export_path("out`cmd`"), "disallowed")
@@ -39,6 +39,13 @@ test_that("validate_export_path afviser stadig shell-pipeline metacharacters + L
   expect_error(validate_export_path("out>redirect"), "disallowed")
   expect_error(validate_export_path("out\nevil"), "disallowed")
   expect_error(validate_export_path("out\revil"), "disallowed")
+})
+
+test_that("validate_export_path afviser double-quote i output-sti (M2)", {
+  # Double-quote can break shell argument boundaries even inside shQuote'd strings
+  # in some edge cases. Rejected as a safety measure.
+  expect_error(validate_export_path('a".pdf'), "disallowed")
+  expect_error(validate_export_path('out"evil.pdf'), "disallowed")
 })
 
 test_that("validate_export_path tillader hospital-relevante karakterer i output-stier", {
@@ -295,5 +302,92 @@ test_that("$ in output path renders actual PDF with literal filename (live Quart
   expect_true(
     grepl("$HOME", basename(out_dollar), fixed = TRUE),
     info = "Filename must contain literal $HOME, not expanded home directory"
+  )
+})
+
+# ============================================================================
+# M18: Windows early-return path in .safe_system2_capture (mock-based)
+# ============================================================================
+#
+# .is_windows() is extracted as a helper specifically to allow mocking via
+# local_mocked_bindings(). These tests verify that the Windows branch (no
+# shQuote) is exercised without needing a real Windows OS.
+
+test_that(".safe_system2_capture skips shQuote on Windows (mocked)", {
+  typst_file <- tempfile(fileext = ".typ")
+  writeLines("#text[win test]", typst_file)
+  withr::defer(unlink(typst_file))
+
+  out_pdf <- tempfile(fileext = ".pdf")
+  withr::defer(unlink(out_pdf))
+
+  captured_args <- NULL
+  win_mock_system2 <- function(command, args, ...) {
+    captured_args <<- args
+    file.create(out_pdf)
+    character(0)
+  }
+
+  # Mock .is_windows to return TRUE regardless of the host OS.
+  # with_mocked_bindings() modifies the binding in the loaded package namespace.
+  with_mocked_bindings(
+    .is_windows = function() TRUE,
+    code = {
+      BFHcharts:::bfh_compile_typst(
+        typst_file, out_pdf,
+        .system2 = win_mock_system2,
+        .quarto_path = "/fake/quarto"
+      )
+    }
+  )
+
+  # On Windows path, args must NOT be wrapped in single-quotes by shQuote
+  expect_false(
+    any(startsWith(captured_args, "'")),
+    info = "Windows branch must not apply shQuote -- args should be unquoted"
+  )
+  # The raw typst_file path should appear literally in the args
+  expect_true(
+    any(captured_args == typst_file),
+    info = "Windows branch must pass raw (unquoted) path to system2"
+  )
+})
+
+test_that(".safe_system2_capture applies shQuote on non-Windows (mocked)", {
+  skip_on_os("windows") # Only meaningful to test POSIX quoting on POSIX
+
+  typst_file <- tempfile(fileext = ".typ")
+  writeLines("#text[posix test]", typst_file)
+  withr::defer(unlink(typst_file))
+
+  out_pdf <- tempfile(fileext = ".pdf")
+  withr::defer(unlink(out_pdf))
+
+  captured_args <- NULL
+  posix_mock <- function(command, args, ...) {
+    captured_args <<- args
+    file.create(out_pdf)
+    character(0)
+  }
+
+  with_mocked_bindings(
+    .is_windows = function() FALSE,
+    code = {
+      BFHcharts:::bfh_compile_typst(
+        typst_file, out_pdf,
+        .system2 = posix_mock,
+        .quarto_path = "/fake/quarto"
+      )
+    }
+  )
+
+  # On POSIX path, non-flag args must be shQuote'd (single-quote wrapping)
+  path_args <- captured_args[!captured_args %in% c(
+    "typst", "compile",
+    "--ignore-system-fonts", "--font-path"
+  )]
+  expect_true(
+    all(startsWith(path_args, "'")),
+    info = "POSIX branch must wrap path args in single-quotes via shQuote"
   )
 })

--- a/tests/testthat/test-security-inject-assets.R
+++ b/tests/testthat/test-security-inject-assets.R
@@ -3,12 +3,15 @@
 # =============================================================================
 #
 # Covers: task 2.5-2.7, 6.1 (spec: pdf-export/spec.md)
+# H1 (harden-export-pipeline-security): warning -> stop; namespace allowlist.
 # Scenarios:
 #   - NULL inject_assets passes silently
 #   - Non-function errors immediately
-#   - Function from a package namespace passes silently
-#   - Function from globalenv warns
-#   - options(BFHcharts.allow_globalenv_inject = TRUE) suppresses warning
+#   - Function from allowed package namespace (BFHcharts) passes silently
+#   - Function from allowed namespace (biSPCharts) passes silently via allowlist
+#   - Function from globalenv now ERRORS (breaking change from H1)
+#   - Function from unrecognized namespace errors
+#   - options(BFHcharts.allow_globalenv_inject = TRUE) suppresses error
 
 
 test_that(".validate_inject_assets: NULL passes silently", {
@@ -30,56 +33,67 @@ test_that(".validate_inject_assets: non-function stops with informative error", 
   )
 })
 
-test_that(".validate_inject_assets: namespace function passes silently", {
-  # Use an actual exported BFHcharts function as the inject_assets callback.
-  # Functions exported from a package namespace have topenv() == that namespace,
-  # not globalenv(), so no warning should be emitted.
+test_that(".validate_inject_assets: BFHcharts namespace function passes silently", {
+  # Functions from the BFHcharts namespace are in the default allowed_namespaces.
+  # topenv() of a namespace function yields that namespace environment.
   namespace_fn <- BFHcharts:::bfh_extract_spc_stats
   expect_silent(BFHcharts:::.validate_inject_assets(namespace_fn))
 })
 
-test_that(".validate_inject_assets: globalenv function warns", {
-  # Define function at script scope, which lives in globalenv() during tests.
-  # Use local() to ensure we control environment explicitly.
-  local_fn <- local({
-    f <- function(template_dir) invisible(NULL)
-    environment(f) <- globalenv()
-    f
-  })
-
-  expect_warning(
-    BFHcharts:::.validate_inject_assets(local_fn),
-    regexp = "global environment"
+test_that(".validate_inject_assets: explicit allowed_namespaces accepts base package function", {
+  # Passing a function whose topenv is "base" with "base" in allowed_namespaces
+  # should pass silently. This exercises the custom-allowlist path.
+  # identity is a primitive so environment(identity) is NULL -> treated as trusted.
+  # Use a non-primitive from base instead.
+  base_fn <- base::Sys.time # non-primitive, topenv is "base"
+  # environmentName(topenv(environment(base::Sys.time))) == "base"
+  expect_silent(
+    BFHcharts:::.validate_inject_assets(base_fn, allowed_namespaces = c("BFHcharts", "base"))
   )
 })
 
-test_that(".validate_inject_assets: globalenv warning mentions recommended pattern", {
+test_that(".validate_inject_assets: globalenv function now errors (H1 breaking change)", {
+  # H1: warning -> stop. Functions from .GlobalEnv are no longer silently
+  # warned about -- they hard-fail to prevent privilege-escalation in production.
   local_fn <- local({
     f <- function(template_dir) invisible(NULL)
     environment(f) <- globalenv()
     f
   })
 
-  expect_warning(
+  expect_error(
+    BFHcharts:::.validate_inject_assets(local_fn),
+    regexp = "trusted package namespace"
+  )
+})
+
+test_that(".validate_inject_assets: globalenv error mentions recommended pattern", {
+  local_fn <- local({
+    f <- function(template_dir) invisible(NULL)
+    environment(f) <- globalenv()
+    f
+  })
+
+  expect_error(
     BFHcharts:::.validate_inject_assets(local_fn),
     regexp = "MyOrgAssets::inject_my_assets"
   )
 })
 
-test_that(".validate_inject_assets: globalenv warning mentions opt-out option", {
+test_that(".validate_inject_assets: globalenv error mentions opt-out option", {
   local_fn <- local({
     f <- function(template_dir) invisible(NULL)
     environment(f) <- globalenv()
     f
   })
 
-  expect_warning(
+  expect_error(
     BFHcharts:::.validate_inject_assets(local_fn),
     regexp = "allow_globalenv_inject"
   )
 })
 
-test_that(".validate_inject_assets: option suppresses globalenv warning", {
+test_that(".validate_inject_assets: option suppresses globalenv error", {
   local_fn <- local({
     f <- function(template_dir) invisible(NULL)
     environment(f) <- globalenv()
@@ -89,6 +103,17 @@ test_that(".validate_inject_assets: option suppresses globalenv warning", {
   withr::with_options(
     list(BFHcharts.allow_globalenv_inject = TRUE),
     expect_silent(BFHcharts:::.validate_inject_assets(local_fn))
+  )
+})
+
+test_that(".validate_inject_assets: function from unrecognized namespace errors", {
+  # A function from a namespace not in the allowlist must be rejected.
+  f <- function(template_dir) invisible(NULL)
+  environment(f) <- as.environment("package:base")
+
+  expect_error(
+    BFHcharts:::.validate_inject_assets(f),
+    regexp = "trusted package namespace"
   )
 })
 


### PR DESCRIPTION
## Summary

Security hardening pass on the Typst export pipeline. Addresses 6 audit findings: 5 bug fixes (M1, M2, M3, M18 + H2 new feature) and 1 **breaking change** (H1).

## Breaking change (H1)

`.validate_inject_assets()` now errors instead of warns when `inject_assets` originates from `.GlobalEnv` or a non-allowlisted namespace.

- Default allowlist: `c("BFHcharts", "biSPCharts")`
- Bypass: `options(BFHcharts.allow_globalenv_inject = TRUE)` (existing dev-flag, still respected)
- Existing `expect_warning` tests in `test-security-inject-assets.R` migrated to `expect_error`
- Rationale: prevents end-user RCE when callers bind reactive helpers to `.GlobalEnv`

Migration: production callers passing `inject_assets` should ensure the function lives in a package namespace, not `.GlobalEnv`. Dev iteration via `options()` flag.

## Bug fixes

### M1 — Flag-allowlist in `.safe_system2_capture()`

Previously `startsWith(arg, "--")` was used to identify flags (skipped `shQuote`). A future or crafted arg starting with `--` (e.g. `--rce`) would silently bypass quoting.

Replaced with explicit `KNOWN_TYPST_FLAGS <- c("--ignore-system-fonts", "--font-path")` allowlist. Everything else is shell-quoted.

### M2 — Add `"` to `SHELL_METACHARS_OUTPUT_PATH`

Quote-char missing from blocked-char set in `utils_path_policy.R:29`. On Windows where `system2` builds a single command-line string, a path containing `"` could corrupt argv splitting. Now `validate_export_path()` rejects paths with literal `"` characters.

### M3 — `font_path` fallback after NULL-reset

When user-supplied `font_path` failed validation, code warned + reset to `NULL` but skipped the `else`-branch auto-detect. Result: silent fallback to system fonts (blocked by `--ignore-system-fonts`).

Extracted `.detect_packaged_fonts()` helper. Now called from both the NULL-input branch AND the validation-fail-reset branch. Bad user `font_path` → packaged fonts auto-detected.

### M18 — Cross-platform Windows-branch tests

Extracted `.is_windows()` helper from `.safe_system2_capture()` for testability. Tests now use `with_mocked_bindings(.is_windows = ...)` to cover both Windows early-return (no shQuote) and POSIX quoting paths. Bumps testthat dependency to >= 3.1.7.

## New feature

### H2 — `restrict_template = FALSE` parameter on `bfh_export_pdf()`

When TRUE, refuses any `template_path` that isn't packaged. Default FALSE preserves backward compat. Production deployers can opt-in to mitigate Typst-template arbitrary-code-execution risk.

## Test results

- `test-harden-export-pipeline-security.R`: 56/0 pass/fail (includes new M3 test verifying `--font-path <packaged_fonts_dir>` appears in args after bad input)
- `test-path-policy.R`: 62/0 pass/fail (1 skip: pre-existing render test)
- `test-security-inject-assets.R`: 12/0 pass/fail (migrated from `expect_warning` to `expect_error`)
- Pre-push hook `PREPUSH_MODE=full`: 147s, full suite green

## Version

DESCRIPTION: 0.14.1 → 0.14.2 (PATCH per VERSIONING_POLICY pre-1.0 rules; H1 documented under `## Breaking changes` in NEWS.md per pre-1.0 convention).

## Coordination

Sibling PRs (independent file scope):
- PR #280 (Fase 1C): `fix/dep-guards-coverage`
- PR #281 (Fase 1B): `chore/error-message-policy-compliance` — left version at 0.14.1, parent reconciles

This PR introduces 0.14.2; B and C will merge cleanly into the same release after rebasing on this PR's NEWS.md changes.