### PR TITLE
docs(openspec): Fase 4 refactor proposals (decompose-marquee-labels, decompose-fallback-analysis, extract-utils-text-da)

### DIFF
--- a/openspec/changes/decompose-fallback-analysis/.openspec.yaml
+++ b/openspec/changes/decompose-fallback-analysis/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-03

--- a/openspec/changes/decompose-fallback-analysis/design.md
+++ b/openspec/changes/decompose-fallback-analysis/design.md
@@ -1,0 +1,120 @@
+## Context
+
+`R/spc_analysis.R` (~929 lines) is the package's largest single file and houses four logically distinct concerns:
+
+1. Target resolution (`resolve_target()`)
+2. Danish text formatting utilities (`pluralize_da()`, `pick_text()`, `substitute_placeholders()`, `pad_to_minimum()`, `ensure_within_max()`)
+3. Analysis context construction (`bfh_build_analysis_context()`, `bfh_generate_analysis()`)
+4. Fallback narrative generation (`build_fallback_analysis()`)
+
+Concern #4 is where the boolean-cascade lives. It owns the logic that picks one of ~15 narrative templates based on a tuple of detected signals (runs, crossings, outliers, stability, target presence, target direction, goal met, at target). Today this is encoded as three nested `if/else if/else if` chains spanning 210 lines (`R/spc_analysis.R:608-817`).
+
+The separate concern #2 (Danish text utilities) is a candidate for extraction in a sibling change `extract-utils-text-da`. This proposal focuses solely on concern #4 — the dispatch decomposition.
+
+Constraints:
+
+- **Behavior must not change.** Existing fallback-narrative tests (`tests/testthat/test-spc_analysis.R`) cover all current cascade arms; they must continue to pass without modification.
+- **`bfh_generate_analysis()` is exported.** Its signature and return contract must remain stable. Only internal helpers below the fallback boundary may change.
+- **biSPCharts consumes `bfh_generate_analysis()`** via `BFHcharts::bfh_generate_analysis()`. No expected impact since only internals change.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Decompose `build_fallback_analysis()` into orchestrator (≤60 lines) + 4 named pure helpers.
+- Each helper is unit-testable in isolation via table-driven tests.
+- Adding a new cascade arm becomes a single new test row + one new key + one new i18n string — no multi-place edit.
+- Zero behavioral change. Same narrative output for every input today.
+
+**Non-Goals:**
+
+- Restructuring `bfh_generate_analysis()` (the AI-vs-fallback dispatch above this layer is out of scope).
+- Extracting Danish text utilities (`pluralize_da()`, `pick_text()`, etc.) — covered by sibling proposal `extract-utils-text-da`.
+- Adding new cascade arms or new signal types. This is pure refactor.
+- Changing the i18n key naming scheme.
+- Performance optimization.
+
+## Decisions
+
+### Decision 1: Four pure helpers, all returning typed structs
+
+**Choice:**
+
+1. `.detect_signal_flags(spc_stats)` → named logical list
+   ```r
+   list(
+     has_runs = TRUE/FALSE,
+     has_crossings = TRUE/FALSE,
+     has_outliers = TRUE/FALSE,
+     is_stable = TRUE/FALSE,
+     has_target = TRUE/FALSE,
+     target_direction = "above"/"below"/NA,
+     goal_met = TRUE/FALSE/NA,
+     at_target = TRUE/FALSE/NA
+   )
+   ```
+2. `.allocate_text_budget(max_chars, has_target)` → named integer list `(budget_stability, budget_action)`
+3. `.select_stability_key(flags)` → character scalar (i18n key into the stability arm)
+4. `.select_action_key(flags)` → character scalar (i18n key into the action arm)
+
+**Rationale:** Pure functions with explicit inputs/outputs are testable as data tables. Today's cascade buries the input-to-output mapping in 210 lines of conditional code; expressed as pure functions, the mapping is a literal lookup that any reader can audit by reading the function body top-to-bottom.
+
+The named-list return shape mirrors existing patterns in the codebase (`spc_plot_config()`, `viewport_dims()`, the `placement` result from `place_two_labels_npc()`).
+
+**Alternative considered:** Single function returning both keys at once. Rejected: bundles two independent concerns (stability narrative, action narrative) which today's cascade interleaves. Decoupling clarifies that the two cascades are independent.
+
+### Decision 2: i18n strings stay in `inst/i18n/`, NOT inlined
+
+**Choice:** The selected keys (`stability_key`, `action_key`) are the helpers' output. The orchestrator then calls `i18n_lookup(key, language)` exactly as today.
+
+**Rationale:** i18n separation is already a clean boundary in the package. Mixing translated strings into the dispatch logic would re-introduce the multi-place edit problem we're trying to solve.
+
+**Alternative considered:** Helpers return final strings, not keys. Rejected: ties dispatch to `language` parameter and prevents adding new languages without re-running the cascade.
+
+### Decision 3: Table-driven unit tests via `tibble` + `purrr::pmap()`
+
+**Choice:** Each `.select_*_key()` helper gets a test that defines a tibble of `(flags, expected_key)` rows and uses `purrr::pmap()` to verify each row. New cascade arms extend the tibble.
+
+**Rationale:** The point of decomposition is to make new arms cheap. The test format must reflect that. Today's tests are ad-hoc `expect_equal()` calls per arm; switching to table-driven matches the new dispatch shape.
+
+**Alternative considered:** Keep ad-hoc tests. Rejected: re-introduces the friction we're removing.
+
+### Decision 4: Helpers stay in `R/spc_analysis.R`
+
+**Choice:** All four new helpers live in the same file as `build_fallback_analysis()`.
+
+**Rationale:** Co-location with the orchestrator they serve. This file is the right size to host them without creating a new file. Once `extract-utils-text-da` lands in parallel, this file shrinks substantially anyway.
+
+**Alternative considered:** New file `R/spc_fallback_analysis.R`. Deferred: revisit after `extract-utils-text-da` lands; if `R/spc_analysis.R` is still oversized, consider further file-level decomposition as a separate proposal.
+
+## Risks / Trade-offs
+
+- **[Risk] Behavioral drift on edge cases (e.g. `is.na(target_direction)` propagation).** → Mitigation: the orchestrator wraps NA-aware conditionals where needed. Add explicit test rows for each NA-mixed input.
+
+- **[Risk] Test rewrite friction if existing snapshot tests assert intermediate logging.** → Mitigation: pre-flight grep `tests/testthat/test-spc_analysis.R` and any related test files for verbose-output assertions; ensure none rely on internal cascade state.
+
+- **[Trade-off] Helper count grows from 1 to 5.** → Acceptable: each helper has a single clear responsibility. Discoverability improves (named functions vs anonymous if-arm).
+
+- **[Trade-off] Boilerplate for table tests.** → One-time cost, paid back on first new cascade arm.
+
+## Migration Plan
+
+This is a pure refactor. No deployment migration needed.
+
+**Implementation sequence:**
+
+1. Branch: `refactor/decompose-fallback-analysis` from current develop.
+2. Commit 1: Add `.detect_signal_flags()` + table tests covering existing flag combinations. Replace inline detection in orchestrator with helper call.
+3. Commit 2: Add `.allocate_text_budget()` + tests. Replace inline budget computation.
+4. Commit 3: Add `.select_stability_key()` + table tests. Replace stability cascade in orchestrator.
+5. Commit 4: Add `.select_action_key()` + table tests. Replace action cascade. **Largest commit; bisect-friendly via per-arm tests.**
+6. Commit 5: Final orchestrator simplification (≤60 lines verification). Update NEWS.md.
+7. Open PR. CI must pass. Review.
+
+**Rollback strategy:** `git revert <merge-sha>`. No persistent state.
+
+## Open Questions
+
+- Should `.detect_signal_flags()` accept a `bfh_qic_result` directly or just `spc_stats`? Current code path receives both — propose `spc_stats` to keep the helper minimal and avoid coupling to the S3 class. Discuss at PR review if this becomes awkward.
+
+- Should the table-driven tests live in a new helper file (`tests/testthat/helper-fallback-tables.R`) so they're shareable with future cascade extensions? Defer to PR review.

--- a/openspec/changes/decompose-fallback-analysis/proposal.md
+++ b/openspec/changes/decompose-fallback-analysis/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+`build_fallback_analysis()` in `R/spc_analysis.R` is a 210-line function that mixes four abstraction levels (signal-flag detection, text-budget allocation, key dispatch, padding) inside three sequential boolean cascades that map signal tuples to template keys. Every time a new chart-type signal or stability state is added, the cascade must be edited in three coordinated places — exactly the kind of code that grows bugs.
+
+Decomposing the cascade into named helpers makes the dispatch table-test friendly: each helper accepts a typed flag struct and returns a string key. New signals become a single new test row, not a multi-place edit.
+
+## What Changes
+
+- Extract `.detect_signal_flags(spc_stats)` returning a named-logical struct: `(has_runs, has_crossings, has_outliers, is_stable, has_target, target_direction, goal_met, at_target)`.
+- Extract `.allocate_text_budget(max_chars, has_target)` returning numeric `(budget_stability, budget_action)`.
+- Extract `.select_stability_key(flags)` returning string key for the stability-narrative arm of the cascade.
+- Extract `.select_action_key(flags, has_target, target_direction, goal_met, at_target, is_stable)` returning string key for the action-narrative arm.
+- Reduce orchestrator `build_fallback_analysis()` to ≤60 lines: detect flags → allocate budgets → select keys → look up i18n strings → assemble markdown → pad.
+- Each helper is pure: same inputs always produce same key. Suitable for `expect_equal()` table tests.
+- Behavior unchanged: no observable change to fallback narrative output. Existing snapshot/integration tests must continue to pass.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `spc-analysis-api`: refines `bfh_generate_analysis()` fallback-pipeline organization. Current spec describes the user-visible behavior; this change adds an internal-structure requirement that the cascade dispatch lives in named pure helpers.
+
+## Impact
+
+- `R/spc_analysis.R`: file grows from 1 to 5 functions in the fallback-analysis section; LOC roughly unchanged.
+- `tests/testthat/test-spc_analysis.R` (extension): table-driven tests for `.detect_signal_flags()` and the two `.select_*_key()` helpers covering at least one row per current cascade arm.
+- biSPCharts: no public API change. `bfh_generate_analysis()` signature stable.
+- No statistical validation needed (no Anhøj-rule or control-limit logic touched).
+- No NEWS.md user-visible entry (internal refactor); add bullet under `## Internal changes` for next release.
+- Future extension benefit: when biSPCharts maintainer requests a new fallback-narrative arm (e.g. for a new chart type), edit becomes a single new key + one i18n string + one new test row — no multi-place cascade edit.

--- a/openspec/changes/decompose-fallback-analysis/specs/spc-analysis-api/spec.md
+++ b/openspec/changes/decompose-fallback-analysis/specs/spc-analysis-api/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Fallback-narrative dispatch SHALL use named pure helpers
+
+The dispatch logic that maps detected SPC signals to fallback-narrative i18n keys SHALL be expressed as named pure helpers, not as nested boolean cascades. The orchestrator `build_fallback_analysis()` SHALL be ≤60 lines and SHALL only invoke helpers in pipeline order: detect flags → allocate budget → select keys → look up i18n strings → assemble markdown → pad.
+
+The following private helpers SHALL exist in `R/spc_analysis.R`:
+
+- `.detect_signal_flags(spc_stats)` — pure function returning a named-logical struct with at minimum the fields `(has_runs, has_crossings, has_outliers, is_stable, has_target, target_direction, goal_met, at_target)`
+- `.allocate_text_budget(max_chars, has_target)` — pure function returning a named-integer struct `(budget_stability, budget_action)`
+- `.select_stability_key(flags)` — pure function returning a character scalar i18n key
+- `.select_action_key(flags)` — pure function returning a character scalar i18n key
+
+Helpers SHALL be `@keywords internal @noRd`. The dispatch SHALL emit i18n keys, not translated strings; translation happens at the orchestrator boundary via existing `i18n_lookup()`.
+
+#### Scenario: build_fallback_analysis is a thin orchestrator
+
+- **WHEN** the package source is inspected for `R/spc_analysis.R`
+- **THEN** `build_fallback_analysis()` SHALL be ≤60 lines and SHALL contain no nested `if/else if` chains for cascade dispatch (only top-level orchestration calls + i18n lookups + markdown assembly)
+- **AND** the four helpers `.detect_signal_flags()`, `.allocate_text_budget()`, `.select_stability_key()`, `.select_action_key()` SHALL exist in the same file
+
+#### Scenario: dispatch helpers are unit-testable as data tables
+
+- **WHEN** unit tests for `.select_stability_key()` and `.select_action_key()` are run
+- **THEN** the tests SHALL exercise each helper via a table of `(flag_combination, expected_key)` rows covering at minimum every key currently produced by the cascade
+- **AND** the tests SHALL pass without invoking `bfh_generate_analysis()` or any function above the dispatch layer
+
+#### Scenario: adding a new fallback-narrative arm is a single-file edit
+
+- **WHEN** a new cascade arm is added (e.g. for a new chart type or signal combination)
+- **THEN** the change SHALL consist of: one new key in the appropriate `.select_*_key()` helper, one new i18n string in `inst/i18n/`, and one new test row in the table-driven test
+- **AND** no edit to `build_fallback_analysis()` or to other dispatch helpers SHALL be required
+
+#### Scenario: existing fallback narrative output is unchanged
+
+- **WHEN** the existing fallback-analysis tests in `tests/testthat/test-spc_analysis.R` are run after refactor
+- **THEN** all tests SHALL pass without modification (zero behavioral change)
+- **AND** the integration tests covering `bfh_generate_analysis(use_ai = FALSE)` SHALL produce byte-identical narrative output for every existing input scenario

--- a/openspec/changes/decompose-fallback-analysis/tasks.md
+++ b/openspec/changes/decompose-fallback-analysis/tasks.md
@@ -1,0 +1,50 @@
+## 1. Branch + baseline verification
+
+- [ ] 1.1 Create branch `refactor/decompose-fallback-analysis` from current develop
+- [ ] 1.2 Verify pre-push hook passes on baseline (`PREPUSH_MODE=full git push --dry-run`)
+- [ ] 1.3 Capture baseline narrative output: run all existing `test-spc_analysis.R` scenarios via `Rscript -e 'devtools::test(filter = "spc_analysis")'` and save the test-output snapshot for comparison
+
+## 2. Extract `.detect_signal_flags()`
+
+- [ ] 2.1 Add private helper `.detect_signal_flags(spc_stats)` in `R/spc_analysis.R` returning the documented named-logical struct
+- [ ] 2.2 Replace inline flag-detection block in `build_fallback_analysis()` with call to helper; bind result to local `flags`
+- [ ] 2.3 Add table-driven unit tests in `tests/testthat/test-spc_analysis.R` (or new file `test-fallback-dispatch.R`) covering all 8 flag combinations currently produced by the cascade
+- [ ] 2.4 Run targeted tests: `Rscript -e 'devtools::test(filter = "spc_analysis")'`. Must pass.
+
+## 3. Extract `.allocate_text_budget()`
+
+- [ ] 3.1 Add private helper `.allocate_text_budget(max_chars, has_target)` returning named-integer struct
+- [ ] 3.2 Replace inline budget computation in orchestrator with call to helper
+- [ ] 3.3 Add unit tests covering: with-target budget split, without-target budget split, edge case max_chars=0
+- [ ] 3.4 Run targeted tests. Must pass.
+
+## 4. Extract `.select_stability_key()`
+
+- [ ] 4.1 Add private helper `.select_stability_key(flags)` returning character scalar
+- [ ] 4.2 Replace stability-cascade arm in orchestrator with call to helper
+- [ ] 4.3 Add table-driven unit tests with one row per existing stability key (every output the current cascade can produce). Use `tibble` + `purrr::pmap()` pattern.
+- [ ] 4.4 Run targeted tests. Must pass.
+
+## 5. Extract `.select_action_key()`
+
+- [ ] 5.1 Add private helper `.select_action_key(flags)` returning character scalar
+- [ ] 5.2 Replace action-cascade arm in orchestrator with call to helper
+- [ ] 5.3 Add table-driven unit tests with one row per existing action key (largest of the four cascades; expect ~10-15 rows)
+- [ ] 5.4 Run targeted tests. Must pass.
+- [ ] 5.5 Run integration test: `Rscript -e 'devtools::test(filter = "bfh_generate_analysis")'` — fallback-mode narrative must be byte-identical to baseline
+
+## 6. Final orchestrator simplification
+
+- [ ] 6.1 Verify `build_fallback_analysis()` is ≤60 lines (count via `awk` over the function body)
+- [ ] 6.2 Remove dead inline comments referring to extracted blocks
+- [ ] 6.3 Run `lintr::lint("R/spc_analysis.R")`. Zero new lint issues vs baseline.
+- [ ] 6.4 Run `styler::style_file("R/spc_analysis.R")` and inspect diff
+- [ ] 6.5 Update NEWS.md under next version's `## Internal changes`: "Decompose `build_fallback_analysis()` into orchestrator + 4 named pure helpers (`.detect_signal_flags()`, `.allocate_text_budget()`, `.select_stability_key()`, `.select_action_key()`). Adds table-driven dispatch tests. Pure refactor: fallback narrative output unchanged."
+
+## 7. Verification + PR
+
+- [ ] 7.1 Run full test suite with all gating env vars: `Rscript -e 'Sys.setenv(NOT_CRAN="true", BFHCHARTS_TEST_FULL="true"); devtools::test()'`. Zero failures.
+- [ ] 7.2 Run pre-push hook end-to-end via `git push -u origin refactor/decompose-fallback-analysis` (no `SKIP_PREPUSH` allowed)
+- [ ] 7.3 Open PR `refactor/decompose-fallback-analysis` → develop with link to OpenSpec change folder
+- [ ] 7.4 Verify CI green
+- [ ] 7.5 After merge, archive change: `/opsx:archive decompose-fallback-analysis`

--- a/openspec/changes/decompose-marquee-labels/.openspec.yaml
+++ b/openspec/changes/decompose-marquee-labels/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-03

--- a/openspec/changes/decompose-marquee-labels/design.md
+++ b/openspec/changes/decompose-marquee-labels/design.md
@@ -1,0 +1,113 @@
+## Context
+
+`add_right_labels_marquee()` (R/utils_add_right_labels_marquee.R, ~510 lines) is the largest single function in the package. It is the heart of the labeling pipeline that ships with every PDF/PNG export and every `bfh_qic()` invocation. The function is invoked from two places:
+
+1. `apply_spc_labels_to_export()` — render path (export pipeline)
+2. `add_spc_labels()` — interactive/preview path
+
+The function has accumulated 11 distinct responsibilities over time as the labeling system evolved through:
+
+- v0.10.x: initial marquee-based label rendering
+- v0.12.0: NIVEAU-cascade collision avoidance
+- v0.13.0: 3-layer split of `place_two_labels_npc()` (sister function)
+- v0.14.x: device-leak hardening + viewport-vs-fallback strategy
+
+The 3-layer split that succeeded for `place_two_labels_npc()` (validate -> resolve -> strategy) is the proven template. The existing inline comments in `add_right_labels_marquee()` already partition the function into the three layers we want; the comments document the seams. Verbose-logging blocks (9 `if (verbose) message(...)` calls) currently spread across the function will follow each helper into its new home.
+
+Constraints:
+
+- **Behavior must not change.** Visual regression baselines (PR #279, freshly refreshed in v0.14.2) are the authoritative correctness gate. Any pixel diff from refactor = regression.
+- **biSPCharts is a `:::` consumer** of `add_spc_labels()`, not of `add_right_labels_marquee()` directly. Internal helper signature changes are allowed; public-facing path through `add_spc_labels()` must remain stable.
+- **Pre-push hook (`PREPUSH_MODE=full`) runs visual regression** with `NOT_CRAN=true`. Refactor cannot be merged unless the hook passes without baseline updates.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Decompose `add_right_labels_marquee()` into orchestrator (≤120 lines) + 3 named helpers along existing comment-partition lines.
+- Each helper has a single responsibility: geometry resolution, device acquisition, label-height measurement.
+- Each helper accepts injected dependencies (config, device, style) for unit-testability without device side effects.
+- Verbose-logging messages remain (gated by `verbose = FALSE` default per Fase 1B work) and travel with their helper.
+- Zero behavioral change. Same output bytes for every test scenario. Visual regression: zero diff.
+
+**Non-Goals:**
+
+- Restructuring the NIVEAU-cascade in `place_two_labels_npc()` (already done in v0.13.0).
+- Replacing the marquee rendering library (out of scope; would be a separate proposal).
+- Performance optimization (M10/M11 from review remain in Fase 5 backlog).
+- Public API changes. `add_spc_labels()` signature stays.
+- Adding new features (target arrows, multi-line labels, etc).
+- Splitting `add_right_labels_marquee()` into a separate file. Helpers live in the same file under shared header comment.
+
+## Decisions
+
+### Decision 1: 3-layer split mirroring `place_two_labels_npc()`
+
+**Choice:** Three private helpers prefixed `.`:
+
+1. `.resolve_label_geometry(label_size, lineheight_factor, marquee_size_factor, header_pt, value_pt, gap_line, gap_labels, pad_top, pad_bot)` → returns named list `(scale_factor, header_size, value_size, lineheight, gap_line, gap_labels, pad_top, pad_bot, cfg)`. Pure function. Replaces lines ~137-170. Reuses the `resolve_label_size()` helper extracted in v0.14.3.
+
+2. `.acquire_device_for_measurement(viewport_width, viewport_height, panel_width_inches, fallback_width = 10, fallback_height = 7.5, verbose = FALSE)` → returns list `(device_size, panel_height_inches, temp_device_opened, cleanup_fn)`. Side-effect at this layer: opens fallback device when viewport unavailable. Returns `cleanup_fn` so orchestrator can `withr::defer(cleanup_fn())`. Replaces lines ~200-315.
+
+3. `.measure_label_heights(textA, textB, style, panel_height_inches, device_size, marquee_height_estimator = estimate_label_heights_npc)` → returns named list `(height_A, height_B, label_height_npc)`. Pure given inputs (estimator is injected for tests). Handles empty-label fallback selection. Replaces lines ~320-410.
+
+**Rationale:** Mirrors the proven `place_two_labels_npc()` decomposition. Each helper's name reads as a complete sentence. Each is testable without a real graphics device thanks to injectable seams (`cleanup_fn`, `marquee_height_estimator`). Returning a single `list` per layer matches existing style elsewhere in the file (`device_info`, `placement` results).
+
+**Alternative considered:** S3 class for "label geometry" + methods. Rejected: too heavy for an internal pipeline. The codebase has only one S3 class (`bfh_qic_result`) and that is for public API data. Internal pipelines use plain lists.
+
+### Decision 2: Device-leak cleanup uses `withr::defer()` at orchestrator boundary
+
+**Choice:** `.acquire_device_for_measurement()` returns a `cleanup_fn` closure that the orchestrator binds via `withr::defer(cleanup_fn(), envir = parent.frame())`. The closure encapsulates the `dev.off()` call(s) needed to balance any device opened during measurement.
+
+**Rationale:** `withr::defer()` is testthat-aware and unwinds correctly on early return or error. Existing `tryCatch` + manual `dev.off()` patterns in the function are race-prone. The package already uses `withr::defer()` extensively in test files (PR #284 standardized this in test-export-session.R).
+
+**Alternative considered:** R6 RAII-style "Device" class. Rejected: same heaviness argument as Decision 1; closures are idiomatic R for this.
+
+### Decision 3: Verbose-message blocks stay with their helper
+
+**Choice:** Each helper gets its own `verbose` parameter (defaults to `FALSE`). The `if (verbose) message(sprintf(...))` blocks travel with the code that produces the value being logged. Component-tag prefixes preserved verbatim (`[VIEWPORT_STRATEGY]`, `[DEVICE_FALLBACK]`, `[DEVICE_SIZE]`, `[PANEL_HEIGHT]`, `[LABEL_HEIGHT]`).
+
+**Rationale:** Logging colocated with the logic it diagnoses. Defaults stay quiet (consistent with PR #281's i18n cleanup). No behavioral change in default code path.
+
+**Alternative considered:** Centralized logging facade. Rejected: opens a separate refactor scope (would require touching many other files); not aligned with this proposal's "pure decomposition" goal.
+
+### Decision 4: Helpers stay in the same file
+
+**Choice:** All four functions (orchestrator + 3 helpers) live in `R/utils_add_right_labels_marquee.R`. Helpers are `@keywords internal @noRd` private, prefixed `.`.
+
+**Rationale:** Co-location matches the existing pattern in `R/utils_label_placement.R` (orchestrator `place_two_labels_npc()` + helpers `.try_niveau_1_gap_reduction()`, `.try_niveau_2_flip()`, `.apply_niveau_3_shelf()`). Splitting into 4 files would fragment the labeling pipeline without grep-friendly benefit.
+
+**Alternative considered:** Move to new files (`R/label_geometry.R`, `R/label_device.R`, etc.). Rejected: makes navigation worse for the same logical unit.
+
+## Risks / Trade-offs
+
+- **[Risk] Visual regression diff after refactor.** → Mitigation: run pre-push hook (`PREPUSH_MODE=full`) before opening PR; require zero `.new.svg` files in `tests/testthat/_snaps/visual-regression/`. Decompose in small commits per helper so a regression bisects to a single helper.
+
+- **[Risk] Device-leak regression on test-runner with parallel workers.** → Mitigation: `withr::defer()` is parallel-safe per testthat 3.x docs. Each test process opens/closes its own device. Verify with `Rscript -e 'devtools::test()'` in fresh R session.
+
+- **[Risk] Verbose-output diff in tests grepping log lines.** → Mitigation: pre-flight grep `tests/testthat/` for the 5 verbose-tag prefixes; if any test asserts log content, update them in the same commit that moves the message.
+
+- **[Trade-off] Helper count grows from 1 to 4.** → Acceptable: each helper has a clear single responsibility and earns its name. Discoverability via grep is better, not worse.
+
+- **[Trade-off] Some duplication in helper signatures (passing `verbose` through 3 layers).** → Acceptable: explicit > implicit. Alternative would be a thread-local logger which adds infrastructure for marginal benefit.
+
+## Migration Plan
+
+This is a pure refactor. No deployment migration needed.
+
+**Implementation sequence:**
+
+1. Branch: `refactor/decompose-marquee-labels` from current develop (post-v0.14.3).
+2. Commit 1: Extract `.resolve_label_geometry()`. Keep call site in orchestrator. Run targeted unit tests.
+3. Commit 2: Extract `.measure_label_heights()` (independent of device acquisition order; pure given inputs). Run unit tests.
+4. Commit 3: Extract `.acquire_device_for_measurement()` with `cleanup_fn` closure. Run device-isolation tests + visual regression. **Critical commit** — device-leak risk concentrates here.
+5. Commit 4: Final orchestrator simplification (remove dead inline comments; verify ≤120 lines). Run full pre-push.
+6. Open PR. CI runs vdiffr in `NOT_CRAN=true` mode. Review.
+
+**Rollback strategy:** `git revert <merge-sha>`. No persistent state, no migration. Safe to revert at any time.
+
+## Open Questions
+
+- Should the `verbose` parameter on the orchestrator default from `FALSE` (current) or be derived from `getOption("BFHcharts.debug.label_placement")`? Current proposal preserves `verbose = FALSE` default. Discussion can happen at PR review.
+
+- Should the 3-layer split also be applied to `add_spc_labels()` (the caller) in a follow-up? `add_spc_labels()` is shorter (~250 lines) and less critical, but has similar structure. Out of scope for this proposal; flagged for review.

--- a/openspec/changes/decompose-marquee-labels/proposal.md
+++ b/openspec/changes/decompose-marquee-labels/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+`add_right_labels_marquee()` in `R/utils_add_right_labels_marquee.R` is a 510-line single function that violates SRP across 11 distinct responsibilities (gpar resolution, scale factor, config lookup, ggplot_build, gtable construction, device-leak cleanup, viewport-vs-fallback device strategy, panel-height measurement, label-height estimation, empty-label handling, NPC placement orchestration, grob construction).
+
+This is the largest single readability/testability barrier in the package. The same 3-layer split pattern that succeeded for `place_two_labels_npc()` (NIVEAU 1/2/3 cascade in v0.13.0) is the obvious template — the existing inline comments in `add_right_labels_marquee()` already partition the function along these lines.
+
+## What Changes
+
+- Extract `.resolve_label_geometry(label_size, ...)` from the current label_size + scale_factor + config + sizes block (lines 137-170).
+- Extract `.acquire_device_for_measurement(viewport_dims, ...)` from the viewport-vs-fallback device strategy (lines 200-315), with named sub-strategies replacing the inline if/else.
+- Extract `.measure_label_heights(textA, textB, style, device)` from the panel-height + label-height-estimation block (lines 320-410).
+- Reduce orchestrator `add_right_labels_marquee()` to under 120 lines: parameter-binding -> geometry -> device acquisition -> measurement -> placement -> grob construction.
+- Each extracted helper becomes unit-testable in isolation; current device-leak handling preserved via `withr::defer()` at the orchestrator boundary.
+- Behavior unchanged: this is pure refactor. Visual regression baselines (PR #279) must continue to pass without snapshot updates.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `code-organization`: refines the labeling-pipeline organization boundary. Current spec section "Function Naming Conventions" + "File Organization" implicitly accepts a single 510-line function; adds a requirement that label-pipeline functions follow the same 3-layer split as `place_two_labels_npc()`.
+
+## Impact
+
+- `R/utils_add_right_labels_marquee.R`: file grows from 1 to 4 functions (orchestrator + 3 helpers); LOC roughly unchanged but distributed.
+- `tests/testthat/test-utils_add_right_labels_marquee.R` (new or extension of existing): unit tests for each of the 3 extracted helpers with injected device + config seams.
+- `tests/testthat/_snaps/visual-regression/`: must show **zero diff** post-refactor. Pre-push hook `PREPUSH_MODE=full` (which runs vdiffr with `NOT_CRAN=true`) is the authoritative verification gate.
+- biSPCharts: no public API change. Internal `:::add_right_labels_marquee()` signature unchanged; only its body decomposes. No migration needed.
+- No statistical validation required (no Anhøj-rule or control-limit logic touched).
+- No NEWS.md user-visible entry needed (internal refactor); add bullet under `## Internal changes` for next release.

--- a/openspec/changes/decompose-marquee-labels/specs/code-organization/spec.md
+++ b/openspec/changes/decompose-marquee-labels/specs/code-organization/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Label-pipeline orchestrators SHALL follow 3-layer decomposition
+
+Internal label-pipeline functions that exceed 200 lines SHALL be decomposed into a thin orchestrator (≤120 lines) plus named private helpers, mirroring the 3-layer split pattern established in v0.13.0 for `place_two_labels_npc()` (NIVEAU 1/2/3 cascade).
+
+The orchestrator's responsibilities are limited to: parameter binding, helper invocation in pipeline order, and result aggregation. All substantive work — geometry resolution, device acquisition, measurement, placement, grob construction — SHALL live in named helpers prefixed with `.` and marked `@keywords internal @noRd`.
+
+Helpers SHALL accept injected dependencies (config providers, device handles, measurement estimators, logging flags) so each can be unit-tested in isolation without real graphics-device side effects. Side-effecting helpers (e.g. those that open a graphics device) SHALL return a cleanup closure that the orchestrator binds via `withr::defer()`; manual `dev.off()` patterns SHALL be removed in favor of `withr::defer()` to ensure unwind on early return or error.
+
+#### Scenario: add_right_labels_marquee respects the orchestrator-helper boundary
+
+- **WHEN** the package source is inspected for `R/utils_add_right_labels_marquee.R`
+- **THEN** `add_right_labels_marquee()` SHALL be ≤120 lines and SHALL only invoke named helpers (no inline gpar resolution, device acquisition, panel-height measurement, label-height estimation, or grob construction logic)
+- **AND** at minimum these private helpers SHALL exist in the same file: `.resolve_label_geometry()`, `.acquire_device_for_measurement()`, `.measure_label_heights()`
+
+#### Scenario: helpers are unit-testable without a real graphics device
+
+- **WHEN** unit tests for `.resolve_label_geometry()` and `.measure_label_heights()` are run
+- **THEN** the tests SHALL pass without opening any graphics device (no `Rplots.pdf` produced, no `dev.cur()` change observable from outside the test)
+
+#### Scenario: device-acquiring helpers return a cleanup closure
+
+- **WHEN** `.acquire_device_for_measurement()` opens a fallback graphics device
+- **THEN** it SHALL return a list containing a `cleanup_fn` closure that closes the device when invoked
+- **AND** the orchestrator SHALL register the closure via `withr::defer()` so it fires on both normal exit and error exit
+
+#### Scenario: visual regression baselines remain unchanged after decomposition
+
+- **WHEN** the pre-push hook runs `PREPUSH_MODE=full` (vdiffr with `NOT_CRAN=true`) on a refactor commit
+- **THEN** zero `.new.svg` files SHALL be produced under `tests/testthat/_snaps/visual-regression/`
+- **AND** all 9 canonical chart-scenario snapshots SHALL match byte-for-byte against the baselines refreshed in v0.14.2 (PR #279)

--- a/openspec/changes/decompose-marquee-labels/tasks.md
+++ b/openspec/changes/decompose-marquee-labels/tasks.md
@@ -1,0 +1,47 @@
+## 1. Branch + baseline verification
+
+- [ ] 1.1 Create branch `refactor/decompose-marquee-labels` from current develop (post-v0.14.3)
+- [ ] 1.2 Verify pre-push hook passes on develop baseline (`PREPUSH_MODE=full git push --dry-run`) so any later failure is attributable to refactor
+- [ ] 1.3 Capture baseline output: run `Rscript dev/preview_labels.R` and snapshot resulting PNGs to compare visually after refactor
+
+## 2. Extract `.resolve_label_geometry()`
+
+- [ ] 2.1 Add private helper `.resolve_label_geometry()` in `R/utils_add_right_labels_marquee.R` containing scale_factor + config lookup + header_size + value_size + lineheight + gap_line + gap_labels + pad_top + pad_bot computation (current lines ~137-170)
+- [ ] 2.2 Replace inline block in `add_right_labels_marquee()` with call to `.resolve_label_geometry()`; bind returned list to local `geom`
+- [ ] 2.3 Update orchestrator to reference `geom$header_size`, `geom$value_size`, etc. instead of locally-bound names
+- [ ] 2.4 Add unit tests in `tests/testthat/test-utils_add_right_labels_marquee.R` (or extend existing test file) covering: pure-input → pure-output, no graphics-device side effect, config-injection seam works
+- [ ] 2.5 Run targeted tests: `Rscript -e 'devtools::test(filter = "utils_add_right_labels_marquee")'`. Must pass.
+
+## 3. Extract `.measure_label_heights()`
+
+- [ ] 3.1 Add private helper `.measure_label_heights(textA, textB, style, panel_height_inches, device_size, marquee_height_estimator = estimate_label_heights_npc)` covering height_A + height_B + label_height_npc selection + empty-label fallback (current lines ~320-410)
+- [ ] 3.2 Replace inline block in `add_right_labels_marquee()` with call to `.measure_label_heights()`
+- [ ] 3.3 Verify the orchestrator threads `device_size` and `panel_height_inches` from the device-acquisition layer (still inline at this commit) into the new helper
+- [ ] 3.4 Add unit tests covering: empty textA, empty textB, both empty, both non-empty (max-selected), injected estimator returns mock heights
+- [ ] 3.5 Run targeted tests + visual regression: `Rscript -e 'Sys.setenv(NOT_CRAN="true"); devtools::test(filter = "(utils_add_right_labels_marquee|visual-regression)")'`. Zero `.new.svg` files allowed.
+
+## 4. Extract `.acquire_device_for_measurement()` (critical commit)
+
+- [ ] 4.1 Add private helper `.acquire_device_for_measurement(viewport_width, viewport_height, panel_width_inches, fallback_width = 10, fallback_height = 7.5, verbose = FALSE)` covering viewport-vs-fallback strategy + device opening + panel-height measurement (current lines ~200-315)
+- [ ] 4.2 Helper returns named list `(device_size, panel_height_inches, temp_device_opened, cleanup_fn)` where `cleanup_fn` is a closure that closes any device opened by this call
+- [ ] 4.3 In orchestrator, replace inline block with: `dev_ctx <- .acquire_device_for_measurement(...); withr::defer(dev_ctx$cleanup_fn())`. Remove existing manual `dev.off()` patterns from the orchestrator.
+- [ ] 4.4 Add unit tests with mocked `grDevices::dev.cur()` / `grDevices::dev.size()` covering: viewport-available path (no device opened), viewport-unavailable path (fallback device opened + closed by cleanup_fn)
+- [ ] 4.5 Run **full** pre-push hook: `git push --dry-run` (or push to scratch branch). Visual regression must be byte-clean.
+- [ ] 4.6 Run device-leak smoke test: `Rscript -e 'devtools::test(); ls(tempdir())'`. No `Rplots.pdf` written by package code.
+
+## 5. Final orchestrator simplification
+
+- [ ] 5.1 Remove dead inline comments in `add_right_labels_marquee()` that referred to extracted blocks
+- [ ] 5.2 Verify orchestrator is ≤120 lines (count via `awk 'NR==FNR{} END{print NR}' < <(sed -n '/^add_right_labels_marquee <- function/,/^}/p' R/utils_add_right_labels_marquee.R)`)
+- [ ] 5.3 Run `devtools::document()` if any roxygen changes were made to the helpers (each helper gets `@keywords internal @noRd`)
+- [ ] 5.4 Run `lintr::lint("R/utils_add_right_labels_marquee.R")`. Zero new lint issues vs baseline.
+- [ ] 5.5 Run `styler::style_file("R/utils_add_right_labels_marquee.R")` and inspect diff
+- [ ] 5.6 Update NEWS.md under next version's `## Internal changes` section: "Decompose `add_right_labels_marquee()` into orchestrator + 3 named helpers (`.resolve_label_geometry()`, `.acquire_device_for_measurement()`, `.measure_label_heights()`) following the 3-layer pattern from v0.13.0's `place_two_labels_npc()` refactor. Pure refactor: visual regression baselines unchanged."
+
+## 6. Verification + PR
+
+- [ ] 6.1 Run full test suite with all gating env vars: `Rscript -e 'Sys.setenv(NOT_CRAN="true", BFHCHARTS_TEST_FULL="true"); devtools::test()'`. Zero failures.
+- [ ] 6.2 Run pre-push hook end-to-end via `git push -u origin refactor/decompose-marquee-labels` (no `SKIP_PREPUSH` allowed)
+- [ ] 6.3 Open PR `refactor/decompose-marquee-labels` → develop with link to OpenSpec change folder; reference proposal.md and design.md in PR body
+- [ ] 6.4 Verify CI green (R-CMD-check ubuntu/windows/oldrel, lint, pdf-smoke, git-archive-render)
+- [ ] 6.5 After merge, archive change: `/opsx:archive decompose-marquee-labels`

--- a/openspec/changes/extract-utils-text-da/.openspec.yaml
+++ b/openspec/changes/extract-utils-text-da/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-03

--- a/openspec/changes/extract-utils-text-da/design.md
+++ b/openspec/changes/extract-utils-text-da/design.md
@@ -1,0 +1,94 @@
+## Context
+
+`R/spc_analysis.R` (~929 lines) is the package's largest single file. It hosts four concerns that grew there organically:
+
+1. Target resolution (`resolve_target()` and friends)
+2. **Danish text-formatting utilities** ← target of this proposal
+3. Analysis-context construction
+4. Fallback-narrative generation (target of sibling proposal `decompose-fallback-analysis`)
+
+The Danish text helpers are pure string-manipulation functions with no dependency on SPC concepts. They were placed in `spc_analysis.R` because that's where the first caller appeared during early development. Today they're called from multiple sites in the file and could potentially be reused from other label-formatting sites — but their current location buries them under the SPC pipeline filename.
+
+Constraints:
+
+- **Behavior must not change.** Existing tests covering `pluralize_da()`, `pick_text()`, etc. (in `tests/testthat/test-spc_analysis.R`) must continue to pass without modification.
+- **All five helpers are `@keywords internal @noRd`** — no public-API impact.
+- **R loads files alphabetically from `R/`**. New file `utils_text_da.R` sorts before `spc_analysis.R`, which is fine since helpers are referenced after package load is complete.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Move five Danish text-formatting helpers from `R/spc_analysis.R` to new file `R/utils_text_da.R`.
+- Preserve all signatures, internals, roxygen, and `@noRd` annotations exactly.
+- Pair-aware with `decompose-fallback-analysis`: if both land, `spc_analysis.R` shrinks by ~250+ lines.
+- Zero behavioral change. Existing tests pass without modification.
+
+**Non-Goals:**
+
+- Refactoring the helpers themselves.
+- Changing helper signatures or making any of them public.
+- Moving the test file (`tests/testthat/test-spc_analysis.R` continues to host tests for the relocated helpers).
+- Restructuring i18n infrastructure (`inst/i18n/`).
+- Creating a new English-text counterpart (`utils_text_en.R`) — premature; revisit only when actual reuse from English-only paths appears.
+
+## Decisions
+
+### Decision 1: New file is `R/utils_text_da.R`, not `R/text_utils.R`
+
+**Choice:** File name is `R/utils_text_da.R` per package naming convention (`utils_*.R` prefix; `_da` suffix denotes Danish-specific scope).
+
+**Rationale:** Existing files use the `utils_*` prefix consistently (`utils_audit.R`, `utils_helpers.R`, `utils_label_helpers.R`, etc.). The `_da` suffix telegraphs that the helpers are language-specific (vs `utils_path_policy.R` which is language-agnostic). Future English-specific text helpers (if ever needed) would land in `utils_text_en.R` symmetrically.
+
+**Alternative considered:** `R/text_utils.R` (no prefix). Rejected: breaks the existing convention; reduces grep-friendliness.
+
+### Decision 2: Helpers move as a single unit
+
+**Choice:** All five helpers move in one commit. Tests stay where they are.
+
+**Rationale:** Five small helpers with no inter-helper dependency or external dependency. Splitting into multiple commits adds review friction for no benefit.
+
+**Alternative considered:** Per-helper commits. Rejected: serial commits would each touch the same two files; review noise outweighs bisect benefit.
+
+### Decision 3: Tests stay in `test-spc_analysis.R`
+
+**Choice:** Tests for the relocated helpers continue to live in `tests/testthat/test-spc_analysis.R`.
+
+**Rationale:** The helpers are still called from `spc_analysis.R` and the tests exercise that integration path. Splitting tests across files would lose the integration coverage. If the helpers grow new callers in other files, those callers' tests would naturally exercise them; no need to pre-emptively split.
+
+**Alternative considered:** Move tests to new `test-utils_text_da.R`. Deferred: revisit after first non-spc-analysis caller appears.
+
+### Decision 4: roxygen annotations preserved verbatim
+
+**Choice:** Each helper's `#'` block, `@param`, `@return`, `@keywords internal`, and `@noRd` lines move verbatim. No reformatting.
+
+**Rationale:** Pure relocation. Diff hygiene matters for review. Any roxygen polish is a separate concern.
+
+## Risks / Trade-offs
+
+- **[Risk] Helper invoked from a place we missed.** → Mitigation: pre-flight `grep -rn "pluralize_da\|pick_text\|substitute_placeholders\|pad_to_minimum\|ensure_within_max" R/ tests/` to enumerate all call sites before extraction; verify all callers continue to resolve correctly via `BFHcharts:::` namespace lookup after relocation.
+
+- **[Risk] R-CMD-check warning about file-load ordering.** → Negligible: helpers are not referenced at package-load time (no `.onLoad()` use), only at runtime. R's lazy-load handles this transparently.
+
+- **[Trade-off] Adding a new file vs growing an existing utility file.** → Acceptable: `R/utils_helpers.R` is already a catch-all (audit-flagged in original review); creating a focused `utils_text_da.R` avoids worsening the catch-all.
+
+## Migration Plan
+
+This is a pure relocation. No deployment migration needed.
+
+**Implementation sequence:**
+
+1. Branch: `refactor/extract-utils-text-da` from current develop.
+2. Single commit:
+   - Create `R/utils_text_da.R` with all five helpers + their roxygen blocks
+   - Delete the helpers from `R/spc_analysis.R`
+   - Verify `grep -rn "pluralize_da\|pick_text\|substitute_placeholders\|pad_to_minimum\|ensure_within_max" R/ tests/` shows callers unchanged
+   - Run `Rscript -e 'devtools::load_all(); devtools::test()'`
+3. Update NEWS.md under next version's `## Internal changes`.
+4. Open PR. CI must pass.
+
+**Rollback strategy:** `git revert <merge-sha>`.
+
+## Open Questions
+
+- Should this proposal be merged before, after, or simultaneously with `decompose-fallback-analysis`? Both touch `R/spc_analysis.R` but in non-overlapping regions; either order is fine. Recommend landing this one first since it is smaller and lower-risk.

--- a/openspec/changes/extract-utils-text-da/proposal.md
+++ b/openspec/changes/extract-utils-text-da/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+`R/spc_analysis.R` is the package's largest single file (929 lines) and mixes four logically distinct concerns: target resolution, Danish text-formatting utilities, analysis-context construction, and fallback-narrative generation. The Danish text-formatting block (`pluralize_da()`, `pick_text()`, `substitute_placeholders()`, `pad_to_minimum()`, `ensure_within_max()`) has no dependency on the SPC analysis pipeline — these are reusable string helpers that happened to be born inside `spc_analysis.R` because that's where they were first needed.
+
+Extracting them into `R/utils_text_da.R` lets `spc_analysis.R` shrink toward its core responsibility, makes the helpers grep-friendly under their own filename, and surfaces them as candidates for reuse from other call sites (e.g. label formatting, summary text) without introducing a circular dependency on the SPC analysis layer.
+
+## What Changes
+
+- Create new file `R/utils_text_da.R` containing the five string helpers extracted from `R/spc_analysis.R`:
+  - `pluralize_da(n, singular, plural)` — Danish noun pluralization based on count
+  - `pick_text(condition_or_index, ...)` — branched text selection
+  - `substitute_placeholders(template, values)` — i18n-template variable substitution
+  - `pad_to_minimum(text, min_chars, padding_char = " ")` — string-length padding
+  - `ensure_within_max(text, max_chars)` — string-length truncation
+- Each helper retains its current `@keywords internal @noRd` annotation (no public-API change).
+- Preserve all existing call sites in `spc_analysis.R`; no signature changes.
+- `spc_analysis.R` shrinks by approximately 100-150 lines.
+- Pure relocation: zero behavioral change.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `code-organization`: refines file-organization boundary. Current spec contains "Single Responsibility per file" guidance; this change demonstrates the principle by extracting the cohesive text-utility group out of the analysis file.
+
+## Impact
+
+- `R/spc_analysis.R`: shrinks ~100-150 lines.
+- `R/utils_text_da.R`: new file, ~100-150 lines.
+- All existing call sites of the five helpers continue to work unchanged (R sources files alphabetically in `R/`; the new file ordering does not affect resolution since helpers are private and called only from `spc_analysis.R`).
+- biSPCharts: no public API change. None of the five helpers are exported.
+- No statistical validation needed.
+- No tests need to move — existing tests of `pluralize_da`, `pick_text`, etc. continue to invoke the same `BFHcharts:::` paths.
+- No NEWS.md user-visible entry; add bullet under `## Internal changes` for next release: "Extract Danish text-formatting helpers (`pluralize_da`, `pick_text`, `substitute_placeholders`, `pad_to_minimum`, `ensure_within_max`) from `R/spc_analysis.R` into a dedicated `R/utils_text_da.R`. Pure relocation."
+- This proposal pairs naturally with `decompose-fallback-analysis` (sibling change). They can land in either order; combined effect is a ~250-line reduction in `spc_analysis.R` without behavior change.

--- a/openspec/changes/extract-utils-text-da/specs/code-organization/spec.md
+++ b/openspec/changes/extract-utils-text-da/specs/code-organization/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Language-specific text utilities SHALL live in dedicated files
+
+Internal helpers for language-specific text formatting (pluralization, branched text selection, placeholder substitution, length padding, length truncation) SHALL live in dedicated files named `R/utils_text_<lang>.R` rather than embedded inside larger pipeline files.
+
+The current Danish text-formatting helpers — `pluralize_da()`, `pick_text()`, `substitute_placeholders()`, `pad_to_minimum()`, `ensure_within_max()` — SHALL be located in `R/utils_text_da.R` (not in `R/spc_analysis.R` or any other pipeline file).
+
+Helpers SHALL retain `@keywords internal @noRd` annotations and SHALL NOT be exported. Tests for these helpers MAY remain in their existing location (typically `tests/testthat/test-spc_analysis.R`) if the helpers are exercised primarily through their original integration path.
+
+#### Scenario: Danish text helpers live in dedicated file
+
+- **WHEN** the package source is inspected
+- **THEN** `R/utils_text_da.R` SHALL exist and SHALL contain at minimum: `pluralize_da()`, `pick_text()`, `substitute_placeholders()`, `pad_to_minimum()`, `ensure_within_max()`
+- **AND** `R/spc_analysis.R` SHALL NOT contain any of these five function definitions
+
+#### Scenario: existing call sites resolve correctly after relocation
+
+- **WHEN** `devtools::load_all()` runs after the relocation
+- **THEN** all internal call sites of the five helpers SHALL resolve correctly via R's namespace lookup
+- **AND** all existing tests covering these helpers SHALL pass without modification
+
+#### Scenario: future English-specific text utilities follow the same pattern
+
+- **WHEN** new language-specific text-formatting helpers are introduced for English (e.g. `pluralize_en()`)
+- **THEN** they SHALL be placed in `R/utils_text_en.R`, not embedded in pipeline files

--- a/openspec/changes/extract-utils-text-da/tasks.md
+++ b/openspec/changes/extract-utils-text-da/tasks.md
@@ -1,0 +1,37 @@
+## 1. Branch + audit call sites
+
+- [ ] 1.1 Create branch `refactor/extract-utils-text-da` from current develop
+- [ ] 1.2 Enumerate all call sites: `grep -rn "pluralize_da\|pick_text\|substitute_placeholders\|pad_to_minimum\|ensure_within_max" R/ tests/`. Record all hits.
+- [ ] 1.3 Identify line ranges in `R/spc_analysis.R` for each helper to relocate (function definitions only, not callers)
+
+## 2. Create `R/utils_text_da.R`
+
+- [ ] 2.1 Create new file `R/utils_text_da.R` with a brief file-header comment explaining purpose
+- [ ] 2.2 Copy all five helper definitions verbatim from `R/spc_analysis.R` into the new file, preserving roxygen blocks (`@param`, `@return`, `@keywords internal`, `@noRd`)
+- [ ] 2.3 Verify the new file passes `Rscript -e 'devtools::load_all()'` (no syntax errors, no missing dependencies)
+
+## 3. Remove helpers from `R/spc_analysis.R`
+
+- [ ] 3.1 Delete the five helper definitions from `R/spc_analysis.R` (definitions only; callers remain)
+- [ ] 3.2 Verify file still parses: `Rscript -e 'parse("R/spc_analysis.R")'`
+- [ ] 3.3 Re-run `devtools::load_all()` and verify all callers resolve
+
+## 4. Test verification
+
+- [ ] 4.1 Run targeted tests: `Rscript -e 'devtools::test(filter = "spc_analysis")'`. All existing tests covering the five helpers must pass without modification.
+- [ ] 4.2 Run full test suite: `Rscript -e 'Sys.setenv(NOT_CRAN="true"); devtools::test()'`. Zero failures.
+- [ ] 4.3 Run ASCII compliance: `Rscript -e 'devtools::test(filter = "source-ascii")'`. Pass required.
+
+## 5. Polish + release prep
+
+- [ ] 5.1 Run `lintr::lint("R/utils_text_da.R")`. Zero new lint issues.
+- [ ] 5.2 Run `styler::style_file("R/utils_text_da.R")` and inspect diff
+- [ ] 5.3 Verify `R/spc_analysis.R` has shrunk by approximately 100-150 lines: `wc -l R/spc_analysis.R`
+- [ ] 5.4 Update NEWS.md under next version's `## Internal changes`: "Extract Danish text-formatting helpers (`pluralize_da`, `pick_text`, `substitute_placeholders`, `pad_to_minimum`, `ensure_within_max`) from `R/spc_analysis.R` into a dedicated `R/utils_text_da.R`. Pure relocation; no behavioral change."
+
+## 6. Verification + PR
+
+- [ ] 6.1 Run pre-push hook end-to-end: `git push -u origin refactor/extract-utils-text-da` (no `SKIP_PREPUSH` allowed)
+- [ ] 6.2 Open PR `refactor/extract-utils-text-da` → develop with link to OpenSpec change folder
+- [ ] 6.3 Verify CI green
+- [ ] 6.4 After merge, archive change: `/opsx:archive extract-utils-text-da`


### PR DESCRIPTION
## Summary

Three OpenSpec change proposals from the multi-agent code review (Fase 4 of the review-plan). All are documentation-only at this point; each implementation lands in its own follow-up PR via `/opsx:apply`.

## Proposals

### 1. `decompose-marquee-labels` (M4)

Split `add_right_labels_marquee()` (R/utils_add_right_labels_marquee.R, ~510 lines, 11 responsibilities) into orchestrator (≤120 lines) + 3 named private helpers:

- `.resolve_label_geometry()` — scale_factor + config + sizes (lines ~137-170)
- `.acquire_device_for_measurement()` — viewport-vs-fallback strategy (lines ~200-315)
- `.measure_label_heights()` — panel-height + label-height estimation (lines ~320-410)

Mirrors the 3-layer split that succeeded for `place_two_labels_npc()` in v0.13.0. Pure refactor; visual regression baselines must remain unchanged. Modifies `code-organization` spec.

### 2. `decompose-fallback-analysis` (M9)

Decompose `build_fallback_analysis()` (R/spc_analysis.R, ~210-line boolean cascade) into orchestrator (≤60 lines) + 4 named pure helpers:

- `.detect_signal_flags(spc_stats)` — typed flag struct
- `.allocate_text_budget(max_chars, has_target)` — budget split
- `.select_stability_key(flags)` — i18n key
- `.select_action_key(flags)` — i18n key

Adds table-driven dispatch tests so adding a new cascade arm becomes a single new test row + one new key + one new i18n string. Pure refactor; fallback narrative output unchanged. Modifies `spc-analysis-api` spec.

### 3. `extract-utils-text-da` (L10)

Move 5 Danish text-formatting helpers (`pluralize_da`, `pick_text`, `substitute_placeholders`, `pad_to_minimum`, `ensure_within_max`) from R/spc_analysis.R (929 lines) into dedicated `R/utils_text_da.R`. Pure relocation; no behavioral change. Pairs with proposal #2 — together they shrink spc_analysis.R by ~250+ lines. Modifies `code-organization` spec.

## Why bundle the proposals?

Single PR keeps the review surface focused on the docs themselves. Each proposal can still be applied independently via `/opsx:apply <change-name>` in any order. Suggested implementation order:

1. **`extract-utils-text-da`** (smallest, lowest risk — pure file move)
2. **`decompose-fallback-analysis`** (medium; pure logic, no graphics)
3. **`decompose-marquee-labels`** (largest; visual regression risk concentrates here)

## Skipped from original review

- M4 marquee god-function split now handled here as proposal #1
- M9 fallback-analysis decomposition now handled here as proposal #2
- L10 utils_text_da extraction now handled here as proposal #3
- M7 long-param helper signature consolidation: deferred. Audit-finding suggested introducing internal `bfh_qic_inputs` S3 struct, but adding a new struct only pays off if/when new params are added. No active driver. Out of scope for Fase 4.

## Test plan

- [x] `openspec status` reports all 3 changes have 4/4 artifacts complete
- [x] Pre-push hook `PREPUSH_MODE=full` green (155s, full test suite)
- [x] Documentation only; no source-code changes

## Coordination

- biSPCharts: no impact. All proposals are internal refactors. Public API (`bfh_qic()`, `bfh_export_pdf()`, etc.) unchanged.
- No release needed for this PR. Each implementation PR will bump version per VERSIONING_POLICY.