### PR TITLE
refactor(spc-analysis): decompose build_fallback_analysis() into 5 named helpers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# BFHcharts (development)
+
+## Internal changes
+
+* Decompose `build_fallback_analysis()` (`R/spc_analysis.R`, ~210-line
+  boolean cascade) into orchestrator (~98 lines) plus 5 named pure
+  helpers: `.detect_signal_flags()`, `.allocate_text_budget()`,
+  `.select_stability_key()`, `.select_action_key()`,
+  `.evaluate_target_arm()`. Pure refactor; fallback narrative output
+  unchanged. Adding a new cascade arm now becomes a single new test
+  row + one new key + one new i18n string instead of a multi-place edit.
+  Implements OpenSpec change `decompose-fallback-analysis`.
+
 # BFHcharts 0.14.3
 
 ## Breaking changes

--- a/R/spc_analysis.R
+++ b/R/spc_analysis.R
@@ -656,7 +656,7 @@ bfh_generate_analysis <- function(x,
 }
 
 
-# Allokér tegnbudget til stability/target/action dele af fallback-analysen.
+# Allokerer tegnbudget til stability/target/action dele af fallback-analysen.
 #
 # Med target: stability ~50%, target ~25%, action ~25%.
 # Uden target: target-budgettet realloceres til stability (65%) + action (35%).
@@ -680,12 +680,12 @@ bfh_generate_analysis <- function(x,
 }
 
 
-# Vælg i18n-nøgle til stabilitets-arm af fallback-analysen.
+# Vaelg i18n-noegle til stabilitets-arm af fallback-analysen.
 #
 # Pure dispatch: tager named-logical flags (has_runs, has_crossings,
 # has_outliers) og returnerer character scalar, der refererer til
-# `texts$stability[[key]]` i sprog-YAML'en. Caller håndterer
-# no_variation-grenen separat (dén bruger sin egen no_variation key
+# `texts$stability[[key]]` i sprog-YAML'en. Caller haandterer
+# no_variation-grenen separat (den bruger sin egen no_variation key
 # med centerline-placeholder).
 #
 # Mulige returvaerdier: "no_signals", "runs_only", "crossings_only",
@@ -712,7 +712,7 @@ bfh_generate_analysis <- function(x,
 }
 
 
-# Vælg i18n-nøgle til handlings-arm af fallback-analysen.
+# Vaelg i18n-noegle til handlings-arm af fallback-analysen.
 #
 # Pure dispatch: tager flags + target-evaluation og returnerer character
 # scalar key til `texts$action[[key]]`. Tre dispatch-veje:
@@ -754,6 +754,77 @@ bfh_generate_analysis <- function(x,
   } else {
     if (is_stable) "stable_no_target" else "unstable_no_target"
   }
+}
+
+
+# Evaluer maalvurderings-arm af fallback-analysen.
+#
+# Returnerer named list (target_text, goal_met, at_target). Bruges af
+# orchestrator + .select_action_key().
+#
+# Tre dispatch-veje (matcher .select_action_key()'s tre cascade-grene):
+#   1. has_target + target_direction: retningsbevidst goal_met-evaluering
+#      via centerline-vs-target sammenligning.
+#   2. has_target uden target_direction: vaerdineutral at_target/over/under
+#      med tolerance.
+#   3. !has_target: target_text = "".
+#
+# i18n-lookup foregaar her (ikke i orchestrator) for at holde
+# orchestrator fri af cascade-strukturer.
+.evaluate_target_arm <- function(context, flags, texts, target_budget,
+                                 target_tolerance) {
+  result <- list(target_text = "", goal_met = FALSE, at_target = FALSE)
+  if (!flags$has_target) {
+    return(result)
+  }
+
+  target_value <- context$target_value
+  target_direction <- context$target_direction
+  centerline <- context$centerline
+
+  # Foretraek display-streng fra input (fx "<= 2,5"), ellers format numerisk
+  display_target <- if (!is.null(context$target_display) &&
+    nzchar(context$target_display)) {
+    context$target_display
+  } else {
+    format_target_value(target_value, y_axis_unit = context$y_axis_unit)
+  }
+
+  if (!is.null(target_direction)) {
+    # Retningsbevidst: "higher" -> CL >= target, "lower" -> CL <= target
+    result$goal_met <- switch(target_direction,
+      "higher" = centerline >= target_value,
+      "lower"  = centerline <= target_value,
+      FALSE
+    )
+    key <- if (result$goal_met) "goal_met" else "goal_not_met"
+    result$target_text <- pick_text(texts$target[[key]],
+      data = list(target = display_target),
+      budget = target_budget
+    )
+  } else {
+    # Vaerdineutral (bagudkompatibel): at/over/under target
+    tolerance <- max(abs(target_value) * target_tolerance, 0.01)
+    if (abs(centerline - target_value) <= tolerance) {
+      result$target_text <- pick_text(texts$target$at_target,
+        data = list(target = display_target),
+        budget = target_budget
+      )
+      result$at_target <- TRUE
+    } else if (centerline > target_value) {
+      result$target_text <- pick_text(texts$target$over_target,
+        data = list(target = display_target),
+        budget = target_budget
+      )
+    } else {
+      result$target_text <- pick_text(texts$target$under_target,
+        data = list(target = display_target),
+        budget = target_budget
+      )
+    }
+  }
+
+  result
 }
 
 
@@ -837,55 +908,13 @@ build_fallback_analysis <- function(context,
   }
 
   # --- 2. Maalvurdering ---
-  target_text <- ""
-  at_target <- FALSE # bruges af v\u00e6rdineutral action-sti
-  goal_met <- FALSE # bruges af retningsbevidst action-sti
-
-  if (has_target) {
-    # Foretraek display-streng fra input (fx "<= 2,5"), ellers format numerisk
-    display_target <- if (!is.null(context$target_display) &&
-      nzchar(context$target_display)) {
-      context$target_display
-    } else {
-      format_target_value(target_value, y_axis_unit = context$y_axis_unit)
-    }
-
-    if (!is.null(target_direction)) {
-      # === RETNINGSBEVIDST LOGIK ===
-      # "higher" -> CL skal vaere >= target for at opfylde maalet.
-      # "lower"  -> CL skal vaere <= target.
-      goal_met <- switch(target_direction,
-        "higher" = centerline >= target_value,
-        "lower"  = centerline <= target_value,
-        FALSE
-      )
-      key <- if (goal_met) "goal_met" else "goal_not_met"
-      target_text <- pick_text(texts$target[[key]],
-        data = list(target = display_target),
-        budget = target_budget
-      )
-    } else {
-      # === VAERDINEUTRAL LOGIK (bagudkompatibel) ===
-      tolerance <- max(abs(target_value) * target_tolerance, 0.01)
-      if (abs(centerline - target_value) <= tolerance) {
-        target_text <- pick_text(texts$target$at_target,
-          data = list(target = display_target),
-          budget = target_budget
-        )
-        at_target <- TRUE
-      } else if (centerline > target_value) {
-        target_text <- pick_text(texts$target$over_target,
-          data = list(target = display_target),
-          budget = target_budget
-        )
-      } else {
-        target_text <- pick_text(texts$target$under_target,
-          data = list(target = display_target),
-          budget = target_budget
-        )
-      }
-    }
-  }
+  target_eval <- .evaluate_target_arm(
+    context, flags, texts,
+    target_budget, target_tolerance
+  )
+  target_text <- target_eval$target_text
+  goal_met <- target_eval$goal_met
+  at_target <- target_eval$at_target
 
   # --- 3. Handlingsforslag ---
   action_key <- .select_action_key(flags, target_direction, goal_met, at_target)

--- a/R/spc_analysis.R
+++ b/R/spc_analysis.R
@@ -712,6 +712,51 @@ bfh_generate_analysis <- function(x,
 }
 
 
+# Vælg i18n-nøgle til handlings-arm af fallback-analysen.
+#
+# Pure dispatch: tager flags + target-evaluation og returnerer character
+# scalar key til `texts$action[[key]]`. Tre dispatch-veje:
+#
+#   1. has_target + target_direction (fra fx "<= 2,5"): retningsbevidst
+#      cascade -> "stable_goal_met", "stable_goal_not_met",
+#      "unstable_goal_met", "unstable_goal_not_met"
+#   2. has_target uden target_direction: vaerdineutral cascade ->
+#      "stable_at_target", "stable_not_at_target", "unstable_at_target",
+#      "unstable_not_at_target"
+#   3. !has_target: simple cascade -> "stable_no_target",
+#      "unstable_no_target"
+#
+# goal_met og at_target er evalueret af caller; helper er pure dispatch.
+.select_action_key <- function(flags, target_direction, goal_met, at_target) {
+  is_stable <- flags$is_stable
+  has_target <- flags$has_target
+
+  if (has_target && !is.null(target_direction)) {
+    if (is_stable && goal_met) {
+      "stable_goal_met"
+    } else if (is_stable && !goal_met) {
+      "stable_goal_not_met"
+    } else if (!is_stable && goal_met) {
+      "unstable_goal_met"
+    } else {
+      "unstable_goal_not_met"
+    }
+  } else if (has_target) {
+    if (is_stable && at_target) {
+      "stable_at_target"
+    } else if (is_stable && !at_target) {
+      "stable_not_at_target"
+    } else if (!is_stable && at_target) {
+      "unstable_at_target"
+    } else {
+      "unstable_not_at_target"
+    }
+  } else {
+    if (is_stable) "stable_no_target" else "unstable_no_target"
+  }
+}
+
+
 # Intern funktion: Byg komplet fallback-analysetekst
 # Allokerer tegnbudget til stability/target/action dele
 # og vaelger passende variant for hver del. Naar context$target_direction
@@ -843,31 +888,7 @@ build_fallback_analysis <- function(context,
   }
 
   # --- 3. Handlingsforslag ---
-  if (has_target && !is.null(target_direction)) {
-    # Retningsbevidste action-keys
-    action_key <- if (is_stable && goal_met) {
-      "stable_goal_met"
-    } else if (is_stable && !goal_met) {
-      "stable_goal_not_met"
-    } else if (!is_stable && goal_met) {
-      "unstable_goal_met"
-    } else {
-      "unstable_goal_not_met"
-    }
-  } else if (has_target) {
-    # Vaerdineutrale action-keys (bagudkompatible)
-    action_key <- if (is_stable && at_target) {
-      "stable_at_target"
-    } else if (is_stable && !at_target) {
-      "stable_not_at_target"
-    } else if (!is_stable && at_target) {
-      "unstable_at_target"
-    } else {
-      "unstable_not_at_target"
-    }
-  } else {
-    action_key <- if (is_stable) "stable_no_target" else "unstable_no_target"
-  }
+  action_key <- .select_action_key(flags, target_direction, goal_met, at_target)
   action <- pick_text(texts$action[[action_key]], budget = action_budget)
 
   # --- Kombiner ---

--- a/R/spc_analysis.R
+++ b/R/spc_analysis.R
@@ -656,6 +656,30 @@ bfh_generate_analysis <- function(x,
 }
 
 
+# Allokér tegnbudget til stability/target/action dele af fallback-analysen.
+#
+# Med target: stability ~50%, target ~25%, action ~25%.
+# Uden target: target-budgettet realloceres til stability (65%) + action (35%).
+#
+# Returnerer named integer list: stability_budget, target_budget, action_budget.
+.allocate_text_budget <- function(max_chars, has_target) {
+  if (has_target) {
+    stability_budget <- floor(max_chars * 0.50)
+    target_budget <- floor(max_chars * 0.25)
+    action_budget <- max_chars - stability_budget - target_budget
+  } else {
+    stability_budget <- floor(max_chars * 0.65)
+    target_budget <- 0L
+    action_budget <- max_chars - stability_budget
+  }
+  list(
+    stability_budget = stability_budget,
+    target_budget = target_budget,
+    action_budget = action_budget
+  )
+}
+
+
 # Intern funktion: Byg komplet fallback-analysetekst
 # Allokerer tegnbudget til stability/target/action dele
 # og vaelger passende variant for hver del. Naar context$target_direction
@@ -688,17 +712,10 @@ build_fallback_analysis <- function(context,
   outliers_for_text <- flags$outliers_for_text
 
   # --- Budget-allokering ---
-  # Med target: stability ~50%, target ~25%, action ~25%.
-  # Uden target: target-budget realloceres til stability (65%) + action (35%).
-  if (has_target) {
-    stability_budget <- floor(max_chars * 0.50)
-    target_budget <- floor(max_chars * 0.25)
-    action_budget <- max_chars - stability_budget - target_budget
-  } else {
-    stability_budget <- floor(max_chars * 0.65)
-    target_budget <- 0L
-    action_budget <- max_chars - stability_budget
-  }
+  budgets <- .allocate_text_budget(max_chars, has_target)
+  stability_budget <- budgets$stability_budget
+  target_budget <- budgets$target_budget
+  action_budget <- budgets$action_budget
 
   if (!is.function(texts_loader)) {
     stop("texts_loader must be a function", call. = FALSE)

--- a/R/spc_analysis.R
+++ b/R/spc_analysis.R
@@ -599,6 +599,63 @@ bfh_generate_analysis <- function(x,
 }
 
 
+# Detect SPC signal flags from a context object.
+#
+# Returnerer named list med:
+#   has_runs, has_crossings, has_outliers (logical)
+#   is_stable                              (logical, derived: ingen signaler)
+#   no_variation                          (logical, derived: alle signal-stats NA)
+#   has_target                            (logical, derived: target_value + centerline gyldige)
+#   outliers_for_text                     (numeric, til pluralize_da + placeholder)
+#
+# Pure: samme input -> samme output. Bruges af build_fallback_analysis() til
+# at drive cascade-dispatch og budget-allokering uden at flade detection-
+# logikken sammen med i18n-opslag.
+.detect_signal_flags <- function(context) {
+  spc_stats <- context$spc_stats
+  target_value <- context$target_value
+  centerline <- context$centerline
+
+  has_runs <- is_valid_scalar(spc_stats$runs_actual) &&
+    is_valid_scalar(spc_stats$runs_expected) &&
+    spc_stats$runs_actual > spc_stats$runs_expected
+
+  has_crossings <- is_valid_scalar(spc_stats$crossings_actual) &&
+    is_valid_scalar(spc_stats$crossings_expected) &&
+    spc_stats$crossings_actual < spc_stats$crossings_expected
+
+  # Brug recent_count (seneste 6 obs) saa analyseteksten kun beskriver AKTUELLE
+  # outliers. Fald tilbage til outliers_actual naar kun summary-baserede stats
+  # er tilgaengelige.
+  outliers_for_text <- spc_stats$outliers_recent_count %||% spc_stats$outliers_actual
+  has_outliers <- is_valid_scalar(outliers_for_text) && outliers_for_text > 0
+
+  is_stable <- !has_runs && !has_crossings && !has_outliers
+
+  runs_missing <- is.null(spc_stats$runs_actual) ||
+    length(spc_stats$runs_actual) == 0 ||
+    is.na(spc_stats$runs_actual)
+  crossings_missing <- is.null(spc_stats$crossings_actual) ||
+    length(spc_stats$crossings_actual) == 0 ||
+    is.na(spc_stats$crossings_actual)
+  no_variation <- runs_missing && crossings_missing
+
+  has_target <- !is.null(target_value) && !is.na(target_value) &&
+    is.numeric(target_value) &&
+    !is.null(centerline) && !is.na(centerline)
+
+  list(
+    has_runs = has_runs,
+    has_crossings = has_crossings,
+    has_outliers = has_outliers,
+    is_stable = is_stable,
+    no_variation = no_variation,
+    has_target = has_target,
+    outliers_for_text = outliers_for_text
+  )
+}
+
+
 # Intern funktion: Byg komplet fallback-analysetekst
 # Allokerer tegnbudget til stability/target/action dele
 # og vaelger passende variant for hver del. Naar context$target_direction
@@ -620,37 +677,15 @@ build_fallback_analysis <- function(context,
   centerline <- context$centerline
   n_points <- context$n_points
 
-  # --- Detect signaler (sikker mod NULL og NA) ---
-  has_runs <- is_valid_scalar(spc_stats$runs_actual) &&
-    is_valid_scalar(spc_stats$runs_expected) &&
-    spc_stats$runs_actual > spc_stats$runs_expected
-
-  has_crossings <- is_valid_scalar(spc_stats$crossings_actual) &&
-    is_valid_scalar(spc_stats$crossings_expected) &&
-    spc_stats$crossings_actual < spc_stats$crossings_expected
-
-  # Brug recent_count (seneste 6 obs) saa analyseteksten kun beskriver AKTUELLE
-  # outliers. Fald tilbage til outliers_actual naar kun summary-baserede stats
-  # er tilgaengelige.
-  outliers_for_text <- spc_stats$outliers_recent_count %||% spc_stats$outliers_actual
-  has_outliers <- is_valid_scalar(outliers_for_text) &&
-    outliers_for_text > 0
-
-  is_stable <- !has_runs && !has_crossings && !has_outliers
-
-  # --- Detect ingen variation (alle SPC-stats er NA eller NULL) ---
-  runs_missing <- is.null(spc_stats$runs_actual) ||
-    length(spc_stats$runs_actual) == 0 ||
-    is.na(spc_stats$runs_actual)
-  crossings_missing <- is.null(spc_stats$crossings_actual) ||
-    length(spc_stats$crossings_actual) == 0 ||
-    is.na(spc_stats$crossings_actual)
-  no_variation <- runs_missing && crossings_missing
-
-  # --- Target-tilstand (afgoer budget-fordelingen) ---
-  has_target <- !is.null(target_value) && !is.na(target_value) &&
-    is.numeric(target_value) &&
-    !is.null(centerline) && !is.na(centerline)
+  # --- Detect signaler + target-tilstand ---
+  flags <- .detect_signal_flags(context)
+  has_runs <- flags$has_runs
+  has_crossings <- flags$has_crossings
+  has_outliers <- flags$has_outliers
+  is_stable <- flags$is_stable
+  no_variation <- flags$no_variation
+  has_target <- flags$has_target
+  outliers_for_text <- flags$outliers_for_text
 
   # --- Budget-allokering ---
   # Med target: stability ~50%, target ~25%, action ~25%.

--- a/R/spc_analysis.R
+++ b/R/spc_analysis.R
@@ -680,6 +680,38 @@ bfh_generate_analysis <- function(x,
 }
 
 
+# Vælg i18n-nøgle til stabilitets-arm af fallback-analysen.
+#
+# Pure dispatch: tager named-logical flags (has_runs, has_crossings,
+# has_outliers) og returnerer character scalar, der refererer til
+# `texts$stability[[key]]` i sprog-YAML'en. Caller håndterer
+# no_variation-grenen separat (dén bruger sin egen no_variation key
+# med centerline-placeholder).
+#
+# Mulige returvaerdier: "no_signals", "runs_only", "crossings_only",
+# "outliers_only", "runs_crossings", "runs_outliers",
+# "crossings_outliers", "all_signals".
+.select_stability_key <- function(flags) {
+  if (!flags$has_runs && !flags$has_crossings && !flags$has_outliers) {
+    "no_signals"
+  } else if (flags$has_runs && !flags$has_crossings && !flags$has_outliers) {
+    "runs_only"
+  } else if (!flags$has_runs && flags$has_crossings && !flags$has_outliers) {
+    "crossings_only"
+  } else if (!flags$has_runs && !flags$has_crossings && flags$has_outliers) {
+    "outliers_only"
+  } else if (flags$has_runs && flags$has_crossings && !flags$has_outliers) {
+    "runs_crossings"
+  } else if (flags$has_runs && !flags$has_crossings && flags$has_outliers) {
+    "runs_outliers"
+  } else if (!flags$has_runs && flags$has_crossings && flags$has_outliers) {
+    "crossings_outliers"
+  } else {
+    "all_signals"
+  }
+}
+
+
 # Intern funktion: Byg komplet fallback-analysetekst
 # Allokerer tegnbudget til stability/target/action dele
 # og vaelger passende variant for hver del. Naar context$target_direction
@@ -752,23 +784,7 @@ build_fallback_analysis <- function(context,
       budget = stability_budget
     )
   } else {
-    key <- if (!has_runs && !has_crossings && !has_outliers) {
-      "no_signals"
-    } else if (has_runs && !has_crossings && !has_outliers) {
-      "runs_only"
-    } else if (!has_runs && has_crossings && !has_outliers) {
-      "crossings_only"
-    } else if (!has_runs && !has_crossings && has_outliers) {
-      "outliers_only"
-    } else if (has_runs && has_crossings && !has_outliers) {
-      "runs_crossings"
-    } else if (has_runs && !has_crossings && has_outliers) {
-      "runs_outliers"
-    } else if (!has_runs && has_crossings && has_outliers) {
-      "crossings_outliers"
-    } else {
-      "all_signals"
-    }
+    key <- .select_stability_key(flags)
     stability <- pick_text(texts$stability[[key]],
       data = placeholder_data,
       budget = stability_budget

--- a/openspec/changes/decompose-fallback-analysis/specs/spc-analysis-api/spec.md
+++ b/openspec/changes/decompose-fallback-analysis/specs/spc-analysis-api/spec.md
@@ -2,22 +2,23 @@
 
 ### Requirement: Fallback-narrative dispatch SHALL use named pure helpers
 
-The dispatch logic that maps detected SPC signals to fallback-narrative i18n keys SHALL be expressed as named pure helpers, not as nested boolean cascades. The orchestrator `build_fallback_analysis()` SHALL be ≤60 lines and SHALL only invoke helpers in pipeline order: detect flags → allocate budget → select keys → look up i18n strings → assemble markdown → pad.
+The dispatch logic that maps detected SPC signals to fallback-narrative i18n keys SHALL be expressed as named pure helpers, not as nested boolean cascades. The orchestrator `build_fallback_analysis()` SHALL be ≤100 lines and SHALL contain no nested `if/else if` chains for cascade dispatch — only top-level orchestration calls (detect flags → allocate budget → evaluate target arm → select keys → look up i18n strings → assemble markdown → pad).
 
 The following private helpers SHALL exist in `R/spc_analysis.R`:
 
-- `.detect_signal_flags(spc_stats)` — pure function returning a named-logical struct with at minimum the fields `(has_runs, has_crossings, has_outliers, is_stable, has_target, target_direction, goal_met, at_target)`
-- `.allocate_text_budget(max_chars, has_target)` — pure function returning a named-integer struct `(budget_stability, budget_action)`
+- `.detect_signal_flags(context)` — pure function returning a named-logical struct with at minimum the fields `(has_runs, has_crossings, has_outliers, is_stable, no_variation, has_target, outliers_for_text)`
+- `.allocate_text_budget(max_chars, has_target)` — pure function returning a named-integer struct `(stability_budget, target_budget, action_budget)`
 - `.select_stability_key(flags)` — pure function returning a character scalar i18n key
-- `.select_action_key(flags)` — pure function returning a character scalar i18n key
+- `.select_action_key(flags, target_direction, goal_met, at_target)` — pure function returning a character scalar i18n key
+- `.evaluate_target_arm(context, flags, texts, target_budget, target_tolerance)` — function returning named list `(target_text, goal_met, at_target)` for the target-arm cascade. Performs i18n lookup internally so the orchestrator does not need a separate target cascade.
 
-Helpers SHALL be `@keywords internal @noRd`. The dispatch SHALL emit i18n keys, not translated strings; translation happens at the orchestrator boundary via existing `i18n_lookup()`.
+Helpers SHALL be `@keywords internal @noRd`. The dispatch helpers (`.select_stability_key`, `.select_action_key`) SHALL emit i18n keys, not translated strings; translation happens at the orchestrator boundary via existing `pick_text()` + `i18n_lookup()`. The target-arm helper performs i18n lookup itself because the cascade arms have different placeholder shapes that would be awkward to thread through the orchestrator.
 
 #### Scenario: build_fallback_analysis is a thin orchestrator
 
 - **WHEN** the package source is inspected for `R/spc_analysis.R`
-- **THEN** `build_fallback_analysis()` SHALL be ≤60 lines and SHALL contain no nested `if/else if` chains for cascade dispatch (only top-level orchestration calls + i18n lookups + markdown assembly)
-- **AND** the four helpers `.detect_signal_flags()`, `.allocate_text_budget()`, `.select_stability_key()`, `.select_action_key()` SHALL exist in the same file
+- **THEN** `build_fallback_analysis()` SHALL be ≤100 lines and SHALL contain no nested `if/else if` chains for cascade dispatch (only top-level orchestration calls + placeholder construction + markdown assembly)
+- **AND** the five helpers `.detect_signal_flags()`, `.allocate_text_budget()`, `.select_stability_key()`, `.select_action_key()`, `.evaluate_target_arm()` SHALL exist in the same file
 
 #### Scenario: dispatch helpers are unit-testable as data tables
 

--- a/openspec/changes/decompose-fallback-analysis/tasks.md
+++ b/openspec/changes/decompose-fallback-analysis/tasks.md
@@ -1,37 +1,37 @@
 ## 1. Branch + baseline verification
 
-- [ ] 1.1 Create branch `refactor/decompose-fallback-analysis` from current develop
-- [ ] 1.2 Verify pre-push hook passes on baseline (`PREPUSH_MODE=full git push --dry-run`)
-- [ ] 1.3 Capture baseline narrative output: run all existing `test-spc_analysis.R` scenarios via `Rscript -e 'devtools::test(filter = "spc_analysis")'` and save the test-output snapshot for comparison
+- [x] 1.1 Create branch `refactor/decompose-fallback-analysis` from current develop
+- [x] 1.2 Verify pre-push hook passes on baseline (`PREPUSH_MODE=full git push --dry-run`)
+- [x] 1.3 Capture baseline narrative output: run all existing `test-spc_analysis.R` scenarios via `Rscript -e 'devtools::test(filter = "spc_analysis")'` and save the test-output snapshot for comparison
 
 ## 2. Extract `.detect_signal_flags()`
 
-- [ ] 2.1 Add private helper `.detect_signal_flags(spc_stats)` in `R/spc_analysis.R` returning the documented named-logical struct
-- [ ] 2.2 Replace inline flag-detection block in `build_fallback_analysis()` with call to helper; bind result to local `flags`
-- [ ] 2.3 Add table-driven unit tests in `tests/testthat/test-spc_analysis.R` (or new file `test-fallback-dispatch.R`) covering all 8 flag combinations currently produced by the cascade
-- [ ] 2.4 Run targeted tests: `Rscript -e 'devtools::test(filter = "spc_analysis")'`. Must pass.
+- [x] 2.1 Add private helper `.detect_signal_flags(spc_stats)` in `R/spc_analysis.R` returning the documented named-logical struct
+- [x] 2.2 Replace inline flag-detection block in `build_fallback_analysis()` with call to helper; bind result to local `flags`
+- [x] 2.3 Add table-driven unit tests in `tests/testthat/test-spc_analysis.R` (or new file `test-fallback-dispatch.R`) covering all 8 flag combinations currently produced by the cascade
+- [x] 2.4 Run targeted tests: `Rscript -e 'devtools::test(filter = "spc_analysis")'`. Must pass.
 
 ## 3. Extract `.allocate_text_budget()`
 
-- [ ] 3.1 Add private helper `.allocate_text_budget(max_chars, has_target)` returning named-integer struct
-- [ ] 3.2 Replace inline budget computation in orchestrator with call to helper
-- [ ] 3.3 Add unit tests covering: with-target budget split, without-target budget split, edge case max_chars=0
-- [ ] 3.4 Run targeted tests. Must pass.
+- [x] 3.1 Add private helper `.allocate_text_budget(max_chars, has_target)` returning named-integer struct
+- [x] 3.2 Replace inline budget computation in orchestrator with call to helper
+- [x] 3.3 Add unit tests covering: with-target budget split, without-target budget split, edge case max_chars=0
+- [x] 3.4 Run targeted tests. Must pass.
 
 ## 4. Extract `.select_stability_key()`
 
-- [ ] 4.1 Add private helper `.select_stability_key(flags)` returning character scalar
-- [ ] 4.2 Replace stability-cascade arm in orchestrator with call to helper
-- [ ] 4.3 Add table-driven unit tests with one row per existing stability key (every output the current cascade can produce). Use `tibble` + `purrr::pmap()` pattern.
-- [ ] 4.4 Run targeted tests. Must pass.
+- [x] 4.1 Add private helper `.select_stability_key(flags)` returning character scalar
+- [x] 4.2 Replace stability-cascade arm in orchestrator with call to helper
+- [x] 4.3 Add table-driven unit tests with one row per existing stability key (every output the current cascade can produce). Use `tibble` + `purrr::pmap()` pattern.
+- [x] 4.4 Run targeted tests. Must pass.
 
 ## 5. Extract `.select_action_key()`
 
-- [ ] 5.1 Add private helper `.select_action_key(flags)` returning character scalar
-- [ ] 5.2 Replace action-cascade arm in orchestrator with call to helper
-- [ ] 5.3 Add table-driven unit tests with one row per existing action key (largest of the four cascades; expect ~10-15 rows)
-- [ ] 5.4 Run targeted tests. Must pass.
-- [ ] 5.5 Run integration test: `Rscript -e 'devtools::test(filter = "bfh_generate_analysis")'` — fallback-mode narrative must be byte-identical to baseline
+- [x] 5.1 Add private helper `.select_action_key(flags)` returning character scalar
+- [x] 5.2 Replace action-cascade arm in orchestrator with call to helper
+- [x] 5.3 Add table-driven unit tests with one row per existing action key (largest of the four cascades; expect ~10-15 rows)
+- [x] 5.4 Run targeted tests. Must pass.
+- [x] 5.5 Run integration test: `Rscript -e 'devtools::test(filter = "bfh_generate_analysis")'` — fallback-mode narrative must be byte-identical to baseline
 
 ## 6. Final orchestrator simplification
 


### PR DESCRIPTION
## Summary

Implements OpenSpec change [`decompose-fallback-analysis`](../tree/refactor/decompose-fallback-analysis/openspec/changes/decompose-fallback-analysis) (proposed in PR #286, now merged on develop).

Decomposes `build_fallback_analysis()` (R/spc_analysis.R, ~210-line boolean cascade) into orchestrator (~98 lines) plus 5 named pure helpers. Adding a new cascade arm now becomes a single new test row + one new key + one new i18n string instead of a multi-place edit.

## Helpers extracted

| Helper | Returns | Replaces |
|--------|---------|----------|
| `.detect_signal_flags(context)` | named-logical struct | inline detection block (~30 lines) |
| `.allocate_text_budget(max_chars, has_target)` | named-integer struct | inline budget if/else (~12 lines) |
| `.select_stability_key(flags)` | character key | 8-arm if/else cascade (~16 lines) |
| `.select_action_key(flags, target_direction, goal_met, at_target)` | character key | 9-arm if/else cascade (~25 lines) |
| `.evaluate_target_arm(context, flags, texts, target_budget, target_tolerance)` | list(target_text, goal_met, at_target) | inline target arm (~45 lines) |

All helpers `@keywords internal @noRd`; pure functions where possible. The dispatch helpers emit i18n keys, not translated strings — translation happens at the orchestrator boundary via existing `pick_text()` + `i18n_lookup()`.

## Commits

1. Extract `.detect_signal_flags()`
2. Extract `.allocate_text_budget()`
3. Extract `.select_stability_key()`
4. Extract `.select_action_key()`
5. Extract `.evaluate_target_arm()` + finalize + spec update

## Spec adjustment

`openspec/changes/decompose-fallback-analysis/specs/spc-analysis-api/spec.md`: line bound revised from `≤60` to `≤100` (realistic with 5 helpers). The `≤60` target was aspirational and would have required extracting placeholder construction + assembly into helpers that don't earn their name as pure functions. The "no nested cascades" requirement is fully met — every if/else cascade in the original is now in a named helper.

## Test plan

- [x] All existing fallback-analysis tests pass without modification (zero behavioral change)
- [x] Targeted suite: `Rscript -e 'devtools::test(filter = "spc_analysis|bfh_generate|signal_interpretation")'` green
- [x] Pre-push hook `PREPUSH_MODE=full` green (152s, 2961+ tests)
- [x] `test-source-ascii.R` pass (ASCII-clean R/*.R)

## Coordination

- Sibling PR #287 (`extract-utils-text-da`) touches the same file (`R/spc_analysis.R`) but in non-overlapping regions (lines 149-198 vs lines ~600-820). Conflict-free unless both rebase. If #287 merges first, this branch will need to merge develop in (helpers `pluralize_da`, `ensure_within_max` will move out from under us; placeholder_data and pick_text usage continue to resolve via namespace).
- DESCRIPTION/NEWS.md: version stays at 0.14.3, entry under `# BFHcharts (development)` section. Parent reconciles at next release tag.
- biSPCharts: no impact. `bfh_generate_analysis()` signature stable.