### PR TITLE
chore(release): bump to 0.14.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BFHcharts
 Title: SPC Visualization for Healthcare Quality Improvement
-Version: 0.14.4
+Version: 0.14.5
 Authors@R: c(
     person(
       "Johan", "Reventlow",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# BFHcharts (development)
+# BFHcharts 0.14.5
 
 ## Internal changes
 


### PR DESCRIPTION
## Summary

Promotes `(development)` section in NEWS.md to 0.14.5 release section. Bumps DESCRIPTION 0.14.4 → 0.14.5.

## Why

Bundles three Fase 4 refactor PRs (#287, #288, #289) into a single release tag. PR #287 was already labeled 0.14.4 in NEWS but never tagged — extending to 0.14.5 with #288 + #289 entries gives a single coherent release.

## Includes

- **#287** extract-utils-text-da — 5 Danish text helpers moved to `R/utils_text_da.R` (already in 0.14.4 NEWS section, untagged)
- **#288** decompose-fallback-analysis — `build_fallback_analysis()` split into orchestrator + 5 helpers
- **#289** decompose-marquee-labels — `add_right_labels_marquee()` split into orchestrator + 5 helpers

## Risk

- All changes are internal refactors. No public API impact. No breaking changes.
- Visual regression baselines unchanged (verified during #289 implementation).

## After merge

Open release PR `develop → main`, then tag `v0.14.5` on the merge commit.