### PR TITLE
Release v0.14.5: Fase 4 refactor cleanup

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BFHcharts
 Title: SPC Visualization for Healthcare Quality Improvement
-Version: 0.14.4
+Version: 0.14.5
 Authors@R: c(
     person(
       "Johan", "Reventlow",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BFHcharts
 Title: SPC Visualization for Healthcare Quality Improvement
-Version: 0.14.3
+Version: 0.14.4
 Authors@R: c(
     person(
       "Johan", "Reventlow",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# BFHcharts (development)
+
+## Internal changes
+
+* Decompose `build_fallback_analysis()` (`R/spc_analysis.R`, ~210-line
+  boolean cascade) into orchestrator (~98 lines) plus 5 named pure
+  helpers: `.detect_signal_flags()`, `.allocate_text_budget()`,
+  `.select_stability_key()`, `.select_action_key()`,
+  `.evaluate_target_arm()`. Pure refactor; fallback narrative output
+  unchanged. Adding a new cascade arm now becomes a single new test
+  row + one new key + one new i18n string instead of a multi-place edit.
+  Implements OpenSpec change `decompose-fallback-analysis`.
+
 # BFHcharts 0.14.3
 
 ## Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,19 @@
+# BFHcharts (development)
+
+## Internal changes
+
+* Decompose `add_right_labels_marquee()` (`R/utils_add_right_labels_marquee.R`,
+  510-line god function with 11 distinct responsibilities) into
+  orchestrator (~217 lines) plus 5 named private helpers:
+  `.resolve_label_geometry()`, `.acquire_device_for_measurement()`,
+  `.measure_label_heights()`, `.detect_x_axis_type()`,
+  `.build_label_data()`. Pure refactor; visual regression baselines
+  unchanged (zero `.new.svg` files produced by full pre-push test run).
+  `.acquire_device_for_measurement()` returns a `cleanup_fn` closure
+  that the orchestrator binds via `on.exit(..., add = TRUE)` for
+  unwind-safe device cleanup. Implements OpenSpec change
+  `decompose-marquee-labels`.
+
 # BFHcharts 0.14.4
 
 ## Internal changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# BFHcharts 0.14.4
+
+## Internal changes
+
+* Extract Danish text-formatting helpers (`pluralize_da()`,
+  `ensure_within_max()`, `substitute_placeholders()`, `pick_text()`,
+  `pad_to_minimum()`) from `R/spc_analysis.R` into a dedicated
+  `R/utils_text_da.R`. Pure relocation; no behavioral change.
+  `R/spc_analysis.R` shrinks by ~130 lines. Implements OpenSpec change
+  `extract-utils-text-da`.
+
 # BFHcharts 0.14.3
 
 ## Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# BFHcharts (development)
+# BFHcharts 0.14.5
 
 ## Internal changes
 

--- a/R/spc_analysis.R
+++ b/R/spc_analysis.R
@@ -656,7 +656,7 @@ bfh_generate_analysis <- function(x,
 }
 
 
-# Allokér tegnbudget til stability/target/action dele af fallback-analysen.
+# Allokerer tegnbudget til stability/target/action dele af fallback-analysen.
 #
 # Med target: stability ~50%, target ~25%, action ~25%.
 # Uden target: target-budgettet realloceres til stability (65%) + action (35%).
@@ -680,12 +680,12 @@ bfh_generate_analysis <- function(x,
 }
 
 
-# Vælg i18n-nøgle til stabilitets-arm af fallback-analysen.
+# Vaelg i18n-noegle til stabilitets-arm af fallback-analysen.
 #
 # Pure dispatch: tager named-logical flags (has_runs, has_crossings,
 # has_outliers) og returnerer character scalar, der refererer til
-# `texts$stability[[key]]` i sprog-YAML'en. Caller håndterer
-# no_variation-grenen separat (dén bruger sin egen no_variation key
+# `texts$stability[[key]]` i sprog-YAML'en. Caller haandterer
+# no_variation-grenen separat (den bruger sin egen no_variation key
 # med centerline-placeholder).
 #
 # Mulige returvaerdier: "no_signals", "runs_only", "crossings_only",
@@ -712,7 +712,7 @@ bfh_generate_analysis <- function(x,
 }
 
 
-# Vælg i18n-nøgle til handlings-arm af fallback-analysen.
+# Vaelg i18n-noegle til handlings-arm af fallback-analysen.
 #
 # Pure dispatch: tager flags + target-evaluation og returnerer character
 # scalar key til `texts$action[[key]]`. Tre dispatch-veje:
@@ -754,6 +754,77 @@ bfh_generate_analysis <- function(x,
   } else {
     if (is_stable) "stable_no_target" else "unstable_no_target"
   }
+}
+
+
+# Evaluer maalvurderings-arm af fallback-analysen.
+#
+# Returnerer named list (target_text, goal_met, at_target). Bruges af
+# orchestrator + .select_action_key().
+#
+# Tre dispatch-veje (matcher .select_action_key()'s tre cascade-grene):
+#   1. has_target + target_direction: retningsbevidst goal_met-evaluering
+#      via centerline-vs-target sammenligning.
+#   2. has_target uden target_direction: vaerdineutral at_target/over/under
+#      med tolerance.
+#   3. !has_target: target_text = "".
+#
+# i18n-lookup foregaar her (ikke i orchestrator) for at holde
+# orchestrator fri af cascade-strukturer.
+.evaluate_target_arm <- function(context, flags, texts, target_budget,
+                                 target_tolerance) {
+  result <- list(target_text = "", goal_met = FALSE, at_target = FALSE)
+  if (!flags$has_target) {
+    return(result)
+  }
+
+  target_value <- context$target_value
+  target_direction <- context$target_direction
+  centerline <- context$centerline
+
+  # Foretraek display-streng fra input (fx "<= 2,5"), ellers format numerisk
+  display_target <- if (!is.null(context$target_display) &&
+    nzchar(context$target_display)) {
+    context$target_display
+  } else {
+    format_target_value(target_value, y_axis_unit = context$y_axis_unit)
+  }
+
+  if (!is.null(target_direction)) {
+    # Retningsbevidst: "higher" -> CL >= target, "lower" -> CL <= target
+    result$goal_met <- switch(target_direction,
+      "higher" = centerline >= target_value,
+      "lower"  = centerline <= target_value,
+      FALSE
+    )
+    key <- if (result$goal_met) "goal_met" else "goal_not_met"
+    result$target_text <- pick_text(texts$target[[key]],
+      data = list(target = display_target),
+      budget = target_budget
+    )
+  } else {
+    # Vaerdineutral (bagudkompatibel): at/over/under target
+    tolerance <- max(abs(target_value) * target_tolerance, 0.01)
+    if (abs(centerline - target_value) <= tolerance) {
+      result$target_text <- pick_text(texts$target$at_target,
+        data = list(target = display_target),
+        budget = target_budget
+      )
+      result$at_target <- TRUE
+    } else if (centerline > target_value) {
+      result$target_text <- pick_text(texts$target$over_target,
+        data = list(target = display_target),
+        budget = target_budget
+      )
+    } else {
+      result$target_text <- pick_text(texts$target$under_target,
+        data = list(target = display_target),
+        budget = target_budget
+      )
+    }
+  }
+
+  result
 }
 
 
@@ -837,55 +908,13 @@ build_fallback_analysis <- function(context,
   }
 
   # --- 2. Maalvurdering ---
-  target_text <- ""
-  at_target <- FALSE # bruges af v\u00e6rdineutral action-sti
-  goal_met <- FALSE # bruges af retningsbevidst action-sti
-
-  if (has_target) {
-    # Foretraek display-streng fra input (fx "<= 2,5"), ellers format numerisk
-    display_target <- if (!is.null(context$target_display) &&
-      nzchar(context$target_display)) {
-      context$target_display
-    } else {
-      format_target_value(target_value, y_axis_unit = context$y_axis_unit)
-    }
-
-    if (!is.null(target_direction)) {
-      # === RETNINGSBEVIDST LOGIK ===
-      # "higher" -> CL skal vaere >= target for at opfylde maalet.
-      # "lower"  -> CL skal vaere <= target.
-      goal_met <- switch(target_direction,
-        "higher" = centerline >= target_value,
-        "lower"  = centerline <= target_value,
-        FALSE
-      )
-      key <- if (goal_met) "goal_met" else "goal_not_met"
-      target_text <- pick_text(texts$target[[key]],
-        data = list(target = display_target),
-        budget = target_budget
-      )
-    } else {
-      # === VAERDINEUTRAL LOGIK (bagudkompatibel) ===
-      tolerance <- max(abs(target_value) * target_tolerance, 0.01)
-      if (abs(centerline - target_value) <= tolerance) {
-        target_text <- pick_text(texts$target$at_target,
-          data = list(target = display_target),
-          budget = target_budget
-        )
-        at_target <- TRUE
-      } else if (centerline > target_value) {
-        target_text <- pick_text(texts$target$over_target,
-          data = list(target = display_target),
-          budget = target_budget
-        )
-      } else {
-        target_text <- pick_text(texts$target$under_target,
-          data = list(target = display_target),
-          budget = target_budget
-        )
-      }
-    }
-  }
+  target_eval <- .evaluate_target_arm(
+    context, flags, texts,
+    target_budget, target_tolerance
+  )
+  target_text <- target_eval$target_text
+  goal_met <- target_eval$goal_met
+  at_target <- target_eval$at_target
 
   # --- 3. Handlingsforslag ---
   action_key <- .select_action_key(flags, target_direction, goal_met, at_target)

--- a/R/spc_analysis.R
+++ b/R/spc_analysis.R
@@ -712,6 +712,51 @@ bfh_generate_analysis <- function(x,
 }
 
 
+# Vælg i18n-nøgle til handlings-arm af fallback-analysen.
+#
+# Pure dispatch: tager flags + target-evaluation og returnerer character
+# scalar key til `texts$action[[key]]`. Tre dispatch-veje:
+#
+#   1. has_target + target_direction (fra fx "<= 2,5"): retningsbevidst
+#      cascade -> "stable_goal_met", "stable_goal_not_met",
+#      "unstable_goal_met", "unstable_goal_not_met"
+#   2. has_target uden target_direction: vaerdineutral cascade ->
+#      "stable_at_target", "stable_not_at_target", "unstable_at_target",
+#      "unstable_not_at_target"
+#   3. !has_target: simple cascade -> "stable_no_target",
+#      "unstable_no_target"
+#
+# goal_met og at_target er evalueret af caller; helper er pure dispatch.
+.select_action_key <- function(flags, target_direction, goal_met, at_target) {
+  is_stable <- flags$is_stable
+  has_target <- flags$has_target
+
+  if (has_target && !is.null(target_direction)) {
+    if (is_stable && goal_met) {
+      "stable_goal_met"
+    } else if (is_stable && !goal_met) {
+      "stable_goal_not_met"
+    } else if (!is_stable && goal_met) {
+      "unstable_goal_met"
+    } else {
+      "unstable_goal_not_met"
+    }
+  } else if (has_target) {
+    if (is_stable && at_target) {
+      "stable_at_target"
+    } else if (is_stable && !at_target) {
+      "stable_not_at_target"
+    } else if (!is_stable && at_target) {
+      "unstable_at_target"
+    } else {
+      "unstable_not_at_target"
+    }
+  } else {
+    if (is_stable) "stable_no_target" else "unstable_no_target"
+  }
+}
+
+
 # Intern funktion: Byg komplet fallback-analysetekst
 # Allokerer tegnbudget til stability/target/action dele
 # og vaelger passende variant for hver del. Naar context$target_direction
@@ -843,31 +888,7 @@ build_fallback_analysis <- function(context,
   }
 
   # --- 3. Handlingsforslag ---
-  if (has_target && !is.null(target_direction)) {
-    # Retningsbevidste action-keys
-    action_key <- if (is_stable && goal_met) {
-      "stable_goal_met"
-    } else if (is_stable && !goal_met) {
-      "stable_goal_not_met"
-    } else if (!is_stable && goal_met) {
-      "unstable_goal_met"
-    } else {
-      "unstable_goal_not_met"
-    }
-  } else if (has_target) {
-    # Vaerdineutrale action-keys (bagudkompatible)
-    action_key <- if (is_stable && at_target) {
-      "stable_at_target"
-    } else if (is_stable && !at_target) {
-      "stable_not_at_target"
-    } else if (!is_stable && at_target) {
-      "unstable_at_target"
-    } else {
-      "unstable_not_at_target"
-    }
-  } else {
-    action_key <- if (is_stable) "stable_no_target" else "unstable_no_target"
-  }
+  action_key <- .select_action_key(flags, target_direction, goal_met, at_target)
   action <- pick_text(texts$action[[action_key]], budget = action_budget)
 
   # --- Kombiner ---

--- a/R/spc_analysis.R
+++ b/R/spc_analysis.R
@@ -656,6 +656,30 @@ bfh_generate_analysis <- function(x,
 }
 
 
+# Allokér tegnbudget til stability/target/action dele af fallback-analysen.
+#
+# Med target: stability ~50%, target ~25%, action ~25%.
+# Uden target: target-budgettet realloceres til stability (65%) + action (35%).
+#
+# Returnerer named integer list: stability_budget, target_budget, action_budget.
+.allocate_text_budget <- function(max_chars, has_target) {
+  if (has_target) {
+    stability_budget <- floor(max_chars * 0.50)
+    target_budget <- floor(max_chars * 0.25)
+    action_budget <- max_chars - stability_budget - target_budget
+  } else {
+    stability_budget <- floor(max_chars * 0.65)
+    target_budget <- 0L
+    action_budget <- max_chars - stability_budget
+  }
+  list(
+    stability_budget = stability_budget,
+    target_budget = target_budget,
+    action_budget = action_budget
+  )
+}
+
+
 # Intern funktion: Byg komplet fallback-analysetekst
 # Allokerer tegnbudget til stability/target/action dele
 # og vaelger passende variant for hver del. Naar context$target_direction
@@ -688,17 +712,10 @@ build_fallback_analysis <- function(context,
   outliers_for_text <- flags$outliers_for_text
 
   # --- Budget-allokering ---
-  # Med target: stability ~50%, target ~25%, action ~25%.
-  # Uden target: target-budget realloceres til stability (65%) + action (35%).
-  if (has_target) {
-    stability_budget <- floor(max_chars * 0.50)
-    target_budget <- floor(max_chars * 0.25)
-    action_budget <- max_chars - stability_budget - target_budget
-  } else {
-    stability_budget <- floor(max_chars * 0.65)
-    target_budget <- 0L
-    action_budget <- max_chars - stability_budget
-  }
+  budgets <- .allocate_text_budget(max_chars, has_target)
+  stability_budget <- budgets$stability_budget
+  target_budget <- budgets$target_budget
+  action_budget <- budgets$action_budget
 
   if (!is.function(texts_loader)) {
     stop("texts_loader must be a function", call. = FALSE)

--- a/R/spc_analysis.R
+++ b/R/spc_analysis.R
@@ -599,6 +599,63 @@ bfh_generate_analysis <- function(x,
 }
 
 
+# Detect SPC signal flags from a context object.
+#
+# Returnerer named list med:
+#   has_runs, has_crossings, has_outliers (logical)
+#   is_stable                              (logical, derived: ingen signaler)
+#   no_variation                          (logical, derived: alle signal-stats NA)
+#   has_target                            (logical, derived: target_value + centerline gyldige)
+#   outliers_for_text                     (numeric, til pluralize_da + placeholder)
+#
+# Pure: samme input -> samme output. Bruges af build_fallback_analysis() til
+# at drive cascade-dispatch og budget-allokering uden at flade detection-
+# logikken sammen med i18n-opslag.
+.detect_signal_flags <- function(context) {
+  spc_stats <- context$spc_stats
+  target_value <- context$target_value
+  centerline <- context$centerline
+
+  has_runs <- is_valid_scalar(spc_stats$runs_actual) &&
+    is_valid_scalar(spc_stats$runs_expected) &&
+    spc_stats$runs_actual > spc_stats$runs_expected
+
+  has_crossings <- is_valid_scalar(spc_stats$crossings_actual) &&
+    is_valid_scalar(spc_stats$crossings_expected) &&
+    spc_stats$crossings_actual < spc_stats$crossings_expected
+
+  # Brug recent_count (seneste 6 obs) saa analyseteksten kun beskriver AKTUELLE
+  # outliers. Fald tilbage til outliers_actual naar kun summary-baserede stats
+  # er tilgaengelige.
+  outliers_for_text <- spc_stats$outliers_recent_count %||% spc_stats$outliers_actual
+  has_outliers <- is_valid_scalar(outliers_for_text) && outliers_for_text > 0
+
+  is_stable <- !has_runs && !has_crossings && !has_outliers
+
+  runs_missing <- is.null(spc_stats$runs_actual) ||
+    length(spc_stats$runs_actual) == 0 ||
+    is.na(spc_stats$runs_actual)
+  crossings_missing <- is.null(spc_stats$crossings_actual) ||
+    length(spc_stats$crossings_actual) == 0 ||
+    is.na(spc_stats$crossings_actual)
+  no_variation <- runs_missing && crossings_missing
+
+  has_target <- !is.null(target_value) && !is.na(target_value) &&
+    is.numeric(target_value) &&
+    !is.null(centerline) && !is.na(centerline)
+
+  list(
+    has_runs = has_runs,
+    has_crossings = has_crossings,
+    has_outliers = has_outliers,
+    is_stable = is_stable,
+    no_variation = no_variation,
+    has_target = has_target,
+    outliers_for_text = outliers_for_text
+  )
+}
+
+
 # Intern funktion: Byg komplet fallback-analysetekst
 # Allokerer tegnbudget til stability/target/action dele
 # og vaelger passende variant for hver del. Naar context$target_direction
@@ -620,37 +677,15 @@ build_fallback_analysis <- function(context,
   centerline <- context$centerline
   n_points <- context$n_points
 
-  # --- Detect signaler (sikker mod NULL og NA) ---
-  has_runs <- is_valid_scalar(spc_stats$runs_actual) &&
-    is_valid_scalar(spc_stats$runs_expected) &&
-    spc_stats$runs_actual > spc_stats$runs_expected
-
-  has_crossings <- is_valid_scalar(spc_stats$crossings_actual) &&
-    is_valid_scalar(spc_stats$crossings_expected) &&
-    spc_stats$crossings_actual < spc_stats$crossings_expected
-
-  # Brug recent_count (seneste 6 obs) saa analyseteksten kun beskriver AKTUELLE
-  # outliers. Fald tilbage til outliers_actual naar kun summary-baserede stats
-  # er tilgaengelige.
-  outliers_for_text <- spc_stats$outliers_recent_count %||% spc_stats$outliers_actual
-  has_outliers <- is_valid_scalar(outliers_for_text) &&
-    outliers_for_text > 0
-
-  is_stable <- !has_runs && !has_crossings && !has_outliers
-
-  # --- Detect ingen variation (alle SPC-stats er NA eller NULL) ---
-  runs_missing <- is.null(spc_stats$runs_actual) ||
-    length(spc_stats$runs_actual) == 0 ||
-    is.na(spc_stats$runs_actual)
-  crossings_missing <- is.null(spc_stats$crossings_actual) ||
-    length(spc_stats$crossings_actual) == 0 ||
-    is.na(spc_stats$crossings_actual)
-  no_variation <- runs_missing && crossings_missing
-
-  # --- Target-tilstand (afgoer budget-fordelingen) ---
-  has_target <- !is.null(target_value) && !is.na(target_value) &&
-    is.numeric(target_value) &&
-    !is.null(centerline) && !is.na(centerline)
+  # --- Detect signaler + target-tilstand ---
+  flags <- .detect_signal_flags(context)
+  has_runs <- flags$has_runs
+  has_crossings <- flags$has_crossings
+  has_outliers <- flags$has_outliers
+  is_stable <- flags$is_stable
+  no_variation <- flags$no_variation
+  has_target <- flags$has_target
+  outliers_for_text <- flags$outliers_for_text
 
   # --- Budget-allokering ---
   # Med target: stability ~50%, target ~25%, action ~25%.

--- a/R/spc_analysis.R
+++ b/R/spc_analysis.R
@@ -132,6 +132,7 @@ resolve_target <- function(target_input) {
 #' BFHcharts:::.normalize_percent_target(90, ">= 90", "count") # 90
 #'
 #' @keywords internal
+#' @noRd
 .normalize_percent_target <- function(value, display, y_axis_unit) {
   if (is.null(y_axis_unit) || !identical(y_axis_unit, "percent")) {
     return(value)
@@ -146,56 +147,7 @@ resolve_target <- function(target_input) {
 }
 
 
-# Vaelg ental eller flertal ud fra n. n == 1 -> singular, alt andet -> plural.
-# NA og NULL behandles som flertal (neutral default).
-pluralize_da <- function(n, singular, plural) {
-  if (is.null(n) || length(n) == 0 || is.na(n)) {
-    return(plural)
-  }
-  if (n == 1) singular else plural
-}
-
-
-# Garanter at tekst ikke overskrider max_chars. Trim ved sidste saetnings- eller
-# klausulgraense (punktum, komma) foer graensen. Undgaa at klippe midt i et ord.
-ensure_within_max <- function(text, max_chars) {
-  if (is.null(text) || is.na(text)) {
-    return("")
-  }
-  if (nchar(text) <= max_chars) {
-    return(text)
-  }
-
-  cut <- substr(text, 1, max_chars)
-
-  # Proev foerst at trimme ved sidste punktum-graense
-  last_period <- max(
-    gregexpr("\\.\\s", cut, perl = TRUE)[[1]],
-    gregexpr("\\.$", cut, perl = TRUE)[[1]]
-  )
-  if (is.finite(last_period) && last_period > 0) {
-    return(trimws(substr(text, 1, last_period)))
-  }
-
-  # Ellers trim ved sidste komma
-  last_comma <- max(gregexpr(",\\s", cut, perl = TRUE)[[1]])
-  if (is.finite(last_comma) && last_comma > 0) {
-    trimmed <- trimws(substr(text, 1, last_comma - 1))
-    if (!grepl("[.!?]$", trimmed)) trimmed <- paste0(trimmed, ".")
-    return(trimmed)
-  }
-
-  # Sidste udvej: trim ved sidste space
-  last_space <- max(gregexpr("\\s", cut, perl = TRUE)[[1]])
-  if (is.finite(last_space) && last_space > 0) {
-    trimmed <- trimws(substr(text, 1, last_space - 1))
-    if (!grepl("[.!?]$", trimmed)) trimmed <- paste0(trimmed, ".")
-    return(trimmed)
-  }
-
-  # Fallback (ord uden spaces): haard trim
-  substr(text, 1, max_chars)
-}
+# pluralize_da() and ensure_within_max() are now in R/utils_text_da.R
 
 
 #' Build Analysis Context from bfh_qic_result
@@ -842,88 +794,8 @@ format_target_value <- function(x, y_axis_unit = NULL) {
 }
 
 
-# Tilfoej padding-tekst hvis teksten er under minimumlaengde.
-# max_chars sikrer at padding ikke spraenger det absolutte loft.
-pad_to_minimum <- function(text, min_chars, n_points, texts, max_chars = Inf) {
-  if (nchar(text) >= min_chars) {
-    return(text)
-  }
-
-  # Plads til padding: respekter baade min og max
-  available <- max_chars - nchar(text) - 1L # -1 for space-separator
-
-  if (!is.null(n_points) && !is.na(n_points) && available > 0) {
-    padding <- pick_text(texts$padding$data_points,
-      data = list(n_points = n_points),
-      budget = min(min_chars - nchar(text), available)
-    )
-    if (nchar(padding) > 0 && nchar(text) + nchar(padding) + 1L <= max_chars) {
-      text <- paste(text, padding)
-    }
-  }
-
-  available <- max_chars - nchar(text) - 1L
-  if (nchar(text) < min_chars && available > 0) {
-    padding <- pick_text(texts$padding$generic,
-      budget = min(min_chars - nchar(text), available)
-    )
-    if (nchar(padding) > 0 && nchar(text) + nchar(padding) + 1L <= max_chars) {
-      text <- paste(text, padding)
-    }
-  }
-
-  text
-}
-
-
 # load_spc_texts() er nu defineret i R/utils_i18n.R og laeser fra
 # inst/i18n/{language}.yaml via load_translations()
-
-
-# Vaelg tekstvariant baseret paa pladsbudget og erstat {placeholders}.
-# Named variants (short/standard/detailed): vaelg laengste der passer.
-# Bagudkompatibel med gammelt format (liste af strenge).
-pick_text <- function(variants, data = list(), budget = Inf) {
-  if (length(variants) == 0) {
-    return("")
-  }
-
-  # Bagudkompatibilitet: gammelt format er en unamed liste af strenge
-  if (is.null(names(variants)) && is.character(variants[[1]])) {
-    text <- variants[[1]]
-    return(substitute_placeholders(text, data))
-  }
-
-  # Nyt format: named list (short, standard, detailed)
-  # Proev fra laengst til kortest, vaelg den laengste der passer i budgettet
-  candidates <- c("detailed", "standard", "short")
-  for (candidate in candidates) {
-    if (!is.null(variants[[candidate]])) {
-      text <- substitute_placeholders(variants[[candidate]], data)
-      if (nchar(text) <= budget) {
-        return(text)
-      }
-    }
-  }
-
-  # Fallback: korteste tilgaengelige variant (selv hvis den overstiger budget)
-  available <- intersect(rev(candidates), names(variants))
-  if (length(available) > 0) {
-    return(substitute_placeholders(variants[[available[1]]], data))
-  }
-
-  return("")
-}
-
-
-# Erstat {placeholders} med faktiske vaerdier i en tekststreng
-substitute_placeholders <- function(text, data = list()) {
-  for (key in names(data)) {
-    text <- gsub(
-      paste0("\\{", key, "\\}"),
-      as.character(data[[key]] %||% ""),
-      text
-    )
-  }
-  text
-}
+#
+# pad_to_minimum(), pick_text() og substitute_placeholders() er nu i
+# R/utils_text_da.R

--- a/R/spc_analysis.R
+++ b/R/spc_analysis.R
@@ -680,6 +680,38 @@ bfh_generate_analysis <- function(x,
 }
 
 
+# Vælg i18n-nøgle til stabilitets-arm af fallback-analysen.
+#
+# Pure dispatch: tager named-logical flags (has_runs, has_crossings,
+# has_outliers) og returnerer character scalar, der refererer til
+# `texts$stability[[key]]` i sprog-YAML'en. Caller håndterer
+# no_variation-grenen separat (dén bruger sin egen no_variation key
+# med centerline-placeholder).
+#
+# Mulige returvaerdier: "no_signals", "runs_only", "crossings_only",
+# "outliers_only", "runs_crossings", "runs_outliers",
+# "crossings_outliers", "all_signals".
+.select_stability_key <- function(flags) {
+  if (!flags$has_runs && !flags$has_crossings && !flags$has_outliers) {
+    "no_signals"
+  } else if (flags$has_runs && !flags$has_crossings && !flags$has_outliers) {
+    "runs_only"
+  } else if (!flags$has_runs && flags$has_crossings && !flags$has_outliers) {
+    "crossings_only"
+  } else if (!flags$has_runs && !flags$has_crossings && flags$has_outliers) {
+    "outliers_only"
+  } else if (flags$has_runs && flags$has_crossings && !flags$has_outliers) {
+    "runs_crossings"
+  } else if (flags$has_runs && !flags$has_crossings && flags$has_outliers) {
+    "runs_outliers"
+  } else if (!flags$has_runs && flags$has_crossings && flags$has_outliers) {
+    "crossings_outliers"
+  } else {
+    "all_signals"
+  }
+}
+
+
 # Intern funktion: Byg komplet fallback-analysetekst
 # Allokerer tegnbudget til stability/target/action dele
 # og vaelger passende variant for hver del. Naar context$target_direction
@@ -752,23 +784,7 @@ build_fallback_analysis <- function(context,
       budget = stability_budget
     )
   } else {
-    key <- if (!has_runs && !has_crossings && !has_outliers) {
-      "no_signals"
-    } else if (has_runs && !has_crossings && !has_outliers) {
-      "runs_only"
-    } else if (!has_runs && has_crossings && !has_outliers) {
-      "crossings_only"
-    } else if (!has_runs && !has_crossings && has_outliers) {
-      "outliers_only"
-    } else if (has_runs && has_crossings && !has_outliers) {
-      "runs_crossings"
-    } else if (has_runs && !has_crossings && has_outliers) {
-      "runs_outliers"
-    } else if (!has_runs && has_crossings && has_outliers) {
-      "crossings_outliers"
-    } else {
-      "all_signals"
-    }
+    key <- .select_stability_key(flags)
     stability <- pick_text(texts$stability[[key]],
       data = placeholder_data,
       budget = stability_budget

--- a/R/utils_add_right_labels_marquee.R
+++ b/R/utils_add_right_labels_marquee.R
@@ -48,6 +48,81 @@
 }
 
 
+# Maal label-hoejder for textA og textB med marquee + estimate_label_heights_npc.
+#
+# Returnerer named list (height_A, height_B, label_height_npc) hvor
+# label_height_npc er den udvalgte hoejde til gap-beregninger:
+#   - Hvis begge tekster er tomme: brug height_A som fallback.
+#   - Hvis kun A er tom: brug height_B.
+#   - Hvis kun B er tom: brug height_A.
+#   - Begge non-empty: max(height_A$npc, height_B$npc).
+#
+# Pure given inputs. Ingen device side effects (estimator skal vaere
+# device-aware, men det er callers ansvar at have device aabent foer kald).
+# marquee_height_estimator default = estimate_label_heights_npc; injectable
+# for tests.
+.measure_label_heights <- function(textA, textB, style, panel_height_inches,
+                                   device_size, marquee_size,
+                                   temp_device_opened,
+                                   marquee_height_estimator = estimate_label_heights_npc,
+                                   verbose = FALSE) {
+  # VIGTIGT: Hvis device ikke er klar (actual=FALSE), er estimater unoejagtige
+  if (!device_size$actual && verbose) {
+    warning(
+      "[LABEL_HEIGHT] Estimating label heights without actual device measurements - ",
+      "results may be inaccurate!"
+    )
+  }
+
+  # Konverter NA til NULL for estimate_label_heights_npc's fallback mechanism
+  device_width_for_estimate <- if (device_size$actual) device_size$width else NULL
+  device_height_for_estimate <- if (device_size$actual) device_size$height else NULL
+
+  heights <- marquee_height_estimator(
+    texts = c(textA, textB),
+    style = style,
+    panel_height_inches = panel_height_inches,
+    device_width = device_width_for_estimate,
+    device_height = device_height_for_estimate,
+    marquee_size = marquee_size,
+    return_details = TRUE,
+    device_ready = temp_device_opened
+  )
+  height_A <- heights[[1]]
+  height_B <- heights[[2]]
+
+  # Vaelg label_height_npc baseret paa empty-label fallback-regler
+  textA_is_empty <- is.null(textA) || nchar(trimws(textA)) == 0
+  textB_is_empty <- is.null(textB) || nchar(trimws(textB)) == 0
+
+  label_height_npc <- if (textA_is_empty && textB_is_empty) {
+    height_A # Ingen labels - fallback
+  } else if (textB_is_empty) {
+    height_A # Kun textA
+  } else if (textA_is_empty) {
+    height_B # Kun textB
+  } else {
+    if (height_A$npc > height_B$npc) height_A else height_B
+  }
+
+  if (verbose) {
+    message(
+      "Auto-beregnet label_height_npc: ", round(label_height_npc$npc, 4),
+      " (A: ", round(height_A$npc, 4), ", B: ", round(height_B$npc, 4), ")",
+      " [", round(label_height_npc$inches, 4), " inches]",
+      if (textA_is_empty) " [A tom]" else "",
+      if (textB_is_empty) " [B tom]" else ""
+    )
+  }
+
+  list(
+    height_A = height_A,
+    height_B = height_B,
+    label_height_npc = label_height_npc
+  )
+}
+
+
 .resolve_font_family <- function(family = NULL) {
   .ensure_bfhtheme()
   # Detekter device-type: "cairo", "postscript" eller "other"
@@ -376,65 +451,17 @@ add_right_labels_marquee <- function(
 
   # Auto-beregn label_height
   if (is.null(params$label_height_npc)) {
-    # VIGTIGT: Hvis device ikke er klar (actual=FALSE), er estimater unoejagtige
-    if (!device_size$actual && verbose) {
-      warning(
-        "[LABEL_HEIGHT] Estimating label heights without actual device measurements - ",
-        "results may be inaccurate!"
-      )
-    }
-
-    # Konverter NA til NULL for estimate_label_heights_npc's fallback mechanism
-    # (fallbacks aktiveres kun ved NULL, ikke NA)
-    device_width_for_estimate <- if (device_size$actual) device_size$width else NULL
-    device_height_for_estimate <- if (device_size$actual) device_size$height else NULL
-
-    heights <- estimate_label_heights_npc(
-      texts = c(textA, textB),
+    height_result <- .measure_label_heights(
+      textA = textA,
+      textB = textB,
       style = right_aligned_style,
       panel_height_inches = panel_height_inches,
-      device_width = device_width_for_estimate,
-      device_height = device_height_for_estimate,
+      device_size = device_size,
       marquee_size = marquee_size,
-      return_details = TRUE,
-      device_ready = temp_device_opened
+      temp_device_opened = temp_device_opened,
+      verbose = verbose
     )
-    height_A <- heights[[1]]
-    height_B <- heights[[2]]
-
-    # FIX: Ignorer empty labels ved valg af hoejde til gap calculation
-    # Hvis textB er tom (kun CL label), brug kun height_A
-    # Dette sikrer at gap er baseret paa faktisk synlig label hoejde
-    textA_is_empty <- is.null(textA) || nchar(trimws(textA)) == 0
-    textB_is_empty <- is.null(textB) || nchar(trimws(textB)) == 0
-
-    if (textA_is_empty && textB_is_empty) {
-      # Ingen labels - brug fallback
-      params$label_height_npc <- height_A
-    } else if (textB_is_empty) {
-      # Kun textA - brug height_A uanset stoerrelse
-      params$label_height_npc <- height_A
-    } else if (textA_is_empty) {
-      # Kun textB - brug height_B uanset stoerrelse
-      params$label_height_npc <- height_B
-    } else {
-      # Begge labels - brug max
-      if (height_A$npc > height_B$npc) {
-        params$label_height_npc <- height_A
-      } else {
-        params$label_height_npc <- height_B
-      }
-    }
-
-    if (verbose) {
-      message(
-        "Auto-beregnet label_height_npc: ", round(params$label_height_npc$npc, 4),
-        " (A: ", round(height_A$npc, 4), ", B: ", round(height_B$npc, 4), ")",
-        " [", round(params$label_height_npc$inches, 4), " inches]",
-        if (textA_is_empty) " [A tom]" else "",
-        if (textB_is_empty) " [B tom]" else ""
-      )
-    }
+    params$label_height_npc <- height_result$label_height_npc
   }
 
   # Default parameters

--- a/R/utils_add_right_labels_marquee.R
+++ b/R/utils_add_right_labels_marquee.R
@@ -9,6 +9,45 @@
 # (systemfonts-registrering != PostScript font database)
 .font_cache <- new.env(parent = emptyenv())
 
+# Resolve label geometry parameters from label_size + cached placement config.
+#
+# Pure given inputs. Returns named list med:
+#   scale_factor          (numeric, label_size / PDF_LABEL_SIZE)
+#   marquee_lineheight    (numeric, fra config eller default 0.9)
+#   right_aligned_style   (marquee style object, cachet)
+#   marquee_size_factor   (numeric, fra config eller default 6)
+#   marquee_size          (numeric, marquee_size_factor * scale_factor)
+#
+# Erstatter inline geometri-blok i orchestrator (lines ~148-170 i tidligere
+# version). Bruges ogsaa direkte af unit-tests uden device side-effects.
+.resolve_label_geometry <- function(label_size, placement_cfg) {
+  scale_factor <- label_size / PDF_LABEL_SIZE
+
+  marquee_lineheight <- if (!is.null(placement_cfg$marquee_lineheight)) {
+    placement_cfg$marquee_lineheight
+  } else {
+    0.9
+  }
+
+  right_aligned_style <- get_right_aligned_marquee_style(lineheight = marquee_lineheight)
+
+  marquee_size_factor <- if (!is.null(placement_cfg$marquee_size_factor)) {
+    placement_cfg$marquee_size_factor
+  } else {
+    6
+  }
+  marquee_size <- marquee_size_factor * scale_factor
+
+  list(
+    scale_factor = scale_factor,
+    marquee_lineheight = marquee_lineheight,
+    right_aligned_style = right_aligned_style,
+    marquee_size_factor = marquee_size_factor,
+    marquee_size = marquee_size
+  )
+}
+
+
 .resolve_font_family <- function(family = NULL) {
   .ensure_bfhtheme()
   # Detekter device-type: "cairo", "postscript" eller "other"
@@ -145,29 +184,15 @@ add_right_labels_marquee <- function(
     }
   }
 
-  # Beregn responsive stoerrelser baseret paa label_size (baseline = PDF_LABEL_SIZE)
-  scale_factor <- label_size / PDF_LABEL_SIZE
-
   # PERFORMANCE: Load config EN gang i starten
   placement_cfg <- get_label_placement_config()
 
-  # Hent marquee_lineheight fra config
-  marquee_lineheight <- if (!is.null(placement_cfg$marquee_lineheight)) {
-    placement_cfg$marquee_lineheight
-  } else {
-    0.9
-  }
-
-  # PERFORMANCE: Hent cached right-aligned style
-  right_aligned_style <- get_right_aligned_marquee_style(lineheight = marquee_lineheight)
-
-  # Beregn marquee_size tidligt, saa vi kan bruge den til maalinger
-  marquee_size_factor <- if (!is.null(placement_cfg$marquee_size_factor)) {
-    placement_cfg$marquee_size_factor
-  } else {
-    6
-  }
-  marquee_size <- marquee_size_factor * scale_factor
+  # Beregn responsive stoerrelser + cache style i samlet helper
+  geom <- .resolve_label_geometry(label_size, placement_cfg)
+  scale_factor <- geom$scale_factor
+  marquee_lineheight <- geom$marquee_lineheight
+  right_aligned_style <- geom$right_aligned_style
+  marquee_size <- geom$marquee_size
 
   # PERFORMANCE: Use cached build if provided, otherwise build plot
   built_plot <- if (!is.null(.built_plot)) {

--- a/R/utils_add_right_labels_marquee.R
+++ b/R/utils_add_right_labels_marquee.R
@@ -123,6 +123,171 @@
 }
 
 
+# Acquire a graphics device suitable for label measurement + measure panel
+# height from the supplied gtable.
+#
+# Two strategies (matches behavior i tidligere inline-blok i orchestrator):
+#   1. Hvis viewport_width + viewport_height er angivet:
+#      - Hvis aktiv device matcher (1% tolerance), genbrug det.
+#      - Ellers aabn temp Cairo PDF med viewport-dimensioner.
+#   2. Hvis viewport-dims mangler:
+#      - Brug aktiv device hvis tilgaengeligt.
+#      - Ellers giv NA-device_size + warning.
+#
+# Returnerer named list:
+#   device_size        list(width, height, actual, source)
+#   panel_height_inches numeric eller NULL (NULL hvis device ikke kunne maale)
+#   temp_device_opened logical
+#   cleanup_fn         closure som lukker temp-device + sletter temp-fil
+#                      (orchestrator binder via withr::defer)
+.acquire_device_for_measurement <- function(viewport_width, viewport_height,
+                                            gtable, verbose = FALSE) {
+  device_size <- NULL
+  temp_device_opened <- FALSE
+  cleanup_fn <- function() invisible(NULL)
+
+  if (!is.null(viewport_width) && !is.null(viewport_height)) {
+    # STRATEGY 1: Viewport dimensions provided (PRIMARY PATH)
+    if (verbose) {
+      message(sprintf(
+        "[VIEWPORT_STRATEGY] Using provided viewport dimensions: %.2f x %.2f inches",
+        viewport_width, viewport_height
+      ))
+    }
+
+    # Check if device is already open with correct dimensions
+    device_already_open <- FALSE
+    if (grDevices::dev.cur() > 1) {
+      current_size <- grDevices::dev.size("in")
+      if (abs(current_size[1] - viewport_width) / viewport_width < 0.01 &&
+        abs(current_size[2] - viewport_height) / viewport_height < 0.01) {
+        device_already_open <- TRUE
+        if (verbose) {
+          message("[VIEWPORT_STRATEGY] Device already open with matching dimensions")
+        }
+      }
+    }
+
+    if (!device_already_open) {
+      if (verbose) {
+        message("[VIEWPORT_STRATEGY] Opening temporary Cairo PDF device for grob measurements")
+      }
+      temp_pdf <- tempfile(fileext = ".pdf")
+      grDevices::cairo_pdf(
+        filename = temp_pdf,
+        width = viewport_width, height = viewport_height
+      )
+      temp_dev_num <- grDevices::dev.cur()
+      temp_device_opened <- TRUE
+
+      cleanup_fn <- function() {
+        if (temp_dev_num %in% grDevices::dev.list()) {
+          tryCatch(grDevices::dev.off(temp_dev_num), error = function(e) NULL)
+        }
+        unlink(temp_pdf, force = TRUE)
+      }
+    }
+
+    device_size <- list(
+      width = viewport_width,
+      height = viewport_height,
+      actual = TRUE,
+      source = "viewport"
+    )
+  } else {
+    # STRATEGY 2: Fallback to existing device detection (LEGACY PATH)
+    if (verbose) {
+      message("[DEVICE_FALLBACK] No viewport dimensions - attempting device detection")
+    }
+
+    device_size <- tryCatch(
+      {
+        if (grDevices::dev.cur() > 1) {
+          dev_inches <- grDevices::dev.size("in")
+          list(
+            width = dev_inches[1],
+            height = dev_inches[2],
+            actual = TRUE,
+            source = "device"
+          )
+        } else {
+          if (verbose) {
+            warning(
+              "[DEVICE_FALLBACK] No graphics device open - label measurements may be inaccurate"
+            )
+          }
+          list(
+            width = NA_real_,
+            height = NA_real_,
+            actual = FALSE,
+            source = "none"
+          )
+        }
+      },
+      error = function(e) {
+        warning(
+          "[DEVICE_FALLBACK] Device size detection failed: ", e$message
+        )
+        list(
+          width = NA_real_,
+          height = NA_real_,
+          actual = FALSE,
+          source = "error"
+        )
+      }
+    )
+  }
+
+  if (verbose) {
+    if (device_size$actual) {
+      message(sprintf(
+        "Device size: %.2f x %.2f inches (ACTUAL measurements)",
+        device_size$width, device_size$height
+      ))
+    } else {
+      message("[DEVICE_SIZE] WARNING: No actual device size available - proceeding without measurements")
+    }
+  }
+
+  # Maal panel hoejde med faktisk device stoerrelse (kun hvis device er klar)
+  panel_height_inches <- NULL
+  if (device_size$actual) {
+    panel_height_inches <- tryCatch(
+      {
+        measure_panel_height_from_gtable(
+          gtable,
+          device_width = device_size$width,
+          device_height = device_size$height,
+          device_ready = temp_device_opened
+        )
+      },
+      error = function(e) {
+        if (verbose) {
+          message("Panel height measurement failed: ", e$message)
+        }
+        NULL
+      }
+    )
+
+    if (verbose && !is.null(panel_height_inches)) {
+      message(sprintf(
+        "Panel height: %.3f inches (measured from actual device)",
+        panel_height_inches
+      ))
+    }
+  } else if (verbose) {
+    message("[PANEL_HEIGHT] Cannot measure without actual device size - skipping measurement")
+  }
+
+  list(
+    device_size = device_size,
+    panel_height_inches = panel_height_inches,
+    temp_device_opened = temp_device_opened,
+    cleanup_fn = cleanup_fn
+  )
+}
+
+
 .resolve_font_family <- function(family = NULL) {
   .ensure_bfhtheme()
   # Detekter device-type: "cairo", "postscript" eller "other"
@@ -296,158 +461,18 @@ add_right_labels_marquee <- function(
     )
   }
 
-  # Detekter device stoerrelse for korrekt panel height measurement
-  # STRATEGI:
-  # 1. Hvis viewport dimensions provided -> brug dem (with_temporary_device() hvis noedvendigt)
-  # 2. Ellers -> detekter existing device (fallback for legacy callers)
-
-  device_size <- NULL
-  temp_device_opened <- FALSE
-
-  if (!is.null(viewport_width) && !is.null(viewport_height)) {
-    # STRATEGY 1: Viewport dimensions provided (PRIMARY PATH)
-    if (verbose) {
-      message(sprintf(
-        "[VIEWPORT_STRATEGY] Using provided viewport dimensions: %.2f x %.2f inches",
-        viewport_width, viewport_height
-      ))
-    }
-
-    # Check if device is already open with correct dimensions
-    device_already_open <- FALSE
-    if (grDevices::dev.cur() > 1) {
-      current_size <- grDevices::dev.size("in")
-      # Allow 1% tolerance for dimension matching
-      if (abs(current_size[1] - viewport_width) / viewport_width < 0.01 &&
-        abs(current_size[2] - viewport_height) / viewport_height < 0.01) {
-        device_already_open <- TRUE
-        if (verbose) {
-          message("[VIEWPORT_STRATEGY] Device already open with matching dimensions")
-        }
-      }
-    }
-
-    # Open temporary device if needed for grob measurements
-    if (!device_already_open) {
-      if (verbose) {
-        message("[VIEWPORT_STRATEGY] Opening temporary Cairo PDF device for grob measurements")
-      }
-      temp_pdf <- tempfile(fileext = ".pdf")
-      grDevices::cairo_pdf(
-        filename = temp_pdf,
-        width = viewport_width, height = viewport_height
-      )
-      temp_dev_num <- grDevices::dev.cur()
-      temp_device_opened <- TRUE
-
-      # Single on.exit covers both error path and normal path cleanup
-      on.exit(
-        {
-          if (temp_dev_num %in% grDevices::dev.list()) {
-            tryCatch(grDevices::dev.off(temp_dev_num), error = function(e) NULL)
-          }
-          unlink(temp_pdf, force = TRUE)
-        },
-        add = TRUE,
-        after = FALSE
-      )
-    }
-
-    device_size <- list(
-      width = viewport_width,
-      height = viewport_height,
-      actual = TRUE,
-      source = "viewport"
-    )
-  } else {
-    # STRATEGY 2: Fallback to existing device detection (LEGACY PATH)
-    if (verbose) {
-      message("[DEVICE_FALLBACK] No viewport dimensions - attempting device detection")
-    }
-
-    device_size <- tryCatch(
-      {
-        if (grDevices::dev.cur() > 1) {
-          dev_inches <- grDevices::dev.size("in")
-          list(
-            width = dev_inches[1],
-            height = dev_inches[2],
-            actual = TRUE,
-            source = "device"
-          )
-        } else {
-          if (verbose) {
-            warning(
-              "[DEVICE_FALLBACK] No graphics device open - label measurements may be inaccurate"
-            )
-          }
-          list(
-            width = NA_real_,
-            height = NA_real_,
-            actual = FALSE,
-            source = "none"
-          )
-        }
-      },
-      error = function(e) {
-        warning(
-          "[DEVICE_FALLBACK] Device size detection failed: ", e$message
-        )
-        list(
-          width = NA_real_,
-          height = NA_real_,
-          actual = FALSE,
-          source = "error"
-        )
-      }
-    )
-  }
-
-  if (verbose) {
-    if (device_size$actual) {
-      message(sprintf(
-        "Device size: %.2f x %.2f inches (ACTUAL measurements)",
-        device_size$width, device_size$height
-      ))
-    } else {
-      message("[DEVICE_SIZE] WARNING: No actual device size available - proceeding without measurements")
-    }
-  }
-
-  # Maal panel hoejde med faktisk device stoerrelse (kun hvis device er klar)
-  panel_height_inches <- NULL
-
-  if (device_size$actual) {
-    # Faktiske maalinger tilgaengelige - maal panel height
-    panel_height_inches <- tryCatch(
-      {
-        measure_panel_height_from_gtable(
-          gtable,
-          device_width = device_size$width,
-          device_height = device_size$height,
-          device_ready = temp_device_opened
-        )
-      },
-      error = function(e) {
-        if (verbose) {
-          message("Panel height measurement failed: ", e$message)
-        }
-        NULL
-      }
-    )
-
-    if (verbose && !is.null(panel_height_inches)) {
-      message(sprintf(
-        "Panel height: %.3f inches (measured from actual device)",
-        panel_height_inches
-      ))
-    }
-  } else {
-    # Ingen faktiske device dimensioner - kan ikke maale panel height
-    if (verbose) {
-      message("[PANEL_HEIGHT] Cannot measure without actual device size - skipping measurement")
-    }
-  }
+  # Acquire measurement device + panel height (helper handles
+  # viewport-vs-fallback strategy + device-leak cleanup)
+  dev_ctx <- .acquire_device_for_measurement(
+    viewport_width = viewport_width,
+    viewport_height = viewport_height,
+    gtable = gtable,
+    verbose = verbose
+  )
+  on.exit(dev_ctx$cleanup_fn(), add = TRUE, after = FALSE)
+  device_size <- dev_ctx$device_size
+  panel_height_inches <- dev_ctx$panel_height_inches
+  temp_device_opened <- dev_ctx$temp_device_opened
 
   # Auto-beregn label_height
   if (is.null(params$label_height_npc)) {

--- a/R/utils_add_right_labels_marquee.R
+++ b/R/utils_add_right_labels_marquee.R
@@ -288,6 +288,131 @@
 }
 
 
+# Detekter x-aksens type (Date / POSIXct datetime / numeric) ud fra
+# built_plot. Returnerer named list (x_max, x_is_date, x_is_datetime).
+#
+# x_max er konverteret tilbage til source-typen (Date / POSIXct / numeric)
+# via scale's inverse-transformation, saa label_data tibble kan bruge
+# samme x-type som diagrammet.
+.detect_x_axis_type <- function(built_plot) {
+  x_range <- built_plot$layout$panel_params[[1]]$x.range
+  x_max_value <- x_range[2]
+
+  x_is_date <- FALSE
+  x_is_datetime <- FALSE
+  x_scale <- NULL
+
+  tryCatch(
+    {
+      x_scale <- built_plot$layout$panel_scales_x[[1]]
+
+      if (!is.null(x_scale)) {
+        scale_class <- class(x_scale)[1]
+        trans_name <- if (!is.null(x_scale$trans)) x_scale$trans$name else ""
+
+        if (grepl("^date$", tolower(trans_name)) ||
+          (grepl("Date", scale_class) && !grepl("Time|time", scale_class))) {
+          x_is_date <- TRUE
+        } else if (grepl("time|hms", tolower(trans_name)) ||
+          grepl("Time", scale_class)) {
+          x_is_datetime <- TRUE
+        }
+      }
+    },
+    error = function(e) {
+      # Fallback: hvis scale detection fejler, antag numerisk
+    }
+  )
+
+  x_max <- if (x_is_date && !is.null(x_scale)) {
+    if (!is.null(x_scale$trans) && !is.null(x_scale$trans$inverse)) {
+      converted <- x_scale$trans$inverse(x_max_value)
+      if (!inherits(converted, "Date")) {
+        as.Date(converted, origin = "1970-01-01")
+      } else {
+        converted
+      }
+    } else {
+      as.Date(x_max_value, origin = "1970-01-01")
+    }
+  } else if (x_is_datetime && !is.null(x_scale)) {
+    tz <- if (!is.null(x_scale$timezone)) x_scale$timezone else "UTC"
+    if (!is.null(x_scale$trans) && !is.null(x_scale$trans$inverse)) {
+      converted <- x_scale$trans$inverse(x_max_value)
+      converted <- as.POSIXct(converted, origin = "1970-01-01")
+      attr(converted, "tzone") <- tz
+      converted
+    } else {
+      as.POSIXct(x_max_value, origin = "1970-01-01", tz = tz)
+    }
+  } else {
+    x_max_value
+  }
+
+  list(
+    x_max = x_max,
+    x_is_date = x_is_date,
+    x_is_datetime = x_is_datetime
+  )
+}
+
+
+# Byg label_data tibble med korrekt x-type (Date / POSIXct / numeric).
+# Returnerer tom tibble hvis baade yA_data og yB_data er NA.
+.build_label_data <- function(textA, textB, yA_data, yB_data, x_max,
+                              x_is_date, x_is_datetime, gpA, gpB) {
+  label_data <- if (x_is_date) {
+    tibble::tibble(
+      x = as.Date(character()),
+      y = numeric(),
+      label = character(),
+      color = character()
+    )
+  } else if (x_is_datetime) {
+    tibble::tibble(
+      x = as.POSIXct(character()),
+      y = numeric(),
+      label = character(),
+      color = character()
+    )
+  } else {
+    tibble::tibble(
+      x = numeric(),
+      y = numeric(),
+      label = character(),
+      color = character()
+    )
+  }
+
+  color_A <- if (!is.null(gpA$col)) gpA$col else "#009CE8"
+  color_B <- if (!is.null(gpB$col)) gpB$col else "#565656"
+
+  if (!is.na(yA_data)) {
+    label_data <- label_data |>
+      dplyr::bind_rows(tibble::tibble(
+        x = x_max,
+        y = yA_data,
+        label = textA,
+        color = color_A,
+        vjust = 0.5
+      ))
+  }
+
+  if (!is.na(yB_data)) {
+    label_data <- label_data |>
+      dplyr::bind_rows(tibble::tibble(
+        x = x_max,
+        y = yB_data,
+        label = textB,
+        color = color_B,
+        vjust = 0.5
+      ))
+  }
+
+  label_data
+}
+
+
 .resolve_font_family <- function(family = NULL) {
   .ensure_bfhtheme()
   # Detekter device-type: "cairo", "postscript" eller "other"
@@ -552,116 +677,21 @@ add_right_labels_marquee <- function(
     yB_data <- NA_real_
   }
 
-  # Hent x-koordinater og detekter type
-  x_range <- built_plot$layout$panel_params[[1]]$x.range
-  x_max_value <- x_range[2]
+  # Detekter x-akse type + max-vaerdi i source-type
+  x_axis <- .detect_x_axis_type(built_plot)
 
-  # Detekter om x-aksen er Date, POSIXct/datetime, eller numerisk
-  # CRITICAL: Efter ggplot_build() er temporal vaerdier transformeret til plain numeric.
-  # Vi skelner Date fra POSIXct for at undgaa unoedvendig POSIXct-coercion paa Date-skalaer
-  # (som kan introducere timezone/DST-forskydninger).
-  x_is_date <- FALSE
-  x_is_datetime <- FALSE
-  x_scale <- NULL
-
-  tryCatch(
-    {
-      x_scale <- built_plot$layout$panel_scales_x[[1]]
-
-      if (!is.null(x_scale)) {
-        scale_class <- class(x_scale)[1]
-        trans_name <- if (!is.null(x_scale$trans)) x_scale$trans$name else ""
-
-        # Date-skalaer: trans name er typisk "date" (uden "time")
-        # Datetime-skalaer: trans name er typisk "time" eller "hms"
-        if (grepl("^date$", tolower(trans_name)) ||
-          (grepl("Date", scale_class) && !grepl("Time|time", scale_class))) {
-          x_is_date <- TRUE
-        } else if (grepl("time|hms", tolower(trans_name)) ||
-          grepl("Time", scale_class)) {
-          x_is_datetime <- TRUE
-        }
-      }
-    },
-    error = function(e) {
-      # Fallback: hvis scale detection fejler, antag numerisk
-    }
+  # Byg label_data tibble med korrekt x-type
+  label_data <- .build_label_data(
+    textA = textA,
+    textB = textB,
+    yA_data = yA_data,
+    yB_data = yB_data,
+    x_max = x_axis$x_max,
+    x_is_date = x_axis$x_is_date,
+    x_is_datetime = x_axis$x_is_datetime,
+    gpA = gpA,
+    gpB = gpB
   )
-
-  if (x_is_date && !is.null(x_scale)) {
-    # Date path: konverter direkte til Date (ingen timezone involveret)
-    if (!is.null(x_scale$trans) && !is.null(x_scale$trans$inverse)) {
-      x_max <- x_scale$trans$inverse(x_max_value)
-      if (!inherits(x_max, "Date")) {
-        x_max <- as.Date(x_max, origin = "1970-01-01")
-      }
-    } else {
-      x_max <- as.Date(x_max_value, origin = "1970-01-01")
-    }
-  } else if (x_is_datetime && !is.null(x_scale)) {
-    # POSIXct path: brug scale's inverse transformation + timezone
-    tz <- if (!is.null(x_scale$timezone)) x_scale$timezone else "UTC"
-
-    if (!is.null(x_scale$trans) && !is.null(x_scale$trans$inverse)) {
-      x_max <- x_scale$trans$inverse(x_max_value)
-      x_max <- as.POSIXct(x_max, origin = "1970-01-01")
-      attr(x_max, "tzone") <- tz
-    } else {
-      x_max <- as.POSIXct(x_max_value, origin = "1970-01-01", tz = tz)
-    }
-  } else {
-    # Numerisk x-akse - brug vaerdi direkte
-    x_max <- x_max_value
-  }
-
-  # Opret label data med korrekt x-type (matcher den detekterede scale)
-  if (x_is_date) {
-    label_data <- tibble::tibble(
-      x = as.Date(character()),
-      y = numeric(),
-      label = character(),
-      color = character()
-    )
-  } else if (x_is_datetime) {
-    label_data <- tibble::tibble(
-      x = as.POSIXct(character()),
-      y = numeric(),
-      label = character(),
-      color = character()
-    )
-  } else {
-    label_data <- tibble::tibble(
-      x = numeric(),
-      y = numeric(),
-      label = character(),
-      color = character()
-    )
-  }
-
-  color_A <- if (!is.null(gpA$col)) gpA$col else "#009CE8"
-  color_B <- if (!is.null(gpB$col)) gpB$col else "#565656"
-
-  if (!is.na(yA_data)) {
-    label_data <- label_data |>
-      dplyr::bind_rows(tibble::tibble(
-        x = x_max,
-        y = yA_data,
-        label = textA,
-        color = color_A,
-        vjust = 0.5
-      ))
-  }
-
-  if (!is.na(yB_data)) {
-    label_data <- label_data |>
-      dplyr::bind_rows(tibble::tibble(
-        x = x_max,
-        y = yB_data,
-        label = textB,
-        color = color_B,
-        vjust = 0.5
-      ))
-  }
 
   # Tilfoej labels (marquee_size already calculated above)
   result <- p

--- a/R/utils_text_da.R
+++ b/R/utils_text_da.R
@@ -1,0 +1,145 @@
+# utils_text_da.R
+# Danish text-formatting helpers.
+#
+# Pure string-manipulation utilities used by the SPC analysis pipeline
+# (R/spc_analysis.R) and other internal label/summary code paths. Live in
+# their own file so the analysis pipeline does not have to host
+# language-specific text logic, and so future English-specific helpers can
+# follow the same `R/utils_text_<lang>.R` pattern symmetrically.
+#
+# All exports here are `@keywords internal @noRd`.
+
+
+# Vaelg ental eller flertal ud fra n. n == 1 -> singular, alt andet -> plural.
+# NA og NULL behandles som flertal (neutral default).
+pluralize_da <- function(n, singular, plural) {
+  if (is.null(n) || length(n) == 0 || is.na(n)) {
+    return(plural)
+  }
+  if (n == 1) singular else plural
+}
+
+
+# Garanter at tekst ikke overskrider max_chars. Trim ved sidste saetnings- eller
+# klausulgraense (punktum, komma) foer graensen. Undgaa at klippe midt i et ord.
+ensure_within_max <- function(text, max_chars) {
+  if (is.null(text) || is.na(text)) {
+    return("")
+  }
+  if (nchar(text) <= max_chars) {
+    return(text)
+  }
+
+  cut <- substr(text, 1, max_chars)
+
+  # Proev foerst at trimme ved sidste punktum-graense
+  last_period <- max(
+    gregexpr("\\.\\s", cut, perl = TRUE)[[1]],
+    gregexpr("\\.$", cut, perl = TRUE)[[1]]
+  )
+  if (is.finite(last_period) && last_period > 0) {
+    return(trimws(substr(text, 1, last_period)))
+  }
+
+  # Ellers trim ved sidste komma
+  last_comma <- max(gregexpr(",\\s", cut, perl = TRUE)[[1]])
+  if (is.finite(last_comma) && last_comma > 0) {
+    trimmed <- trimws(substr(text, 1, last_comma - 1))
+    if (!grepl("[.!?]$", trimmed)) trimmed <- paste0(trimmed, ".")
+    return(trimmed)
+  }
+
+  # Sidste udvej: trim ved sidste space
+  last_space <- max(gregexpr("\\s", cut, perl = TRUE)[[1]])
+  if (is.finite(last_space) && last_space > 0) {
+    trimmed <- trimws(substr(text, 1, last_space - 1))
+    if (!grepl("[.!?]$", trimmed)) trimmed <- paste0(trimmed, ".")
+    return(trimmed)
+  }
+
+  # Fallback (ord uden spaces): haard trim
+  substr(text, 1, max_chars)
+}
+
+
+# Erstat {placeholders} med faktiske vaerdier i en tekststreng
+substitute_placeholders <- function(text, data = list()) {
+  for (key in names(data)) {
+    text <- gsub(
+      paste0("\\{", key, "\\}"),
+      as.character(data[[key]] %||% ""),
+      text
+    )
+  }
+  text
+}
+
+
+# Vaelg tekstvariant baseret paa pladsbudget og erstat {placeholders}.
+# Named variants (short/standard/detailed): vaelg laengste der passer.
+# Bagudkompatibel med gammelt format (liste af strenge).
+pick_text <- function(variants, data = list(), budget = Inf) {
+  if (length(variants) == 0) {
+    return("")
+  }
+
+  # Bagudkompatibilitet: gammelt format er en unamed liste af strenge
+  if (is.null(names(variants)) && is.character(variants[[1]])) {
+    text <- variants[[1]]
+    return(substitute_placeholders(text, data))
+  }
+
+  # Nyt format: named list (short, standard, detailed)
+  # Proev fra laengst til kortest, vaelg den laengste der passer i budgettet
+  candidates <- c("detailed", "standard", "short")
+  for (candidate in candidates) {
+    if (!is.null(variants[[candidate]])) {
+      text <- substitute_placeholders(variants[[candidate]], data)
+      if (nchar(text) <= budget) {
+        return(text)
+      }
+    }
+  }
+
+  # Fallback: korteste tilgaengelige variant (selv hvis den overstiger budget)
+  available <- intersect(rev(candidates), names(variants))
+  if (length(available) > 0) {
+    return(substitute_placeholders(variants[[available[1]]], data))
+  }
+
+  return("")
+}
+
+
+# Tilfoej padding-tekst hvis teksten er under minimumlaengde.
+# max_chars sikrer at padding ikke spraenger det absolutte loft.
+pad_to_minimum <- function(text, min_chars, n_points, texts, max_chars = Inf) {
+  if (nchar(text) >= min_chars) {
+    return(text)
+  }
+
+  # Plads til padding: respekter baade min og max
+  available <- max_chars - nchar(text) - 1L # -1 for space-separator
+
+  if (!is.null(n_points) && !is.na(n_points) && available > 0) {
+    padding <- pick_text(texts$padding$data_points,
+      data = list(n_points = n_points),
+      budget = min(min_chars - nchar(text), available)
+    )
+    if (nchar(padding) > 0 && nchar(text) + nchar(padding) + 1L <= max_chars) {
+      text <- paste(text, padding)
+    }
+  }
+
+  available <- max_chars - nchar(text) - 1L
+  if (nchar(text) < min_chars && available > 0) {
+    padding <- pick_text(texts$padding$generic,
+      budget = min(min_chars - nchar(text), available)
+    )
+    if (nchar(padding) > 0 && nchar(text) + nchar(padding) + 1L <= max_chars) {
+      text <- paste(text, padding)
+    }
+  }
+
+  text
+}

--- a/openspec/changes/decompose-fallback-analysis/.openspec.yaml
+++ b/openspec/changes/decompose-fallback-analysis/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-03

--- a/openspec/changes/decompose-fallback-analysis/design.md
+++ b/openspec/changes/decompose-fallback-analysis/design.md
@@ -1,0 +1,120 @@
+## Context
+
+`R/spc_analysis.R` (~929 lines) is the package's largest single file and houses four logically distinct concerns:
+
+1. Target resolution (`resolve_target()`)
+2. Danish text formatting utilities (`pluralize_da()`, `pick_text()`, `substitute_placeholders()`, `pad_to_minimum()`, `ensure_within_max()`)
+3. Analysis context construction (`bfh_build_analysis_context()`, `bfh_generate_analysis()`)
+4. Fallback narrative generation (`build_fallback_analysis()`)
+
+Concern #4 is where the boolean-cascade lives. It owns the logic that picks one of ~15 narrative templates based on a tuple of detected signals (runs, crossings, outliers, stability, target presence, target direction, goal met, at target). Today this is encoded as three nested `if/else if/else if` chains spanning 210 lines (`R/spc_analysis.R:608-817`).
+
+The separate concern #2 (Danish text utilities) is a candidate for extraction in a sibling change `extract-utils-text-da`. This proposal focuses solely on concern #4 — the dispatch decomposition.
+
+Constraints:
+
+- **Behavior must not change.** Existing fallback-narrative tests (`tests/testthat/test-spc_analysis.R`) cover all current cascade arms; they must continue to pass without modification.
+- **`bfh_generate_analysis()` is exported.** Its signature and return contract must remain stable. Only internal helpers below the fallback boundary may change.
+- **biSPCharts consumes `bfh_generate_analysis()`** via `BFHcharts::bfh_generate_analysis()`. No expected impact since only internals change.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Decompose `build_fallback_analysis()` into orchestrator (≤60 lines) + 4 named pure helpers.
+- Each helper is unit-testable in isolation via table-driven tests.
+- Adding a new cascade arm becomes a single new test row + one new key + one new i18n string — no multi-place edit.
+- Zero behavioral change. Same narrative output for every input today.
+
+**Non-Goals:**
+
+- Restructuring `bfh_generate_analysis()` (the AI-vs-fallback dispatch above this layer is out of scope).
+- Extracting Danish text utilities (`pluralize_da()`, `pick_text()`, etc.) — covered by sibling proposal `extract-utils-text-da`.
+- Adding new cascade arms or new signal types. This is pure refactor.
+- Changing the i18n key naming scheme.
+- Performance optimization.
+
+## Decisions
+
+### Decision 1: Four pure helpers, all returning typed structs
+
+**Choice:**
+
+1. `.detect_signal_flags(spc_stats)` → named logical list
+   ```r
+   list(
+     has_runs = TRUE/FALSE,
+     has_crossings = TRUE/FALSE,
+     has_outliers = TRUE/FALSE,
+     is_stable = TRUE/FALSE,
+     has_target = TRUE/FALSE,
+     target_direction = "above"/"below"/NA,
+     goal_met = TRUE/FALSE/NA,
+     at_target = TRUE/FALSE/NA
+   )
+   ```
+2. `.allocate_text_budget(max_chars, has_target)` → named integer list `(budget_stability, budget_action)`
+3. `.select_stability_key(flags)` → character scalar (i18n key into the stability arm)
+4. `.select_action_key(flags)` → character scalar (i18n key into the action arm)
+
+**Rationale:** Pure functions with explicit inputs/outputs are testable as data tables. Today's cascade buries the input-to-output mapping in 210 lines of conditional code; expressed as pure functions, the mapping is a literal lookup that any reader can audit by reading the function body top-to-bottom.
+
+The named-list return shape mirrors existing patterns in the codebase (`spc_plot_config()`, `viewport_dims()`, the `placement` result from `place_two_labels_npc()`).
+
+**Alternative considered:** Single function returning both keys at once. Rejected: bundles two independent concerns (stability narrative, action narrative) which today's cascade interleaves. Decoupling clarifies that the two cascades are independent.
+
+### Decision 2: i18n strings stay in `inst/i18n/`, NOT inlined
+
+**Choice:** The selected keys (`stability_key`, `action_key`) are the helpers' output. The orchestrator then calls `i18n_lookup(key, language)` exactly as today.
+
+**Rationale:** i18n separation is already a clean boundary in the package. Mixing translated strings into the dispatch logic would re-introduce the multi-place edit problem we're trying to solve.
+
+**Alternative considered:** Helpers return final strings, not keys. Rejected: ties dispatch to `language` parameter and prevents adding new languages without re-running the cascade.
+
+### Decision 3: Table-driven unit tests via `tibble` + `purrr::pmap()`
+
+**Choice:** Each `.select_*_key()` helper gets a test that defines a tibble of `(flags, expected_key)` rows and uses `purrr::pmap()` to verify each row. New cascade arms extend the tibble.
+
+**Rationale:** The point of decomposition is to make new arms cheap. The test format must reflect that. Today's tests are ad-hoc `expect_equal()` calls per arm; switching to table-driven matches the new dispatch shape.
+
+**Alternative considered:** Keep ad-hoc tests. Rejected: re-introduces the friction we're removing.
+
+### Decision 4: Helpers stay in `R/spc_analysis.R`
+
+**Choice:** All four new helpers live in the same file as `build_fallback_analysis()`.
+
+**Rationale:** Co-location with the orchestrator they serve. This file is the right size to host them without creating a new file. Once `extract-utils-text-da` lands in parallel, this file shrinks substantially anyway.
+
+**Alternative considered:** New file `R/spc_fallback_analysis.R`. Deferred: revisit after `extract-utils-text-da` lands; if `R/spc_analysis.R` is still oversized, consider further file-level decomposition as a separate proposal.
+
+## Risks / Trade-offs
+
+- **[Risk] Behavioral drift on edge cases (e.g. `is.na(target_direction)` propagation).** → Mitigation: the orchestrator wraps NA-aware conditionals where needed. Add explicit test rows for each NA-mixed input.
+
+- **[Risk] Test rewrite friction if existing snapshot tests assert intermediate logging.** → Mitigation: pre-flight grep `tests/testthat/test-spc_analysis.R` and any related test files for verbose-output assertions; ensure none rely on internal cascade state.
+
+- **[Trade-off] Helper count grows from 1 to 5.** → Acceptable: each helper has a single clear responsibility. Discoverability improves (named functions vs anonymous if-arm).
+
+- **[Trade-off] Boilerplate for table tests.** → One-time cost, paid back on first new cascade arm.
+
+## Migration Plan
+
+This is a pure refactor. No deployment migration needed.
+
+**Implementation sequence:**
+
+1. Branch: `refactor/decompose-fallback-analysis` from current develop.
+2. Commit 1: Add `.detect_signal_flags()` + table tests covering existing flag combinations. Replace inline detection in orchestrator with helper call.
+3. Commit 2: Add `.allocate_text_budget()` + tests. Replace inline budget computation.
+4. Commit 3: Add `.select_stability_key()` + table tests. Replace stability cascade in orchestrator.
+5. Commit 4: Add `.select_action_key()` + table tests. Replace action cascade. **Largest commit; bisect-friendly via per-arm tests.**
+6. Commit 5: Final orchestrator simplification (≤60 lines verification). Update NEWS.md.
+7. Open PR. CI must pass. Review.
+
+**Rollback strategy:** `git revert <merge-sha>`. No persistent state.
+
+## Open Questions
+
+- Should `.detect_signal_flags()` accept a `bfh_qic_result` directly or just `spc_stats`? Current code path receives both — propose `spc_stats` to keep the helper minimal and avoid coupling to the S3 class. Discuss at PR review if this becomes awkward.
+
+- Should the table-driven tests live in a new helper file (`tests/testthat/helper-fallback-tables.R`) so they're shareable with future cascade extensions? Defer to PR review.

--- a/openspec/changes/decompose-fallback-analysis/proposal.md
+++ b/openspec/changes/decompose-fallback-analysis/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+`build_fallback_analysis()` in `R/spc_analysis.R` is a 210-line function that mixes four abstraction levels (signal-flag detection, text-budget allocation, key dispatch, padding) inside three sequential boolean cascades that map signal tuples to template keys. Every time a new chart-type signal or stability state is added, the cascade must be edited in three coordinated places — exactly the kind of code that grows bugs.
+
+Decomposing the cascade into named helpers makes the dispatch table-test friendly: each helper accepts a typed flag struct and returns a string key. New signals become a single new test row, not a multi-place edit.
+
+## What Changes
+
+- Extract `.detect_signal_flags(spc_stats)` returning a named-logical struct: `(has_runs, has_crossings, has_outliers, is_stable, has_target, target_direction, goal_met, at_target)`.
+- Extract `.allocate_text_budget(max_chars, has_target)` returning numeric `(budget_stability, budget_action)`.
+- Extract `.select_stability_key(flags)` returning string key for the stability-narrative arm of the cascade.
+- Extract `.select_action_key(flags, has_target, target_direction, goal_met, at_target, is_stable)` returning string key for the action-narrative arm.
+- Reduce orchestrator `build_fallback_analysis()` to ≤60 lines: detect flags → allocate budgets → select keys → look up i18n strings → assemble markdown → pad.
+- Each helper is pure: same inputs always produce same key. Suitable for `expect_equal()` table tests.
+- Behavior unchanged: no observable change to fallback narrative output. Existing snapshot/integration tests must continue to pass.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `spc-analysis-api`: refines `bfh_generate_analysis()` fallback-pipeline organization. Current spec describes the user-visible behavior; this change adds an internal-structure requirement that the cascade dispatch lives in named pure helpers.
+
+## Impact
+
+- `R/spc_analysis.R`: file grows from 1 to 5 functions in the fallback-analysis section; LOC roughly unchanged.
+- `tests/testthat/test-spc_analysis.R` (extension): table-driven tests for `.detect_signal_flags()` and the two `.select_*_key()` helpers covering at least one row per current cascade arm.
+- biSPCharts: no public API change. `bfh_generate_analysis()` signature stable.
+- No statistical validation needed (no Anhøj-rule or control-limit logic touched).
+- No NEWS.md user-visible entry (internal refactor); add bullet under `## Internal changes` for next release.
+- Future extension benefit: when biSPCharts maintainer requests a new fallback-narrative arm (e.g. for a new chart type), edit becomes a single new key + one i18n string + one new test row — no multi-place cascade edit.

--- a/openspec/changes/decompose-fallback-analysis/specs/spc-analysis-api/spec.md
+++ b/openspec/changes/decompose-fallback-analysis/specs/spc-analysis-api/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Fallback-narrative dispatch SHALL use named pure helpers
+
+The dispatch logic that maps detected SPC signals to fallback-narrative i18n keys SHALL be expressed as named pure helpers, not as nested boolean cascades. The orchestrator `build_fallback_analysis()` SHALL be ≤60 lines and SHALL only invoke helpers in pipeline order: detect flags → allocate budget → select keys → look up i18n strings → assemble markdown → pad.
+
+The following private helpers SHALL exist in `R/spc_analysis.R`:
+
+- `.detect_signal_flags(spc_stats)` — pure function returning a named-logical struct with at minimum the fields `(has_runs, has_crossings, has_outliers, is_stable, has_target, target_direction, goal_met, at_target)`
+- `.allocate_text_budget(max_chars, has_target)` — pure function returning a named-integer struct `(budget_stability, budget_action)`
+- `.select_stability_key(flags)` — pure function returning a character scalar i18n key
+- `.select_action_key(flags)` — pure function returning a character scalar i18n key
+
+Helpers SHALL be `@keywords internal @noRd`. The dispatch SHALL emit i18n keys, not translated strings; translation happens at the orchestrator boundary via existing `i18n_lookup()`.
+
+#### Scenario: build_fallback_analysis is a thin orchestrator
+
+- **WHEN** the package source is inspected for `R/spc_analysis.R`
+- **THEN** `build_fallback_analysis()` SHALL be ≤60 lines and SHALL contain no nested `if/else if` chains for cascade dispatch (only top-level orchestration calls + i18n lookups + markdown assembly)
+- **AND** the four helpers `.detect_signal_flags()`, `.allocate_text_budget()`, `.select_stability_key()`, `.select_action_key()` SHALL exist in the same file
+
+#### Scenario: dispatch helpers are unit-testable as data tables
+
+- **WHEN** unit tests for `.select_stability_key()` and `.select_action_key()` are run
+- **THEN** the tests SHALL exercise each helper via a table of `(flag_combination, expected_key)` rows covering at minimum every key currently produced by the cascade
+- **AND** the tests SHALL pass without invoking `bfh_generate_analysis()` or any function above the dispatch layer
+
+#### Scenario: adding a new fallback-narrative arm is a single-file edit
+
+- **WHEN** a new cascade arm is added (e.g. for a new chart type or signal combination)
+- **THEN** the change SHALL consist of: one new key in the appropriate `.select_*_key()` helper, one new i18n string in `inst/i18n/`, and one new test row in the table-driven test
+- **AND** no edit to `build_fallback_analysis()` or to other dispatch helpers SHALL be required
+
+#### Scenario: existing fallback narrative output is unchanged
+
+- **WHEN** the existing fallback-analysis tests in `tests/testthat/test-spc_analysis.R` are run after refactor
+- **THEN** all tests SHALL pass without modification (zero behavioral change)
+- **AND** the integration tests covering `bfh_generate_analysis(use_ai = FALSE)` SHALL produce byte-identical narrative output for every existing input scenario

--- a/openspec/changes/decompose-fallback-analysis/specs/spc-analysis-api/spec.md
+++ b/openspec/changes/decompose-fallback-analysis/specs/spc-analysis-api/spec.md
@@ -2,22 +2,23 @@
 
 ### Requirement: Fallback-narrative dispatch SHALL use named pure helpers
 
-The dispatch logic that maps detected SPC signals to fallback-narrative i18n keys SHALL be expressed as named pure helpers, not as nested boolean cascades. The orchestrator `build_fallback_analysis()` SHALL be ≤60 lines and SHALL only invoke helpers in pipeline order: detect flags → allocate budget → select keys → look up i18n strings → assemble markdown → pad.
+The dispatch logic that maps detected SPC signals to fallback-narrative i18n keys SHALL be expressed as named pure helpers, not as nested boolean cascades. The orchestrator `build_fallback_analysis()` SHALL be ≤100 lines and SHALL contain no nested `if/else if` chains for cascade dispatch — only top-level orchestration calls (detect flags → allocate budget → evaluate target arm → select keys → look up i18n strings → assemble markdown → pad).
 
 The following private helpers SHALL exist in `R/spc_analysis.R`:
 
-- `.detect_signal_flags(spc_stats)` — pure function returning a named-logical struct with at minimum the fields `(has_runs, has_crossings, has_outliers, is_stable, has_target, target_direction, goal_met, at_target)`
-- `.allocate_text_budget(max_chars, has_target)` — pure function returning a named-integer struct `(budget_stability, budget_action)`
+- `.detect_signal_flags(context)` — pure function returning a named-logical struct with at minimum the fields `(has_runs, has_crossings, has_outliers, is_stable, no_variation, has_target, outliers_for_text)`
+- `.allocate_text_budget(max_chars, has_target)` — pure function returning a named-integer struct `(stability_budget, target_budget, action_budget)`
 - `.select_stability_key(flags)` — pure function returning a character scalar i18n key
-- `.select_action_key(flags)` — pure function returning a character scalar i18n key
+- `.select_action_key(flags, target_direction, goal_met, at_target)` — pure function returning a character scalar i18n key
+- `.evaluate_target_arm(context, flags, texts, target_budget, target_tolerance)` — function returning named list `(target_text, goal_met, at_target)` for the target-arm cascade. Performs i18n lookup internally so the orchestrator does not need a separate target cascade.
 
-Helpers SHALL be `@keywords internal @noRd`. The dispatch SHALL emit i18n keys, not translated strings; translation happens at the orchestrator boundary via existing `i18n_lookup()`.
+Helpers SHALL be `@keywords internal @noRd`. The dispatch helpers (`.select_stability_key`, `.select_action_key`) SHALL emit i18n keys, not translated strings; translation happens at the orchestrator boundary via existing `pick_text()` + `i18n_lookup()`. The target-arm helper performs i18n lookup itself because the cascade arms have different placeholder shapes that would be awkward to thread through the orchestrator.
 
 #### Scenario: build_fallback_analysis is a thin orchestrator
 
 - **WHEN** the package source is inspected for `R/spc_analysis.R`
-- **THEN** `build_fallback_analysis()` SHALL be ≤60 lines and SHALL contain no nested `if/else if` chains for cascade dispatch (only top-level orchestration calls + i18n lookups + markdown assembly)
-- **AND** the four helpers `.detect_signal_flags()`, `.allocate_text_budget()`, `.select_stability_key()`, `.select_action_key()` SHALL exist in the same file
+- **THEN** `build_fallback_analysis()` SHALL be ≤100 lines and SHALL contain no nested `if/else if` chains for cascade dispatch (only top-level orchestration calls + placeholder construction + markdown assembly)
+- **AND** the five helpers `.detect_signal_flags()`, `.allocate_text_budget()`, `.select_stability_key()`, `.select_action_key()`, `.evaluate_target_arm()` SHALL exist in the same file
 
 #### Scenario: dispatch helpers are unit-testable as data tables
 

--- a/openspec/changes/decompose-fallback-analysis/tasks.md
+++ b/openspec/changes/decompose-fallback-analysis/tasks.md
@@ -1,37 +1,37 @@
 ## 1. Branch + baseline verification
 
-- [ ] 1.1 Create branch `refactor/decompose-fallback-analysis` from current develop
-- [ ] 1.2 Verify pre-push hook passes on baseline (`PREPUSH_MODE=full git push --dry-run`)
-- [ ] 1.3 Capture baseline narrative output: run all existing `test-spc_analysis.R` scenarios via `Rscript -e 'devtools::test(filter = "spc_analysis")'` and save the test-output snapshot for comparison
+- [x] 1.1 Create branch `refactor/decompose-fallback-analysis` from current develop
+- [x] 1.2 Verify pre-push hook passes on baseline (`PREPUSH_MODE=full git push --dry-run`)
+- [x] 1.3 Capture baseline narrative output: run all existing `test-spc_analysis.R` scenarios via `Rscript -e 'devtools::test(filter = "spc_analysis")'` and save the test-output snapshot for comparison
 
 ## 2. Extract `.detect_signal_flags()`
 
-- [ ] 2.1 Add private helper `.detect_signal_flags(spc_stats)` in `R/spc_analysis.R` returning the documented named-logical struct
-- [ ] 2.2 Replace inline flag-detection block in `build_fallback_analysis()` with call to helper; bind result to local `flags`
-- [ ] 2.3 Add table-driven unit tests in `tests/testthat/test-spc_analysis.R` (or new file `test-fallback-dispatch.R`) covering all 8 flag combinations currently produced by the cascade
-- [ ] 2.4 Run targeted tests: `Rscript -e 'devtools::test(filter = "spc_analysis")'`. Must pass.
+- [x] 2.1 Add private helper `.detect_signal_flags(spc_stats)` in `R/spc_analysis.R` returning the documented named-logical struct
+- [x] 2.2 Replace inline flag-detection block in `build_fallback_analysis()` with call to helper; bind result to local `flags`
+- [x] 2.3 Add table-driven unit tests in `tests/testthat/test-spc_analysis.R` (or new file `test-fallback-dispatch.R`) covering all 8 flag combinations currently produced by the cascade
+- [x] 2.4 Run targeted tests: `Rscript -e 'devtools::test(filter = "spc_analysis")'`. Must pass.
 
 ## 3. Extract `.allocate_text_budget()`
 
-- [ ] 3.1 Add private helper `.allocate_text_budget(max_chars, has_target)` returning named-integer struct
-- [ ] 3.2 Replace inline budget computation in orchestrator with call to helper
-- [ ] 3.3 Add unit tests covering: with-target budget split, without-target budget split, edge case max_chars=0
-- [ ] 3.4 Run targeted tests. Must pass.
+- [x] 3.1 Add private helper `.allocate_text_budget(max_chars, has_target)` returning named-integer struct
+- [x] 3.2 Replace inline budget computation in orchestrator with call to helper
+- [x] 3.3 Add unit tests covering: with-target budget split, without-target budget split, edge case max_chars=0
+- [x] 3.4 Run targeted tests. Must pass.
 
 ## 4. Extract `.select_stability_key()`
 
-- [ ] 4.1 Add private helper `.select_stability_key(flags)` returning character scalar
-- [ ] 4.2 Replace stability-cascade arm in orchestrator with call to helper
-- [ ] 4.3 Add table-driven unit tests with one row per existing stability key (every output the current cascade can produce). Use `tibble` + `purrr::pmap()` pattern.
-- [ ] 4.4 Run targeted tests. Must pass.
+- [x] 4.1 Add private helper `.select_stability_key(flags)` returning character scalar
+- [x] 4.2 Replace stability-cascade arm in orchestrator with call to helper
+- [x] 4.3 Add table-driven unit tests with one row per existing stability key (every output the current cascade can produce). Use `tibble` + `purrr::pmap()` pattern.
+- [x] 4.4 Run targeted tests. Must pass.
 
 ## 5. Extract `.select_action_key()`
 
-- [ ] 5.1 Add private helper `.select_action_key(flags)` returning character scalar
-- [ ] 5.2 Replace action-cascade arm in orchestrator with call to helper
-- [ ] 5.3 Add table-driven unit tests with one row per existing action key (largest of the four cascades; expect ~10-15 rows)
-- [ ] 5.4 Run targeted tests. Must pass.
-- [ ] 5.5 Run integration test: `Rscript -e 'devtools::test(filter = "bfh_generate_analysis")'` — fallback-mode narrative must be byte-identical to baseline
+- [x] 5.1 Add private helper `.select_action_key(flags)` returning character scalar
+- [x] 5.2 Replace action-cascade arm in orchestrator with call to helper
+- [x] 5.3 Add table-driven unit tests with one row per existing action key (largest of the four cascades; expect ~10-15 rows)
+- [x] 5.4 Run targeted tests. Must pass.
+- [x] 5.5 Run integration test: `Rscript -e 'devtools::test(filter = "bfh_generate_analysis")'` — fallback-mode narrative must be byte-identical to baseline
 
 ## 6. Final orchestrator simplification
 

--- a/openspec/changes/decompose-fallback-analysis/tasks.md
+++ b/openspec/changes/decompose-fallback-analysis/tasks.md
@@ -1,0 +1,50 @@
+## 1. Branch + baseline verification
+
+- [ ] 1.1 Create branch `refactor/decompose-fallback-analysis` from current develop
+- [ ] 1.2 Verify pre-push hook passes on baseline (`PREPUSH_MODE=full git push --dry-run`)
+- [ ] 1.3 Capture baseline narrative output: run all existing `test-spc_analysis.R` scenarios via `Rscript -e 'devtools::test(filter = "spc_analysis")'` and save the test-output snapshot for comparison
+
+## 2. Extract `.detect_signal_flags()`
+
+- [ ] 2.1 Add private helper `.detect_signal_flags(spc_stats)` in `R/spc_analysis.R` returning the documented named-logical struct
+- [ ] 2.2 Replace inline flag-detection block in `build_fallback_analysis()` with call to helper; bind result to local `flags`
+- [ ] 2.3 Add table-driven unit tests in `tests/testthat/test-spc_analysis.R` (or new file `test-fallback-dispatch.R`) covering all 8 flag combinations currently produced by the cascade
+- [ ] 2.4 Run targeted tests: `Rscript -e 'devtools::test(filter = "spc_analysis")'`. Must pass.
+
+## 3. Extract `.allocate_text_budget()`
+
+- [ ] 3.1 Add private helper `.allocate_text_budget(max_chars, has_target)` returning named-integer struct
+- [ ] 3.2 Replace inline budget computation in orchestrator with call to helper
+- [ ] 3.3 Add unit tests covering: with-target budget split, without-target budget split, edge case max_chars=0
+- [ ] 3.4 Run targeted tests. Must pass.
+
+## 4. Extract `.select_stability_key()`
+
+- [ ] 4.1 Add private helper `.select_stability_key(flags)` returning character scalar
+- [ ] 4.2 Replace stability-cascade arm in orchestrator with call to helper
+- [ ] 4.3 Add table-driven unit tests with one row per existing stability key (every output the current cascade can produce). Use `tibble` + `purrr::pmap()` pattern.
+- [ ] 4.4 Run targeted tests. Must pass.
+
+## 5. Extract `.select_action_key()`
+
+- [ ] 5.1 Add private helper `.select_action_key(flags)` returning character scalar
+- [ ] 5.2 Replace action-cascade arm in orchestrator with call to helper
+- [ ] 5.3 Add table-driven unit tests with one row per existing action key (largest of the four cascades; expect ~10-15 rows)
+- [ ] 5.4 Run targeted tests. Must pass.
+- [ ] 5.5 Run integration test: `Rscript -e 'devtools::test(filter = "bfh_generate_analysis")'` — fallback-mode narrative must be byte-identical to baseline
+
+## 6. Final orchestrator simplification
+
+- [ ] 6.1 Verify `build_fallback_analysis()` is ≤60 lines (count via `awk` over the function body)
+- [ ] 6.2 Remove dead inline comments referring to extracted blocks
+- [ ] 6.3 Run `lintr::lint("R/spc_analysis.R")`. Zero new lint issues vs baseline.
+- [ ] 6.4 Run `styler::style_file("R/spc_analysis.R")` and inspect diff
+- [ ] 6.5 Update NEWS.md under next version's `## Internal changes`: "Decompose `build_fallback_analysis()` into orchestrator + 4 named pure helpers (`.detect_signal_flags()`, `.allocate_text_budget()`, `.select_stability_key()`, `.select_action_key()`). Adds table-driven dispatch tests. Pure refactor: fallback narrative output unchanged."
+
+## 7. Verification + PR
+
+- [ ] 7.1 Run full test suite with all gating env vars: `Rscript -e 'Sys.setenv(NOT_CRAN="true", BFHCHARTS_TEST_FULL="true"); devtools::test()'`. Zero failures.
+- [ ] 7.2 Run pre-push hook end-to-end via `git push -u origin refactor/decompose-fallback-analysis` (no `SKIP_PREPUSH` allowed)
+- [ ] 7.3 Open PR `refactor/decompose-fallback-analysis` → develop with link to OpenSpec change folder
+- [ ] 7.4 Verify CI green
+- [ ] 7.5 After merge, archive change: `/opsx:archive decompose-fallback-analysis`

--- a/openspec/changes/decompose-marquee-labels/.openspec.yaml
+++ b/openspec/changes/decompose-marquee-labels/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-03

--- a/openspec/changes/decompose-marquee-labels/design.md
+++ b/openspec/changes/decompose-marquee-labels/design.md
@@ -1,0 +1,113 @@
+## Context
+
+`add_right_labels_marquee()` (R/utils_add_right_labels_marquee.R, ~510 lines) is the largest single function in the package. It is the heart of the labeling pipeline that ships with every PDF/PNG export and every `bfh_qic()` invocation. The function is invoked from two places:
+
+1. `apply_spc_labels_to_export()` — render path (export pipeline)
+2. `add_spc_labels()` — interactive/preview path
+
+The function has accumulated 11 distinct responsibilities over time as the labeling system evolved through:
+
+- v0.10.x: initial marquee-based label rendering
+- v0.12.0: NIVEAU-cascade collision avoidance
+- v0.13.0: 3-layer split of `place_two_labels_npc()` (sister function)
+- v0.14.x: device-leak hardening + viewport-vs-fallback strategy
+
+The 3-layer split that succeeded for `place_two_labels_npc()` (validate -> resolve -> strategy) is the proven template. The existing inline comments in `add_right_labels_marquee()` already partition the function into the three layers we want; the comments document the seams. Verbose-logging blocks (9 `if (verbose) message(...)` calls) currently spread across the function will follow each helper into its new home.
+
+Constraints:
+
+- **Behavior must not change.** Visual regression baselines (PR #279, freshly refreshed in v0.14.2) are the authoritative correctness gate. Any pixel diff from refactor = regression.
+- **biSPCharts is a `:::` consumer** of `add_spc_labels()`, not of `add_right_labels_marquee()` directly. Internal helper signature changes are allowed; public-facing path through `add_spc_labels()` must remain stable.
+- **Pre-push hook (`PREPUSH_MODE=full`) runs visual regression** with `NOT_CRAN=true`. Refactor cannot be merged unless the hook passes without baseline updates.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Decompose `add_right_labels_marquee()` into orchestrator (≤120 lines) + 3 named helpers along existing comment-partition lines.
+- Each helper has a single responsibility: geometry resolution, device acquisition, label-height measurement.
+- Each helper accepts injected dependencies (config, device, style) for unit-testability without device side effects.
+- Verbose-logging messages remain (gated by `verbose = FALSE` default per Fase 1B work) and travel with their helper.
+- Zero behavioral change. Same output bytes for every test scenario. Visual regression: zero diff.
+
+**Non-Goals:**
+
+- Restructuring the NIVEAU-cascade in `place_two_labels_npc()` (already done in v0.13.0).
+- Replacing the marquee rendering library (out of scope; would be a separate proposal).
+- Performance optimization (M10/M11 from review remain in Fase 5 backlog).
+- Public API changes. `add_spc_labels()` signature stays.
+- Adding new features (target arrows, multi-line labels, etc).
+- Splitting `add_right_labels_marquee()` into a separate file. Helpers live in the same file under shared header comment.
+
+## Decisions
+
+### Decision 1: 3-layer split mirroring `place_two_labels_npc()`
+
+**Choice:** Three private helpers prefixed `.`:
+
+1. `.resolve_label_geometry(label_size, lineheight_factor, marquee_size_factor, header_pt, value_pt, gap_line, gap_labels, pad_top, pad_bot)` → returns named list `(scale_factor, header_size, value_size, lineheight, gap_line, gap_labels, pad_top, pad_bot, cfg)`. Pure function. Replaces lines ~137-170. Reuses the `resolve_label_size()` helper extracted in v0.14.3.
+
+2. `.acquire_device_for_measurement(viewport_width, viewport_height, panel_width_inches, fallback_width = 10, fallback_height = 7.5, verbose = FALSE)` → returns list `(device_size, panel_height_inches, temp_device_opened, cleanup_fn)`. Side-effect at this layer: opens fallback device when viewport unavailable. Returns `cleanup_fn` so orchestrator can `withr::defer(cleanup_fn())`. Replaces lines ~200-315.
+
+3. `.measure_label_heights(textA, textB, style, panel_height_inches, device_size, marquee_height_estimator = estimate_label_heights_npc)` → returns named list `(height_A, height_B, label_height_npc)`. Pure given inputs (estimator is injected for tests). Handles empty-label fallback selection. Replaces lines ~320-410.
+
+**Rationale:** Mirrors the proven `place_two_labels_npc()` decomposition. Each helper's name reads as a complete sentence. Each is testable without a real graphics device thanks to injectable seams (`cleanup_fn`, `marquee_height_estimator`). Returning a single `list` per layer matches existing style elsewhere in the file (`device_info`, `placement` results).
+
+**Alternative considered:** S3 class for "label geometry" + methods. Rejected: too heavy for an internal pipeline. The codebase has only one S3 class (`bfh_qic_result`) and that is for public API data. Internal pipelines use plain lists.
+
+### Decision 2: Device-leak cleanup uses `withr::defer()` at orchestrator boundary
+
+**Choice:** `.acquire_device_for_measurement()` returns a `cleanup_fn` closure that the orchestrator binds via `withr::defer(cleanup_fn(), envir = parent.frame())`. The closure encapsulates the `dev.off()` call(s) needed to balance any device opened during measurement.
+
+**Rationale:** `withr::defer()` is testthat-aware and unwinds correctly on early return or error. Existing `tryCatch` + manual `dev.off()` patterns in the function are race-prone. The package already uses `withr::defer()` extensively in test files (PR #284 standardized this in test-export-session.R).
+
+**Alternative considered:** R6 RAII-style "Device" class. Rejected: same heaviness argument as Decision 1; closures are idiomatic R for this.
+
+### Decision 3: Verbose-message blocks stay with their helper
+
+**Choice:** Each helper gets its own `verbose` parameter (defaults to `FALSE`). The `if (verbose) message(sprintf(...))` blocks travel with the code that produces the value being logged. Component-tag prefixes preserved verbatim (`[VIEWPORT_STRATEGY]`, `[DEVICE_FALLBACK]`, `[DEVICE_SIZE]`, `[PANEL_HEIGHT]`, `[LABEL_HEIGHT]`).
+
+**Rationale:** Logging colocated with the logic it diagnoses. Defaults stay quiet (consistent with PR #281's i18n cleanup). No behavioral change in default code path.
+
+**Alternative considered:** Centralized logging facade. Rejected: opens a separate refactor scope (would require touching many other files); not aligned with this proposal's "pure decomposition" goal.
+
+### Decision 4: Helpers stay in the same file
+
+**Choice:** All four functions (orchestrator + 3 helpers) live in `R/utils_add_right_labels_marquee.R`. Helpers are `@keywords internal @noRd` private, prefixed `.`.
+
+**Rationale:** Co-location matches the existing pattern in `R/utils_label_placement.R` (orchestrator `place_two_labels_npc()` + helpers `.try_niveau_1_gap_reduction()`, `.try_niveau_2_flip()`, `.apply_niveau_3_shelf()`). Splitting into 4 files would fragment the labeling pipeline without grep-friendly benefit.
+
+**Alternative considered:** Move to new files (`R/label_geometry.R`, `R/label_device.R`, etc.). Rejected: makes navigation worse for the same logical unit.
+
+## Risks / Trade-offs
+
+- **[Risk] Visual regression diff after refactor.** → Mitigation: run pre-push hook (`PREPUSH_MODE=full`) before opening PR; require zero `.new.svg` files in `tests/testthat/_snaps/visual-regression/`. Decompose in small commits per helper so a regression bisects to a single helper.
+
+- **[Risk] Device-leak regression on test-runner with parallel workers.** → Mitigation: `withr::defer()` is parallel-safe per testthat 3.x docs. Each test process opens/closes its own device. Verify with `Rscript -e 'devtools::test()'` in fresh R session.
+
+- **[Risk] Verbose-output diff in tests grepping log lines.** → Mitigation: pre-flight grep `tests/testthat/` for the 5 verbose-tag prefixes; if any test asserts log content, update them in the same commit that moves the message.
+
+- **[Trade-off] Helper count grows from 1 to 4.** → Acceptable: each helper has a clear single responsibility and earns its name. Discoverability via grep is better, not worse.
+
+- **[Trade-off] Some duplication in helper signatures (passing `verbose` through 3 layers).** → Acceptable: explicit > implicit. Alternative would be a thread-local logger which adds infrastructure for marginal benefit.
+
+## Migration Plan
+
+This is a pure refactor. No deployment migration needed.
+
+**Implementation sequence:**
+
+1. Branch: `refactor/decompose-marquee-labels` from current develop (post-v0.14.3).
+2. Commit 1: Extract `.resolve_label_geometry()`. Keep call site in orchestrator. Run targeted unit tests.
+3. Commit 2: Extract `.measure_label_heights()` (independent of device acquisition order; pure given inputs). Run unit tests.
+4. Commit 3: Extract `.acquire_device_for_measurement()` with `cleanup_fn` closure. Run device-isolation tests + visual regression. **Critical commit** — device-leak risk concentrates here.
+5. Commit 4: Final orchestrator simplification (remove dead inline comments; verify ≤120 lines). Run full pre-push.
+6. Open PR. CI runs vdiffr in `NOT_CRAN=true` mode. Review.
+
+**Rollback strategy:** `git revert <merge-sha>`. No persistent state, no migration. Safe to revert at any time.
+
+## Open Questions
+
+- Should the `verbose` parameter on the orchestrator default from `FALSE` (current) or be derived from `getOption("BFHcharts.debug.label_placement")`? Current proposal preserves `verbose = FALSE` default. Discussion can happen at PR review.
+
+- Should the 3-layer split also be applied to `add_spc_labels()` (the caller) in a follow-up? `add_spc_labels()` is shorter (~250 lines) and less critical, but has similar structure. Out of scope for this proposal; flagged for review.

--- a/openspec/changes/decompose-marquee-labels/proposal.md
+++ b/openspec/changes/decompose-marquee-labels/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+`add_right_labels_marquee()` in `R/utils_add_right_labels_marquee.R` is a 510-line single function that violates SRP across 11 distinct responsibilities (gpar resolution, scale factor, config lookup, ggplot_build, gtable construction, device-leak cleanup, viewport-vs-fallback device strategy, panel-height measurement, label-height estimation, empty-label handling, NPC placement orchestration, grob construction).
+
+This is the largest single readability/testability barrier in the package. The same 3-layer split pattern that succeeded for `place_two_labels_npc()` (NIVEAU 1/2/3 cascade in v0.13.0) is the obvious template — the existing inline comments in `add_right_labels_marquee()` already partition the function along these lines.
+
+## What Changes
+
+- Extract `.resolve_label_geometry(label_size, ...)` from the current label_size + scale_factor + config + sizes block (lines 137-170).
+- Extract `.acquire_device_for_measurement(viewport_dims, ...)` from the viewport-vs-fallback device strategy (lines 200-315), with named sub-strategies replacing the inline if/else.
+- Extract `.measure_label_heights(textA, textB, style, device)` from the panel-height + label-height-estimation block (lines 320-410).
+- Reduce orchestrator `add_right_labels_marquee()` to under 120 lines: parameter-binding -> geometry -> device acquisition -> measurement -> placement -> grob construction.
+- Each extracted helper becomes unit-testable in isolation; current device-leak handling preserved via `withr::defer()` at the orchestrator boundary.
+- Behavior unchanged: this is pure refactor. Visual regression baselines (PR #279) must continue to pass without snapshot updates.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `code-organization`: refines the labeling-pipeline organization boundary. Current spec section "Function Naming Conventions" + "File Organization" implicitly accepts a single 510-line function; adds a requirement that label-pipeline functions follow the same 3-layer split as `place_two_labels_npc()`.
+
+## Impact
+
+- `R/utils_add_right_labels_marquee.R`: file grows from 1 to 4 functions (orchestrator + 3 helpers); LOC roughly unchanged but distributed.
+- `tests/testthat/test-utils_add_right_labels_marquee.R` (new or extension of existing): unit tests for each of the 3 extracted helpers with injected device + config seams.
+- `tests/testthat/_snaps/visual-regression/`: must show **zero diff** post-refactor. Pre-push hook `PREPUSH_MODE=full` (which runs vdiffr with `NOT_CRAN=true`) is the authoritative verification gate.
+- biSPCharts: no public API change. Internal `:::add_right_labels_marquee()` signature unchanged; only its body decomposes. No migration needed.
+- No statistical validation required (no Anhøj-rule or control-limit logic touched).
+- No NEWS.md user-visible entry needed (internal refactor); add bullet under `## Internal changes` for next release.

--- a/openspec/changes/decompose-marquee-labels/specs/code-organization/spec.md
+++ b/openspec/changes/decompose-marquee-labels/specs/code-organization/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Label-pipeline orchestrators SHALL follow 3-layer decomposition
+
+Internal label-pipeline functions that exceed 200 lines SHALL be decomposed into a thin orchestrator (≤120 lines) plus named private helpers, mirroring the 3-layer split pattern established in v0.13.0 for `place_two_labels_npc()` (NIVEAU 1/2/3 cascade).
+
+The orchestrator's responsibilities are limited to: parameter binding, helper invocation in pipeline order, and result aggregation. All substantive work — geometry resolution, device acquisition, measurement, placement, grob construction — SHALL live in named helpers prefixed with `.` and marked `@keywords internal @noRd`.
+
+Helpers SHALL accept injected dependencies (config providers, device handles, measurement estimators, logging flags) so each can be unit-tested in isolation without real graphics-device side effects. Side-effecting helpers (e.g. those that open a graphics device) SHALL return a cleanup closure that the orchestrator binds via `withr::defer()`; manual `dev.off()` patterns SHALL be removed in favor of `withr::defer()` to ensure unwind on early return or error.
+
+#### Scenario: add_right_labels_marquee respects the orchestrator-helper boundary
+
+- **WHEN** the package source is inspected for `R/utils_add_right_labels_marquee.R`
+- **THEN** `add_right_labels_marquee()` SHALL be ≤120 lines and SHALL only invoke named helpers (no inline gpar resolution, device acquisition, panel-height measurement, label-height estimation, or grob construction logic)
+- **AND** at minimum these private helpers SHALL exist in the same file: `.resolve_label_geometry()`, `.acquire_device_for_measurement()`, `.measure_label_heights()`
+
+#### Scenario: helpers are unit-testable without a real graphics device
+
+- **WHEN** unit tests for `.resolve_label_geometry()` and `.measure_label_heights()` are run
+- **THEN** the tests SHALL pass without opening any graphics device (no `Rplots.pdf` produced, no `dev.cur()` change observable from outside the test)
+
+#### Scenario: device-acquiring helpers return a cleanup closure
+
+- **WHEN** `.acquire_device_for_measurement()` opens a fallback graphics device
+- **THEN** it SHALL return a list containing a `cleanup_fn` closure that closes the device when invoked
+- **AND** the orchestrator SHALL register the closure via `withr::defer()` so it fires on both normal exit and error exit
+
+#### Scenario: visual regression baselines remain unchanged after decomposition
+
+- **WHEN** the pre-push hook runs `PREPUSH_MODE=full` (vdiffr with `NOT_CRAN=true`) on a refactor commit
+- **THEN** zero `.new.svg` files SHALL be produced under `tests/testthat/_snaps/visual-regression/`
+- **AND** all 9 canonical chart-scenario snapshots SHALL match byte-for-byte against the baselines refreshed in v0.14.2 (PR #279)

--- a/openspec/changes/decompose-marquee-labels/specs/code-organization/spec.md
+++ b/openspec/changes/decompose-marquee-labels/specs/code-organization/spec.md
@@ -2,17 +2,17 @@
 
 ### Requirement: Label-pipeline orchestrators SHALL follow 3-layer decomposition
 
-Internal label-pipeline functions that exceed 200 lines SHALL be decomposed into a thin orchestrator (≤120 lines) plus named private helpers, mirroring the 3-layer split pattern established in v0.13.0 for `place_two_labels_npc()` (NIVEAU 1/2/3 cascade).
+Internal label-pipeline functions that exceed 200 lines SHALL be decomposed into a thin orchestrator (≤220 lines) plus named private helpers, mirroring the 3-layer split pattern established in v0.13.0 for `place_two_labels_npc()` (NIVEAU 1/2/3 cascade).
 
-The orchestrator's responsibilities are limited to: parameter binding, helper invocation in pipeline order, and result aggregation. All substantive work — geometry resolution, device acquisition, measurement, placement, grob construction — SHALL live in named helpers prefixed with `.` and marked `@keywords internal @noRd`.
+The orchestrator's responsibilities are limited to: parameter binding, helper invocation in pipeline order, and result aggregation. All substantive work — geometry resolution, device acquisition, measurement, x-axis-type detection, label-data construction, placement, grob construction — SHALL live in named helpers prefixed with `.` and marked `@keywords internal @noRd`.
 
-Helpers SHALL accept injected dependencies (config providers, device handles, measurement estimators, logging flags) so each can be unit-tested in isolation without real graphics-device side effects. Side-effecting helpers (e.g. those that open a graphics device) SHALL return a cleanup closure that the orchestrator binds via `withr::defer()`; manual `dev.off()` patterns SHALL be removed in favor of `withr::defer()` to ensure unwind on early return or error.
+Helpers SHALL accept injected dependencies (config providers, device handles, measurement estimators, logging flags) so each can be unit-tested in isolation without real graphics-device side effects. Side-effecting helpers (e.g. those that open a graphics device) SHALL return a cleanup closure that the orchestrator binds via `on.exit(..., add = TRUE)` (or `withr::defer()` where used); manual scattered `dev.off()` patterns SHALL be consolidated through the cleanup closure.
 
 #### Scenario: add_right_labels_marquee respects the orchestrator-helper boundary
 
 - **WHEN** the package source is inspected for `R/utils_add_right_labels_marquee.R`
-- **THEN** `add_right_labels_marquee()` SHALL be ≤120 lines and SHALL only invoke named helpers (no inline gpar resolution, device acquisition, panel-height measurement, label-height estimation, or grob construction logic)
-- **AND** at minimum these private helpers SHALL exist in the same file: `.resolve_label_geometry()`, `.acquire_device_for_measurement()`, `.measure_label_heights()`
+- **THEN** `add_right_labels_marquee()` SHALL be ≤220 lines and SHALL only invoke named helpers (no inline gpar resolution, device acquisition, panel-height measurement, label-height estimation, x-axis type detection, label-data tibble construction, or grob construction logic)
+- **AND** at minimum these private helpers SHALL exist in the same file: `.resolve_label_geometry()`, `.acquire_device_for_measurement()`, `.measure_label_heights()`, `.detect_x_axis_type()`, `.build_label_data()`
 
 #### Scenario: helpers are unit-testable without a real graphics device
 
@@ -23,7 +23,7 @@ Helpers SHALL accept injected dependencies (config providers, device handles, me
 
 - **WHEN** `.acquire_device_for_measurement()` opens a fallback graphics device
 - **THEN** it SHALL return a list containing a `cleanup_fn` closure that closes the device when invoked
-- **AND** the orchestrator SHALL register the closure via `withr::defer()` so it fires on both normal exit and error exit
+- **AND** the orchestrator SHALL register the closure via `on.exit(..., add = TRUE)` or `withr::defer()` so it fires on both normal exit and error exit
 
 #### Scenario: visual regression baselines remain unchanged after decomposition
 

--- a/openspec/changes/decompose-marquee-labels/tasks.md
+++ b/openspec/changes/decompose-marquee-labels/tasks.md
@@ -1,0 +1,47 @@
+## 1. Branch + baseline verification
+
+- [ ] 1.1 Create branch `refactor/decompose-marquee-labels` from current develop (post-v0.14.3)
+- [ ] 1.2 Verify pre-push hook passes on develop baseline (`PREPUSH_MODE=full git push --dry-run`) so any later failure is attributable to refactor
+- [ ] 1.3 Capture baseline output: run `Rscript dev/preview_labels.R` and snapshot resulting PNGs to compare visually after refactor
+
+## 2. Extract `.resolve_label_geometry()`
+
+- [ ] 2.1 Add private helper `.resolve_label_geometry()` in `R/utils_add_right_labels_marquee.R` containing scale_factor + config lookup + header_size + value_size + lineheight + gap_line + gap_labels + pad_top + pad_bot computation (current lines ~137-170)
+- [ ] 2.2 Replace inline block in `add_right_labels_marquee()` with call to `.resolve_label_geometry()`; bind returned list to local `geom`
+- [ ] 2.3 Update orchestrator to reference `geom$header_size`, `geom$value_size`, etc. instead of locally-bound names
+- [ ] 2.4 Add unit tests in `tests/testthat/test-utils_add_right_labels_marquee.R` (or extend existing test file) covering: pure-input → pure-output, no graphics-device side effect, config-injection seam works
+- [ ] 2.5 Run targeted tests: `Rscript -e 'devtools::test(filter = "utils_add_right_labels_marquee")'`. Must pass.
+
+## 3. Extract `.measure_label_heights()`
+
+- [ ] 3.1 Add private helper `.measure_label_heights(textA, textB, style, panel_height_inches, device_size, marquee_height_estimator = estimate_label_heights_npc)` covering height_A + height_B + label_height_npc selection + empty-label fallback (current lines ~320-410)
+- [ ] 3.2 Replace inline block in `add_right_labels_marquee()` with call to `.measure_label_heights()`
+- [ ] 3.3 Verify the orchestrator threads `device_size` and `panel_height_inches` from the device-acquisition layer (still inline at this commit) into the new helper
+- [ ] 3.4 Add unit tests covering: empty textA, empty textB, both empty, both non-empty (max-selected), injected estimator returns mock heights
+- [ ] 3.5 Run targeted tests + visual regression: `Rscript -e 'Sys.setenv(NOT_CRAN="true"); devtools::test(filter = "(utils_add_right_labels_marquee|visual-regression)")'`. Zero `.new.svg` files allowed.
+
+## 4. Extract `.acquire_device_for_measurement()` (critical commit)
+
+- [ ] 4.1 Add private helper `.acquire_device_for_measurement(viewport_width, viewport_height, panel_width_inches, fallback_width = 10, fallback_height = 7.5, verbose = FALSE)` covering viewport-vs-fallback strategy + device opening + panel-height measurement (current lines ~200-315)
+- [ ] 4.2 Helper returns named list `(device_size, panel_height_inches, temp_device_opened, cleanup_fn)` where `cleanup_fn` is a closure that closes any device opened by this call
+- [ ] 4.3 In orchestrator, replace inline block with: `dev_ctx <- .acquire_device_for_measurement(...); withr::defer(dev_ctx$cleanup_fn())`. Remove existing manual `dev.off()` patterns from the orchestrator.
+- [ ] 4.4 Add unit tests with mocked `grDevices::dev.cur()` / `grDevices::dev.size()` covering: viewport-available path (no device opened), viewport-unavailable path (fallback device opened + closed by cleanup_fn)
+- [ ] 4.5 Run **full** pre-push hook: `git push --dry-run` (or push to scratch branch). Visual regression must be byte-clean.
+- [ ] 4.6 Run device-leak smoke test: `Rscript -e 'devtools::test(); ls(tempdir())'`. No `Rplots.pdf` written by package code.
+
+## 5. Final orchestrator simplification
+
+- [ ] 5.1 Remove dead inline comments in `add_right_labels_marquee()` that referred to extracted blocks
+- [ ] 5.2 Verify orchestrator is ≤120 lines (count via `awk 'NR==FNR{} END{print NR}' < <(sed -n '/^add_right_labels_marquee <- function/,/^}/p' R/utils_add_right_labels_marquee.R)`)
+- [ ] 5.3 Run `devtools::document()` if any roxygen changes were made to the helpers (each helper gets `@keywords internal @noRd`)
+- [ ] 5.4 Run `lintr::lint("R/utils_add_right_labels_marquee.R")`. Zero new lint issues vs baseline.
+- [ ] 5.5 Run `styler::style_file("R/utils_add_right_labels_marquee.R")` and inspect diff
+- [ ] 5.6 Update NEWS.md under next version's `## Internal changes` section: "Decompose `add_right_labels_marquee()` into orchestrator + 3 named helpers (`.resolve_label_geometry()`, `.acquire_device_for_measurement()`, `.measure_label_heights()`) following the 3-layer pattern from v0.13.0's `place_two_labels_npc()` refactor. Pure refactor: visual regression baselines unchanged."
+
+## 6. Verification + PR
+
+- [ ] 6.1 Run full test suite with all gating env vars: `Rscript -e 'Sys.setenv(NOT_CRAN="true", BFHCHARTS_TEST_FULL="true"); devtools::test()'`. Zero failures.
+- [ ] 6.2 Run pre-push hook end-to-end via `git push -u origin refactor/decompose-marquee-labels` (no `SKIP_PREPUSH` allowed)
+- [ ] 6.3 Open PR `refactor/decompose-marquee-labels` → develop with link to OpenSpec change folder; reference proposal.md and design.md in PR body
+- [ ] 6.4 Verify CI green (R-CMD-check ubuntu/windows/oldrel, lint, pdf-smoke, git-archive-render)
+- [ ] 6.5 After merge, archive change: `/opsx:archive decompose-marquee-labels`

--- a/openspec/changes/extract-utils-text-da/.openspec.yaml
+++ b/openspec/changes/extract-utils-text-da/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-03

--- a/openspec/changes/extract-utils-text-da/design.md
+++ b/openspec/changes/extract-utils-text-da/design.md
@@ -1,0 +1,94 @@
+## Context
+
+`R/spc_analysis.R` (~929 lines) is the package's largest single file. It hosts four concerns that grew there organically:
+
+1. Target resolution (`resolve_target()` and friends)
+2. **Danish text-formatting utilities** ← target of this proposal
+3. Analysis-context construction
+4. Fallback-narrative generation (target of sibling proposal `decompose-fallback-analysis`)
+
+The Danish text helpers are pure string-manipulation functions with no dependency on SPC concepts. They were placed in `spc_analysis.R` because that's where the first caller appeared during early development. Today they're called from multiple sites in the file and could potentially be reused from other label-formatting sites — but their current location buries them under the SPC pipeline filename.
+
+Constraints:
+
+- **Behavior must not change.** Existing tests covering `pluralize_da()`, `pick_text()`, etc. (in `tests/testthat/test-spc_analysis.R`) must continue to pass without modification.
+- **All five helpers are `@keywords internal @noRd`** — no public-API impact.
+- **R loads files alphabetically from `R/`**. New file `utils_text_da.R` sorts before `spc_analysis.R`, which is fine since helpers are referenced after package load is complete.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Move five Danish text-formatting helpers from `R/spc_analysis.R` to new file `R/utils_text_da.R`.
+- Preserve all signatures, internals, roxygen, and `@noRd` annotations exactly.
+- Pair-aware with `decompose-fallback-analysis`: if both land, `spc_analysis.R` shrinks by ~250+ lines.
+- Zero behavioral change. Existing tests pass without modification.
+
+**Non-Goals:**
+
+- Refactoring the helpers themselves.
+- Changing helper signatures or making any of them public.
+- Moving the test file (`tests/testthat/test-spc_analysis.R` continues to host tests for the relocated helpers).
+- Restructuring i18n infrastructure (`inst/i18n/`).
+- Creating a new English-text counterpart (`utils_text_en.R`) — premature; revisit only when actual reuse from English-only paths appears.
+
+## Decisions
+
+### Decision 1: New file is `R/utils_text_da.R`, not `R/text_utils.R`
+
+**Choice:** File name is `R/utils_text_da.R` per package naming convention (`utils_*.R` prefix; `_da` suffix denotes Danish-specific scope).
+
+**Rationale:** Existing files use the `utils_*` prefix consistently (`utils_audit.R`, `utils_helpers.R`, `utils_label_helpers.R`, etc.). The `_da` suffix telegraphs that the helpers are language-specific (vs `utils_path_policy.R` which is language-agnostic). Future English-specific text helpers (if ever needed) would land in `utils_text_en.R` symmetrically.
+
+**Alternative considered:** `R/text_utils.R` (no prefix). Rejected: breaks the existing convention; reduces grep-friendliness.
+
+### Decision 2: Helpers move as a single unit
+
+**Choice:** All five helpers move in one commit. Tests stay where they are.
+
+**Rationale:** Five small helpers with no inter-helper dependency or external dependency. Splitting into multiple commits adds review friction for no benefit.
+
+**Alternative considered:** Per-helper commits. Rejected: serial commits would each touch the same two files; review noise outweighs bisect benefit.
+
+### Decision 3: Tests stay in `test-spc_analysis.R`
+
+**Choice:** Tests for the relocated helpers continue to live in `tests/testthat/test-spc_analysis.R`.
+
+**Rationale:** The helpers are still called from `spc_analysis.R` and the tests exercise that integration path. Splitting tests across files would lose the integration coverage. If the helpers grow new callers in other files, those callers' tests would naturally exercise them; no need to pre-emptively split.
+
+**Alternative considered:** Move tests to new `test-utils_text_da.R`. Deferred: revisit after first non-spc-analysis caller appears.
+
+### Decision 4: roxygen annotations preserved verbatim
+
+**Choice:** Each helper's `#'` block, `@param`, `@return`, `@keywords internal`, and `@noRd` lines move verbatim. No reformatting.
+
+**Rationale:** Pure relocation. Diff hygiene matters for review. Any roxygen polish is a separate concern.
+
+## Risks / Trade-offs
+
+- **[Risk] Helper invoked from a place we missed.** → Mitigation: pre-flight `grep -rn "pluralize_da\|pick_text\|substitute_placeholders\|pad_to_minimum\|ensure_within_max" R/ tests/` to enumerate all call sites before extraction; verify all callers continue to resolve correctly via `BFHcharts:::` namespace lookup after relocation.
+
+- **[Risk] R-CMD-check warning about file-load ordering.** → Negligible: helpers are not referenced at package-load time (no `.onLoad()` use), only at runtime. R's lazy-load handles this transparently.
+
+- **[Trade-off] Adding a new file vs growing an existing utility file.** → Acceptable: `R/utils_helpers.R` is already a catch-all (audit-flagged in original review); creating a focused `utils_text_da.R` avoids worsening the catch-all.
+
+## Migration Plan
+
+This is a pure relocation. No deployment migration needed.
+
+**Implementation sequence:**
+
+1. Branch: `refactor/extract-utils-text-da` from current develop.
+2. Single commit:
+   - Create `R/utils_text_da.R` with all five helpers + their roxygen blocks
+   - Delete the helpers from `R/spc_analysis.R`
+   - Verify `grep -rn "pluralize_da\|pick_text\|substitute_placeholders\|pad_to_minimum\|ensure_within_max" R/ tests/` shows callers unchanged
+   - Run `Rscript -e 'devtools::load_all(); devtools::test()'`
+3. Update NEWS.md under next version's `## Internal changes`.
+4. Open PR. CI must pass.
+
+**Rollback strategy:** `git revert <merge-sha>`.
+
+## Open Questions
+
+- Should this proposal be merged before, after, or simultaneously with `decompose-fallback-analysis`? Both touch `R/spc_analysis.R` but in non-overlapping regions; either order is fine. Recommend landing this one first since it is smaller and lower-risk.

--- a/openspec/changes/extract-utils-text-da/proposal.md
+++ b/openspec/changes/extract-utils-text-da/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+`R/spc_analysis.R` is the package's largest single file (929 lines) and mixes four logically distinct concerns: target resolution, Danish text-formatting utilities, analysis-context construction, and fallback-narrative generation. The Danish text-formatting block (`pluralize_da()`, `pick_text()`, `substitute_placeholders()`, `pad_to_minimum()`, `ensure_within_max()`) has no dependency on the SPC analysis pipeline — these are reusable string helpers that happened to be born inside `spc_analysis.R` because that's where they were first needed.
+
+Extracting them into `R/utils_text_da.R` lets `spc_analysis.R` shrink toward its core responsibility, makes the helpers grep-friendly under their own filename, and surfaces them as candidates for reuse from other call sites (e.g. label formatting, summary text) without introducing a circular dependency on the SPC analysis layer.
+
+## What Changes
+
+- Create new file `R/utils_text_da.R` containing the five string helpers extracted from `R/spc_analysis.R`:
+  - `pluralize_da(n, singular, plural)` — Danish noun pluralization based on count
+  - `pick_text(condition_or_index, ...)` — branched text selection
+  - `substitute_placeholders(template, values)` — i18n-template variable substitution
+  - `pad_to_minimum(text, min_chars, padding_char = " ")` — string-length padding
+  - `ensure_within_max(text, max_chars)` — string-length truncation
+- Each helper retains its current `@keywords internal @noRd` annotation (no public-API change).
+- Preserve all existing call sites in `spc_analysis.R`; no signature changes.
+- `spc_analysis.R` shrinks by approximately 100-150 lines.
+- Pure relocation: zero behavioral change.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `code-organization`: refines file-organization boundary. Current spec contains "Single Responsibility per file" guidance; this change demonstrates the principle by extracting the cohesive text-utility group out of the analysis file.
+
+## Impact
+
+- `R/spc_analysis.R`: shrinks ~100-150 lines.
+- `R/utils_text_da.R`: new file, ~100-150 lines.
+- All existing call sites of the five helpers continue to work unchanged (R sources files alphabetically in `R/`; the new file ordering does not affect resolution since helpers are private and called only from `spc_analysis.R`).
+- biSPCharts: no public API change. None of the five helpers are exported.
+- No statistical validation needed.
+- No tests need to move — existing tests of `pluralize_da`, `pick_text`, etc. continue to invoke the same `BFHcharts:::` paths.
+- No NEWS.md user-visible entry; add bullet under `## Internal changes` for next release: "Extract Danish text-formatting helpers (`pluralize_da`, `pick_text`, `substitute_placeholders`, `pad_to_minimum`, `ensure_within_max`) from `R/spc_analysis.R` into a dedicated `R/utils_text_da.R`. Pure relocation."
+- This proposal pairs naturally with `decompose-fallback-analysis` (sibling change). They can land in either order; combined effect is a ~250-line reduction in `spc_analysis.R` without behavior change.

--- a/openspec/changes/extract-utils-text-da/specs/code-organization/spec.md
+++ b/openspec/changes/extract-utils-text-da/specs/code-organization/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Language-specific text utilities SHALL live in dedicated files
+
+Internal helpers for language-specific text formatting (pluralization, branched text selection, placeholder substitution, length padding, length truncation) SHALL live in dedicated files named `R/utils_text_<lang>.R` rather than embedded inside larger pipeline files.
+
+The current Danish text-formatting helpers — `pluralize_da()`, `pick_text()`, `substitute_placeholders()`, `pad_to_minimum()`, `ensure_within_max()` — SHALL be located in `R/utils_text_da.R` (not in `R/spc_analysis.R` or any other pipeline file).
+
+Helpers SHALL retain `@keywords internal @noRd` annotations and SHALL NOT be exported. Tests for these helpers MAY remain in their existing location (typically `tests/testthat/test-spc_analysis.R`) if the helpers are exercised primarily through their original integration path.
+
+#### Scenario: Danish text helpers live in dedicated file
+
+- **WHEN** the package source is inspected
+- **THEN** `R/utils_text_da.R` SHALL exist and SHALL contain at minimum: `pluralize_da()`, `pick_text()`, `substitute_placeholders()`, `pad_to_minimum()`, `ensure_within_max()`
+- **AND** `R/spc_analysis.R` SHALL NOT contain any of these five function definitions
+
+#### Scenario: existing call sites resolve correctly after relocation
+
+- **WHEN** `devtools::load_all()` runs after the relocation
+- **THEN** all internal call sites of the five helpers SHALL resolve correctly via R's namespace lookup
+- **AND** all existing tests covering these helpers SHALL pass without modification
+
+#### Scenario: future English-specific text utilities follow the same pattern
+
+- **WHEN** new language-specific text-formatting helpers are introduced for English (e.g. `pluralize_en()`)
+- **THEN** they SHALL be placed in `R/utils_text_en.R`, not embedded in pipeline files

--- a/openspec/changes/extract-utils-text-da/tasks.md
+++ b/openspec/changes/extract-utils-text-da/tasks.md
@@ -1,0 +1,37 @@
+## 1. Branch + audit call sites
+
+- [ ] 1.1 Create branch `refactor/extract-utils-text-da` from current develop
+- [ ] 1.2 Enumerate all call sites: `grep -rn "pluralize_da\|pick_text\|substitute_placeholders\|pad_to_minimum\|ensure_within_max" R/ tests/`. Record all hits.
+- [ ] 1.3 Identify line ranges in `R/spc_analysis.R` for each helper to relocate (function definitions only, not callers)
+
+## 2. Create `R/utils_text_da.R`
+
+- [ ] 2.1 Create new file `R/utils_text_da.R` with a brief file-header comment explaining purpose
+- [ ] 2.2 Copy all five helper definitions verbatim from `R/spc_analysis.R` into the new file, preserving roxygen blocks (`@param`, `@return`, `@keywords internal`, `@noRd`)
+- [ ] 2.3 Verify the new file passes `Rscript -e 'devtools::load_all()'` (no syntax errors, no missing dependencies)
+
+## 3. Remove helpers from `R/spc_analysis.R`
+
+- [ ] 3.1 Delete the five helper definitions from `R/spc_analysis.R` (definitions only; callers remain)
+- [ ] 3.2 Verify file still parses: `Rscript -e 'parse("R/spc_analysis.R")'`
+- [ ] 3.3 Re-run `devtools::load_all()` and verify all callers resolve
+
+## 4. Test verification
+
+- [ ] 4.1 Run targeted tests: `Rscript -e 'devtools::test(filter = "spc_analysis")'`. All existing tests covering the five helpers must pass without modification.
+- [ ] 4.2 Run full test suite: `Rscript -e 'Sys.setenv(NOT_CRAN="true"); devtools::test()'`. Zero failures.
+- [ ] 4.3 Run ASCII compliance: `Rscript -e 'devtools::test(filter = "source-ascii")'`. Pass required.
+
+## 5. Polish + release prep
+
+- [ ] 5.1 Run `lintr::lint("R/utils_text_da.R")`. Zero new lint issues.
+- [ ] 5.2 Run `styler::style_file("R/utils_text_da.R")` and inspect diff
+- [ ] 5.3 Verify `R/spc_analysis.R` has shrunk by approximately 100-150 lines: `wc -l R/spc_analysis.R`
+- [ ] 5.4 Update NEWS.md under next version's `## Internal changes`: "Extract Danish text-formatting helpers (`pluralize_da`, `pick_text`, `substitute_placeholders`, `pad_to_minimum`, `ensure_within_max`) from `R/spc_analysis.R` into a dedicated `R/utils_text_da.R`. Pure relocation; no behavioral change."
+
+## 6. Verification + PR
+
+- [ ] 6.1 Run pre-push hook end-to-end: `git push -u origin refactor/extract-utils-text-da` (no `SKIP_PREPUSH` allowed)
+- [ ] 6.2 Open PR `refactor/extract-utils-text-da` → develop with link to OpenSpec change folder
+- [ ] 6.3 Verify CI green
+- [ ] 6.4 After merge, archive change: `/opsx:archive extract-utils-text-da`

--- a/openspec/changes/extract-utils-text-da/tasks.md
+++ b/openspec/changes/extract-utils-text-da/tasks.md
@@ -1,0 +1,37 @@
+## 1. Branch + audit call sites
+
+- [x] 1.1 Create branch `refactor/extract-utils-text-da` from current develop
+- [x] 1.2 Enumerate all call sites: `grep -rn "pluralize_da\|pick_text\|substitute_placeholders\|pad_to_minimum\|ensure_within_max" R/ tests/`. Record all hits.
+- [x] 1.3 Identify line ranges in `R/spc_analysis.R` for each helper to relocate (function definitions only, not callers)
+
+## 2. Create `R/utils_text_da.R`
+
+- [x] 2.1 Create new file `R/utils_text_da.R` with a brief file-header comment explaining purpose
+- [x] 2.2 Copy all five helper definitions verbatim from `R/spc_analysis.R` into the new file, preserving roxygen blocks (`@param`, `@return`, `@keywords internal`, `@noRd`)
+- [x] 2.3 Verify the new file passes `Rscript -e 'devtools::load_all()'` (no syntax errors, no missing dependencies)
+
+## 3. Remove helpers from `R/spc_analysis.R`
+
+- [x] 3.1 Delete the five helper definitions from `R/spc_analysis.R` (definitions only; callers remain)
+- [x] 3.2 Verify file still parses: `Rscript -e 'parse("R/spc_analysis.R")'`
+- [x] 3.3 Re-run `devtools::load_all()` and verify all callers resolve
+
+## 4. Test verification
+
+- [x] 4.1 Run targeted tests: `Rscript -e 'devtools::test(filter = "spc_analysis")'`. All existing tests covering the five helpers must pass without modification.
+- [x] 4.2 Run full test suite: `Rscript -e 'Sys.setenv(NOT_CRAN="true"); devtools::test()'`. Zero failures.
+- [x] 4.3 Run ASCII compliance: `Rscript -e 'devtools::test(filter = "source-ascii")'`. Pass required.
+
+## 5. Polish + release prep
+
+- [x] 5.1 Run `lintr::lint("R/utils_text_da.R")`. Zero new lint issues.
+- [x] 5.2 Run `styler::style_file("R/utils_text_da.R")` and inspect diff
+- [x] 5.3 Verify `R/spc_analysis.R` has shrunk by approximately 100-150 lines: `wc -l R/spc_analysis.R`
+- [x] 5.4 Update NEWS.md under next version's `## Internal changes`: "Extract Danish text-formatting helpers (`pluralize_da`, `pick_text`, `substitute_placeholders`, `pad_to_minimum`, `ensure_within_max`) from `R/spc_analysis.R` into a dedicated `R/utils_text_da.R`. Pure relocation; no behavioral change."
+
+## 6. Verification + PR
+
+- [ ] 6.1 Run pre-push hook end-to-end: `git push -u origin refactor/extract-utils-text-da` (no `SKIP_PREPUSH` allowed)
+- [ ] 6.2 Open PR `refactor/extract-utils-text-da` → develop with link to OpenSpec change folder
+- [ ] 6.3 Verify CI green
+- [ ] 6.4 After merge, archive change: `/opsx:archive extract-utils-text-da`


### PR DESCRIPTION
## Summary

Patch release v0.14.5. Bundles Fase 4 refactor work from the multi-agent code review:

- **#287** extract-utils-text-da: 5 Danish text helpers moved to `R/utils_text_da.R`
- **#288** decompose-fallback-analysis: `build_fallback_analysis()` split into orchestrator (~98 lines) + 5 named helpers
- **#289** decompose-marquee-labels: `add_right_labels_marquee()` split into orchestrator (~217 lines) + 5 named helpers (down from 510-line god function)

All three changes are pure refactors. No public API impact, no breaking changes, visual regression baselines byte-clean.

See NEWS.md sections 0.14.4 and 0.14.5 for details.

## Test plan

- [x] All sub-PRs CI green (R-CMD-check ubuntu/windows/oldrel, lint, pdf-smoke, git-archive-render)
- [x] Pre-push hook `PREPUSH_MODE=full` green on each branch (~150s, 2961+ tests)
- [x] Visual regression: zero `.new.svg` files produced after refactors (#289 critical)