### PR TITLE
chore: tarball hygiene + offline deploy docs + conditional-image proposal

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -23,9 +23,10 @@
 ^\.\.Rcheck$
 ^BISPCHARTS\.png$
 ^Rplots\.pdf$
-^tests/testthat/Rplots\.pdf$
+^tests/testthat/.*\.pdf$
 ^tests/testthat/_problems$
-^tests/testthat/output; rm -rf
+^inst/templates/typst/bfh-template/fonts$
+^inst/templates/typst/bfh-template/fonts/.*$
 ^\.claude$
 ^\.claude/
 ^\.worktrees$

--- a/.gitignore
+++ b/.gitignore
@@ -43,10 +43,10 @@ inst/templates/typst/bfh-template/fonts/Mari*.woff2
 # Claude local settings
 .claude/settings.local.json
 # Test artifacts
-tests/testthat/Rplots.pdf
+tests/testthat/*.pdf
 tests/testthat/_problems/
-# Shell-injection test directory (deliberate malformed name from security tests)
-tests/testthat/output; rm -rf
+# Shell-injection test directory artifacts (any output*-prefixed dir/file from security tests)
+tests/testthat/output*
 # Log files
 *.log
 # Demo output

--- a/README.md
+++ b/README.md
@@ -56,6 +56,59 @@ form. If you see a startup message
 remotes::install_github("johanreventlow/BFHtheme@v0.5.0")
 ```
 
+### Locked-down / offline environments
+
+Some hospital networks (Posit Connect / RStudio Workbench behind a
+corporate firewall, air-gapped clinical infrastructure) block public
+GitHub access and cannot reach `r-universe.dev` or `github.com`
+directly. BFHcharts can still be deployed in these environments via
+one of three patterns:
+
+**1. Internal Posit Package Manager (recommended)**
+
+If your organisation hosts a Posit Package Manager instance, mirror
+the `johanreventlow.r-universe.dev` repository or publish BFHcharts +
+BFHtheme + BFHllm as internal source packages. Configure
+`options(repos = ...)` to point at the internal endpoint, then:
+
+```r
+install.packages("BFHcharts")
+```
+
+**2. Local tarball install**
+
+For one-off deployments or restricted-network environments without an
+internal mirror, download release tarballs from the GitHub Releases
+page on a connected workstation and transfer them:
+
+```r
+# On a connected machine: download release assets
+# https://github.com/johanreventlow/BFHcharts/releases
+# https://github.com/johanreventlow/BFHtheme/releases
+
+# On the deployment target: install in dependency order
+install.packages("BFHtheme_0.5.0.tar.gz",  repos = NULL, type = "source")
+install.packages("BFHcharts_0.15.0.tar.gz", repos = NULL, type = "source")
+```
+
+CRAN-mirrored runtime dependencies (`ggplot2`, `qicharts2`, `dplyr`,
+`scales`, `lubridate`, `purrr`, `stringr`, `tibble`, `yaml`,
+`commonmark`, `xml2`, `systemfonts`, `rlang`, `svglite`, `marquee`,
+`grid`, `lemon`) must be available from a CRAN mirror reachable by
+the target environment.
+
+**3. Posit Connect manifest deployment**
+
+For Shiny apps deploying via `rsconnect::writeManifest()` to Posit
+Connect (Cloud or self-hosted), the manifest pinpoints package
+versions including `Remotes:` references. Connect resolves these via
+its configured upstream repositories. If Connect cannot resolve
+`johanreventlow/BFHtheme` directly, configure an internal Package
+Manager and pin the manifest's `Remotes:` field to the internal URL.
+
+See [#270 in biSPCharts](https://github.com/johanreventlow/biSPCharts)
+for an example Posit Connect Cloud deployment configuration.
+
 ## Font Requirements
 
 BFHcharts PDF export uses the **Mari font** for hospital branding when available.

--- a/openspec/changes/add-conditional-template-image/design.md
+++ b/openspec/changes/add-conditional-template-image/design.md
@@ -1,0 +1,240 @@
+## Context
+
+BFHcharts ships a Typst template (`inst/templates/typst/bfh-template/bfh-template.typ`)
+that compiles SPC-chart PDFs with hospital branding. The branding has
+two asset categories:
+
+1. **Fonts** -- proprietary Mari + open fallback chain (Roboto, Arial,
+   Helvetica, sans-serif). Handled per ADR-001 Option A: font chain
+   degrades automatically via Typst's built-in fallback when packaged
+   fonts are absent. Companion package `BFHchartsAssets` injects Mari
+   when available.
+
+2. **Images** -- hospital logo
+   (`images/Hospital_Maerke_RGB_A1_str.png`). Currently hard-coded as
+   an unconditional `image()` call in the template. Companion package
+   injects the file via `inject_assets` callback. Without companion,
+   Typst compile fails:
+   ```
+   error: file not found (searched at images/Hospital_Maerke_RGB_A1_str.png)
+   ```
+
+The font path was solved structurally (Typst's font-fallback semantics).
+The image path needs an explicit conditional because Typst's `image()`
+function has no built-in graceful-degradation semantics -- a missing
+file is a hard error.
+
+ADR-001 acknowledges this gap explicitly:
+
+> The `images/` directory is still untracked. Render without companion
+> assets on a clean install will fail if the images/ dir is absent. A
+> future PR should add a conditional image reference or a placeholder
+> asset.
+
+This change is that future PR.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `bfh_export_pdf()` succeeds on a clean install without `inject_assets`
+  callback. PDF renders without the hospital logo.
+- `bfh_export_pdf()` continues to render WITH the logo when assets are
+  injected (via callback or explicit `metadata$logo_path`).
+- Behaviour matches the font-fallback contract: companion-injected
+  branding takes precedence, fallback gives a working but unbranded
+  result.
+- No companion-package update required (auto-detect picks up
+  `<staged-template>/images/` if the callback creates it).
+
+**Non-Goals:**
+- Bundling a placeholder logo (license + maintenance burden; separate
+  decision).
+- Changing the `images/` directory structure or filename convention.
+- Expanding to multiple logos (e.g. region-specific). One logo slot;
+  organizations swap via callback.
+- Refactoring the foreground `place()` block to use a different
+  positioning strategy (header bar uses fixed offsets that already
+  ignore the foreground image -- see "Visual layout decision" below).
+
+## Decisions
+
+### D1 -- Parameter-driven conditional, not file-existence check
+
+Two options were evaluated:
+
+**Option A (chosen):** Add a `logo_path: none` parameter to the
+template. R-side decides whether to populate it. Conditional in
+template wraps the `place(image())` call.
+
+```typst
+foreground: if logo_path != none {
+  place(
+    image(logo_path, height: 19.8mm),
+    dy: 39.6mm, dx: 0mm
+  )
+} else { none }
+```
+
+**Option B (rejected):** Use Typst's hypothetical `if file-exists(...)`
+construct. Typst does NOT have a `file-exists()` function in stable
+versions (>= 0.13). Even if added later, it couples template to runtime
+filesystem state in a way that's harder to test deterministically.
+
+**Rationale:** Option A puts the decision in R (single source of
+truth), keeps Typst code simple, and is symmetric with how `font_path`
+is handled (R decides, passes path or `none`).
+
+### D2 -- Auto-detect logo file in staged template
+
+R-side helper `.detect_packaged_logo()` mirrors the existing
+`.detect_packaged_fonts()` pattern in `R/utils_typst.R`:
+
+```r
+.detect_packaged_logo <- function(typst_file) {
+  staged_logo <- file.path(
+    dirname(typst_file), "bfh-template", "images",
+    "Hospital_Maerke_RGB_A1_str.png"
+  )
+  if (file.exists(staged_logo)) staged_logo else NULL
+}
+```
+
+Filename is **deterministic** (not glob). Companion packages
+(`BFHchartsAssets`) ship the file at this exact path. A glob-based
+detection (`*.png` in `images/`) would tempt callers to drop arbitrary
+images expecting them to render -- explicitness avoids that confusion.
+
+If callers want to use a different logo, they pass it explicitly via
+`metadata$logo_path`, which overrides auto-detect.
+
+### D3 -- Layout: foreground slot empty when logo absent
+
+The foreground `place()` block sits at `dy: 39.6mm, dx: 0mm`. The
+header bar (blue block with hospital + department text) starts at
+`(top, 52.8mm, 26.4mm rows)` -- separate `grid()` block, NOT
+positioned relative to the foreground image.
+
+Verification: removing the foreground block in a test render leaves
+the header bar at its original position. The image was decorative, not
+load-bearing for layout.
+
+If a future requirement needs the slot collapsed (header bar slides
+up), that's a layout-level change distinct from the
+graceful-degradation goal of this change. Out of scope here.
+
+### D4 -- Error semantics for invalid `logo_path`
+
+Three sub-cases:
+
+1. `logo_path = NULL` (default): no logo rendered. Success.
+2. `logo_path = "/path/to/existing.png"`: logo rendered. Success.
+3. `logo_path = "/path/that/does/not/exist.png"`: Typst compile
+   surfaces the file-not-found error verbatim. Caller gets clear
+   diagnostic.
+
+R-side does NOT pre-validate the path's existence. Rationale:
+- Pre-validation duplicates Typst's error.
+- Path may be relative to staged-template-dir at compile time, not at
+  validation time -- file existence check on the R side would have a
+  TOCTOU window.
+- Companion packages may write the file in their `inject_assets`
+  callback after `metadata$logo_path` is set; pre-validation would
+  reject valid paths.
+
+R-side DOES validate `logo_path` as a single character string (length
+1, not NA, not empty) to give a clearer error than a Typst parse
+failure when the value is malformed.
+
+### D5 -- Backward compatibility for callers using `inject_assets` only
+
+Current flow (callers of `inject_assets` callback):
+1. `bfh_export_pdf(inject_assets = MyAssets::inject_logo)`
+2. Callback creates `<staged-template>/images/Hospital_Maerke_...png`
+3. Template's hard-coded `image("images/Hospital_Maerke_...png")`
+   resolves to the staged file.
+
+After this change:
+1. `bfh_export_pdf(inject_assets = MyAssets::inject_logo)`
+2. Callback creates `<staged-template>/images/Hospital_Maerke_...png`
+   (unchanged)
+3. R wrapper auto-detects the staged file via `.detect_packaged_logo()`
+4. Auto-populates `metadata$logo_path` to the staged path
+5. Template's `if logo_path != none { ... }` branch fires with the
+   path. Logo renders identically.
+
+Companion-package consumers do nothing. Their callback continues to
+work. The logo just renders via the new code path.
+
+### D6 -- Test gating with `BFHCHARTS_TEST_RENDER`
+
+The new tests in `test-template-image-conditional.R` invoke a real
+Quarto+Typst compile. They MUST be gated by the
+`BFHCHARTS_TEST_RENDER` env var (matches existing
+`test-production-template-renders.R` pattern). Without the gate, the
+tests skip (regular `R CMD check` is not blocked on Quarto
+availability).
+
+## Risks / Trade-offs
+
+**Risk 1: Layout regression.**
+The foreground image was sized at 19.8mm tall. Removing it leaves
+empty space. If any downstream consumer relied on the visual presence
+of the logo for layout cues (e.g. visual rhythm), they'll see an
+unbranded gap.
+*Mitigation:* Smoke-test renders with + without logo; manual visual
+inspection. The header bar starts immediately below the foreground
+slot; emptiness in that region was already the no-companion behaviour
+(it just compiled-error'd before instead of rendering empty).
+
+**Risk 2: Companion package coupling.**
+If `BFHchartsAssets` ever changes the staged filename or directory,
+auto-detect breaks silently. Caller would see no logo without
+diagnostic.
+*Mitigation:* Document the auto-detect contract in
+`R/utils_typst.R::.detect_packaged_logo()` Roxygen. Companion-package
+README notes the filename convention. Acceptable risk: filename has
+been stable since first release.
+
+**Risk 3: Future multi-logo requirement.**
+If hospitals want region-specific logos, the single `logo_path` slot
+limits flexibility. Would need a list-based approach.
+*Mitigation:* Out of scope; revisit if the requirement materializes.
+The current single-slot design matches the existing template's single
+foreground image.
+
+**Trade-off: Simplicity vs flexibility.**
+A more flexible design would expose the entire `place()` arguments
+(coordinates, dimensions) as Typst parameters. Decided against:
+calibrated coordinates are template-design decisions, not
+caller-decisions. Callers swap the image, not the layout.
+
+## Migration Plan
+
+1. Land this change in a feature branch:
+   `feat/conditional-template-image`.
+2. Open PR; verify CI passes (including PDF render gate when
+   `BFHCHARTS_TEST_RENDER=true`).
+3. Manual verification: clean install in fresh R session +
+   `bfh_export_pdf()` produces logo-less PDF without errors.
+4. Manual verification: install with `BFHchartsAssets` companion +
+   `bfh_export_pdf()` produces logo-bearing PDF (visual diff vs
+   pre-change baseline).
+5. NEWS entry under next PATCH release header.
+6. After merge, mark `2026-05-01-fix-pdf-template-asset-contract`
+   task 2.5 complete and archive that change.
+
+## Open Questions
+
+- **Q1:** Should the auto-detect log a debug message when it finds /
+  doesn't find a packaged logo? Helps companion-package authors debug
+  staging issues.
+  *Tentative answer:* Yes, behind
+  `getOption("BFHcharts.debug.label_placement")` or a new equivalent
+  flag (`BFHcharts.debug.template_assets`). Defer to implementation
+  judgment.
+
+- **Q2:** Should `bfh_create_typst_document()` (exported) also accept
+  `logo_path` directly as a top-level parameter for advanced callers
+  who don't go through `bfh_export_pdf()`?
+  *Tentative answer:* Yes, but via the existing `metadata` argument --
+  no new top-level parameter. Keeps API surface small.

--- a/openspec/changes/add-conditional-template-image/proposal.md
+++ b/openspec/changes/add-conditional-template-image/proposal.md
@@ -1,0 +1,156 @@
+## Why
+
+`bfh_export_pdf()` fails out-of-the-box on a clean install because the
+production Typst template (`inst/templates/typst/bfh-template/bfh-template.typ`,
+line 67) hard-references a hospital logo image that is NOT bundled with
+the package:
+
+```typst
+foreground: (
+   place(
+     image("images/Hospital_Maerke_RGB_A1_str.png",
+     height: 19.8mm
+   ),
+   ...
+```
+
+The `images/` subdirectory is intentionally excluded from the public
+distribution (proprietary BFH branding asset). The companion package
+`BFHchartsAssets` injects the image at runtime via `inject_assets`, but
+users without the companion (e.g. anyone installing
+`pak::pkg_install("johanreventlow/BFHcharts")` without GitHub-private
+access) hit a hard Typst-compile failure:
+
+```
+error: file not found (searched at images/Hospital_Maerke_RGB_A1_str.png)
+```
+
+ADR-001 already documents the gap as the highest-severity remaining
+issue from the asset-policy work
+(`openspec/changes/2026-05-01-fix-pdf-template-asset-contract/tasks.md`
+task 2.5, marked `[-]`). The font-fallback graceful-degradation path is
+in place; only the image reference still aborts the render.
+
+The font story is **degrade gracefully** by design (Mari -> Roboto ->
+Arial -> Helvetica -> sans-serif). The image story should match that
+contract: render without the logo when assets are not injected, render
+with the logo when they are.
+
+This is the last remaining FIX NOW blocker from the production-readiness
+review (item 1.2) and the only outstanding task in the `fix-pdf-template-asset-contract`
+OpenSpec change.
+
+## What Changes
+
+**Slice A -- Conditional image rendering in template (BREAKING for callers
+who relied on the implicit failure mode):**
+
+- Replace the unconditional `image("images/Hospital_Maerke_RGB_A1_str.png", ...)`
+  call in `bfh-template.typ` with a conditional branch driven by a new
+  template parameter `logo_path` (default `none`).
+- When `logo_path` is `none` (default): no foreground image, layout is
+  preserved (same `place()` slot, just empty). Header bar + title still
+  render at the calibrated dimensions.
+- When `logo_path` is a string: image is placed at the existing
+  coordinates (`dy: 39.6mm, dx: 0mm, height: 19.8mm`).
+- Companion packages (BFHchartsAssets) populate `logo_path` via
+  `inject_assets` callback OR via the `metadata` argument to
+  `bfh_export_pdf()`.
+
+**Slice B -- R-side wiring:**
+
+- `R/utils_typst.R::build_typst_content()` adds optional `logo_path`
+  parameter; only emitted in the Typst params block when non-NULL.
+- `R/export_pdf.R::bfh_export_pdf()` adds `logo_path` to the metadata
+  contract (documented under `@param metadata`). Also: when an
+  `inject_assets` callback creates an `images/` subdirectory in the
+  staged template, the wrapper auto-detects the standard logo filename
+  and populates `logo_path` (mirrors the `--font-path` auto-detect
+  pattern in `bfh_compile_typst()`).
+- `R/utils_metadata.R::bfh_merge_metadata()` accepts and forwards
+  `logo_path`.
+
+**Slice C -- Documentation + tests:**
+
+- Update `inst/adr/ADR-001-pdf-asset-policy.md` "Negative / Remaining
+  gaps" section: image-gap is closed via this change.
+- New test `tests/testthat/test-template-image-conditional.R`:
+  - Renders without `logo_path` -> PDF compiles successfully, no logo
+    visible (asserts via `pdftools::pdf_text()` that page renders).
+  - Renders with valid `logo_path` -> PDF compiles, image embedded.
+  - Renders with invalid `logo_path` -> Typst error captured + surfaced
+    with informative message (not a silent fallback to `none`).
+- Update `tests/testthat/test-production-template-renders.R` test 1
+  (the "no inject_assets" path) to assert PDF compiles successfully
+  rather than skipping when images/ missing.
+- Update `tests/testthat/helper-fixtures.R` if it has a fixture that
+  builds metadata for tests.
+- NEWS.md entry under `## Bug fixes`: "PDF export now renders
+  successfully without a hospital logo when assets are not injected
+  (graceful degradation matching the font-fallback contract from
+  ADR-001)."
+
+**Cross-cutting:**
+
+- No version bump required: this is a bug fix that closes a known
+  graceful-degradation gap. Patch-level bump (0.15.0 -> 0.15.1) at next
+  release cadence.
+- Ship in same release as `cleanup-test-artifacts-and-repo-hygiene` if
+  ready, otherwise standalone PATCH.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `pdf-export`: `bfh_export_pdf()` no longer fails when no logo image is
+  available. Default rendering produces a logo-less PDF; companion-injected
+  assets restore branding. Reference: `openspec/specs/pdf-export/spec.md`
+  (will need delta entry under `## ADDED Requirements` for the
+  conditional image rendering).
+
+## Impact
+
+**Code (3 files):**
+- `inst/templates/typst/bfh-template/bfh-template.typ` -- replace
+  unconditional `image()` with conditional branch on `logo_path`
+  parameter (~10 lines).
+- `R/utils_typst.R` -- add `logo_path` to template params emission +
+  auto-detect packaged image (~15 lines).
+- `R/export_pdf.R` + `R/utils_metadata.R` -- forward `logo_path` through
+  metadata contract (~10 lines + Roxygen update).
+
+**Tests (2 files):**
+- `tests/testthat/test-template-image-conditional.R` -- new file, 3
+  test_that blocks (~40 lines).
+- `tests/testthat/test-production-template-renders.R` -- update test 1
+  to assert success rather than skip (~5 lines changed).
+
+**Docs:**
+- `inst/adr/ADR-001-pdf-asset-policy.md` -- close known-gap section.
+- `NEWS.md` -- bug-fix entry.
+- `R/export_pdf.R` Roxygen `@param metadata` -- add `logo_path` field.
+
+**Public API surface:**
+- `bfh_export_pdf(metadata = list(logo_path = ...))` is a new accepted
+  metadata field. Backward-compatible: callers who do not supply it get
+  the new (working) default behaviour.
+- `bfh_create_typst_document()` (exported) gains the new field via its
+  `metadata` parameter.
+
+**Risk:**
+- Visual-regression risk: the foreground `place()` slot will be empty
+  in default render. Layout calibration assumed the image was present.
+  Mitigation: smoke-test renders (no logo + with logo) confirm that
+  removal does not shift other elements (header bar, title block use
+  fixed offsets, not relative-to-image positioning).
+- Companion-package compat: `BFHchartsAssets` currently relies on
+  staging the image via `inject_assets` callback, which writes to
+  `<staged-template>/images/`. After this change the callback-only
+  path still works (auto-detect picks up the staged image). Companion
+  package does NOT need an immediate update.
+
+**Out of scope:**
+- Replacing the BFH logo with a placeholder asset (license decision +
+  bundle-size tradeoff).
+- Bundling Roboto fonts (separate decision per ADR-001 §"Negative").
+- Changing the font chain (companion-only Mari remains first priority).

--- a/openspec/changes/add-conditional-template-image/specs/pdf-export/spec.md
+++ b/openspec/changes/add-conditional-template-image/specs/pdf-export/spec.md
@@ -1,0 +1,93 @@
+## ADDED Requirements
+
+### Requirement: Typst template SHALL render conditionally on logo presence
+
+The `bfh-diagram` Typst template SHALL accept a `logo_path` parameter
+(default `none`) and SHALL render the foreground hospital logo only
+when `logo_path` is supplied with a non-`none` value.
+
+**Rationale:**
+- Mirrors the font-fallback graceful-degradation contract: branding
+  assets injected by companion packages take precedence; absence of
+  assets does not block PDF rendering.
+- `bfh_export_pdf()` succeeds out-of-the-box on a clean install
+  without requiring `inject_assets` callback or
+  `BFHchartsAssets` companion package.
+- Layout calibration of header bar + title block is unchanged
+  (foreground `place()` slot uses fixed offsets, not relative-to-image
+  positioning).
+
+#### Scenario: PDF compiles without logo when no companion assets present
+
+- **GIVEN** a clean BFHcharts install without `BFHchartsAssets`
+  companion package
+- **AND** no `metadata$logo_path` is supplied
+- **AND** no `inject_assets` callback creates `images/` subdirectory
+- **WHEN** `bfh_export_pdf(result, "out.pdf")` is called
+- **THEN** the Typst compile SHALL succeed (no file-not-found error)
+- **AND** the PDF SHALL render with the calibrated header bar + title
+- **AND** the foreground logo slot SHALL be empty (no broken-image
+  marker)
+
+```r
+result <- bfh_qic(test_data, x = month, y = value, chart_type = "i")
+bfh_export_pdf(result, "out.pdf")
+# PDF compiles successfully; no logo visible
+```
+
+#### Scenario: PDF renders with logo when companion injects asset
+
+- **GIVEN** an `inject_assets` callback that writes
+  `<staged-template>/images/Hospital_Maerke_RGB_A1_str.png`
+- **AND** no explicit `metadata$logo_path` is supplied
+- **WHEN** `bfh_export_pdf(result, "out.pdf", inject_assets = MyAssets::inject_logo)`
+  is called
+- **THEN** R-side auto-detect SHALL discover the staged logo file
+- **AND** R-side SHALL populate `metadata$logo_path` automatically
+- **AND** the PDF SHALL render with the hospital logo at the
+  calibrated foreground position
+
+```r
+result <- bfh_qic(test_data, x = month, y = value, chart_type = "i")
+bfh_export_pdf(result, "out.pdf",
+               inject_assets = BFHchartsAssets::inject_bfh_assets)
+# PDF compiles with hospital logo embedded
+```
+
+#### Scenario: PDF renders with explicit logo_path
+
+- **GIVEN** a caller-supplied logo path via metadata
+- **WHEN** `bfh_export_pdf(result, "out.pdf", metadata = list(logo_path = "/abs/path/logo.png"))`
+  is called
+- **THEN** the PDF SHALL render with the supplied image
+- **AND** the explicit `logo_path` SHALL override any auto-detected
+  staged logo
+
+#### Scenario: Invalid logo_path surfaces clear error
+
+- **GIVEN** a `metadata$logo_path` pointing to a non-existent file
+- **WHEN** `bfh_export_pdf(result, "out.pdf", metadata = list(logo_path = "/no/such/file.png"))`
+  is called
+- **THEN** the Typst compile SHALL fail with the underlying
+  file-not-found error surfaced to the caller via the existing
+  `bfh_compile_typst()` error reporting
+- **AND** the error message SHALL contain enough information to
+  identify the missing path
+
+### Requirement: R wrapper SHALL auto-detect packaged logo
+
+`bfh_compile_typst()` SHALL include a helper `.detect_packaged_logo()`
+that mirrors the existing `.detect_packaged_fonts()` semantics.
+
+When `metadata$logo_path` is not supplied AND
+`<staged-template>/images/Hospital_Maerke_RGB_A1_str.png` exists, the
+wrapper SHALL populate `metadata$logo_path` automatically before
+emitting the Typst document.
+
+When `metadata$logo_path` IS supplied (non-NULL), the wrapper SHALL
+NOT override it (explicit takes precedence over auto-detect).
+
+**Rationale:** Symmetric with `--font-path` auto-detect for fonts.
+Companion-package callbacks that write the image file at the standard
+staged path get logo rendering "for free" without requiring callers to
+thread `logo_path` through their code.

--- a/openspec/changes/add-conditional-template-image/tasks.md
+++ b/openspec/changes/add-conditional-template-image/tasks.md
@@ -1,0 +1,84 @@
+## 1. Template-side: conditional image rendering
+
+- [ ] 1.1 Add `logo_path: none` parameter to `bfh-diagram()` function
+      signature in `inst/templates/typst/bfh-template/bfh-template.typ`
+      (next to `footer_content`, around line 41).
+- [ ] 1.2 Replace `foreground: (place(image("images/Hospital_Maerke_RGB_A1_str.png", ...), ...))`
+      block (lines 65-78) with conditional:
+      ```typst
+      foreground: if logo_path != none {
+        place(
+          image(logo_path, height: 19.8mm),
+          dy: 39.6mm,
+          dx: 0mm
+        )
+      } else { none }
+      ```
+- [ ] 1.3 Verify Typst syntax compiles standalone: `quarto typst compile`
+      a minimal test .typ that imports the template with no logo + with
+      a fixture logo.
+
+## 2. R-side: wire `logo_path` through pipeline
+
+- [ ] 2.1 In `R/utils_typst.R::build_typst_content()`: add
+      `if (!is.null(metadata$logo_path)) params$logo_path <- ...` block.
+      Use `escape_typst_string()` on the path. Treat as Typst string,
+      not content block.
+- [ ] 2.2 In `R/utils_typst.R::bfh_compile_typst()`: add helper
+      `.detect_packaged_logo()` mirroring `.detect_packaged_fonts()`.
+      Looks for `<staged-template>/images/Hospital_Maerke_RGB_A1_str.png`
+      (or any `.png`/`.svg` in `images/` -- design decision: deterministic
+      filename vs glob).
+- [ ] 2.3 If `metadata$logo_path` not supplied AND auto-detect finds
+      staged logo: populate `metadata$logo_path` automatically before
+      calling `build_typst_content()`. Mirrors font-path auto-detect
+      semantics.
+- [ ] 2.4 In `R/export_pdf.R`: update `@param metadata` Roxygen to
+      document new `logo_path` field. Note: companion-injected assets
+      auto-populate this; explicit override is for advanced use.
+- [ ] 2.5 In `R/utils_metadata.R::bfh_merge_metadata()`: add `logo_path`
+      to the recognized metadata fields if the function whitelists.
+      Otherwise no change (pass-through).
+
+## 3. Tests
+
+- [ ] 3.1 New file `tests/testthat/test-template-image-conditional.R`
+      with three `test_that` blocks:
+      - `test_that("PDF compiles without logo when logo_path absent", {...})`
+      - `test_that("PDF compiles with logo when logo_path supplied", {...})`
+      - `test_that("PDF errors with informative message on invalid logo_path", {...})`
+      Use `withr::local_tempdir()` + `BFHCHARTS_TEST_RENDER` gate
+      (matches existing `test-production-template-renders.R` pattern).
+- [ ] 3.2 Update `tests/testthat/test-production-template-renders.R` test
+      1 (no inject_assets) to assert PDF compiles successfully (no
+      `skip_if_not()` on missing images/). Test 2 (with inject_assets)
+      remains as-is.
+- [ ] 3.3 Run full test suite + verify no regression in existing PDF
+      tests (`test-export_pdf.R`, `test-export_pdf-content.R`,
+      `test-quarto-isolation.R`).
+
+## 4. Documentation
+
+- [ ] 4.1 Update `inst/adr/ADR-001-pdf-asset-policy.md` "Negative /
+      Remaining gaps" section: image-gap closed; reference this change.
+- [ ] 4.2 NEWS.md: bug-fix entry under next release header (likely
+      `# BFHcharts 0.15.1` or `(development)`).
+- [ ] 4.3 README.md: update PDF asset policy section if it mentions
+      images-as-known-gap.
+
+## 5. Cross-link to existing OpenSpec changes
+
+- [ ] 5.1 Update `openspec/changes/2026-05-01-fix-pdf-template-asset-contract/tasks.md`
+      task 2.5 status: mark as `[x]` with note referencing this change
+      as resolution.
+- [ ] 5.2 Optionally archive `2026-05-01-fix-pdf-template-asset-contract`
+      after this change ships, since it becomes complete.
+
+## 6. Release
+
+- [ ] 6.1 Decide release scope: standalone PATCH (0.15.1) or bundle
+      with `cleanup-test-artifacts-and-repo-hygiene` (also targeting
+      PATCH).
+- [ ] 6.2 `devtools::check()` clean (no new WARNINGs).
+- [ ] 6.3 Manual verification: clean tarball install in fresh R session
+      + `bfh_export_pdf()` on sample data renders PDF without errors.


### PR DESCRIPTION
## Summary

Production-readiness review (BFHcharts v0.15.0, main) identified four FIX NOW
blockers plus several FIX SOON items. This PR resolves the build/distribution
blockers and lays the groundwork for closing the remaining PDF-asset gap via
a new OpenSpec change.

## What changes

### `dfd97cf` — chore(build): exclude proprietary fonts + test PDF artifacts from tarball
- **FIX NOW 1.1:** Adds `.Rbuildignore` patterns for `inst/templates/typst/bfh-template/fonts/`. Verified via `tar -tzf` on a fresh `R CMD build` of v0.15.0: ARIAL.TTF (Microsoft IP) and Mari\*.{otf,ttf} (BFH proprietary) are no longer bundled. Previously gitignored but NOT buildignored — every `R CMD build` shipped 22 copyright-protected fonts (5.1 MB).
- **FIX NOW 1.3:** Replaces the root-only `^[^/]+\.pdf$` rule with `^tests/testthat/.*\.pdf$` so graphics-device-leak artifacts are excluded.
- **FIX NOW 1.4:** Removes the no-op typo line `^tests/testthat/output; rm -rf` in both `.Rbuildignore` and `.gitignore`. The shell-injection test (`test-quarto-isolation.R:243`) validates BEFORE `dir.create()`, so the directory is never created; broader `tests/testthat/output*` gitignore covers any regression.

### `5dc9243` — docs(openspec): propose conditional template image rendering
- **FIX NOW 1.2 (proposal-fase):** New OpenSpec change `add-conditional-template-image` closes the last remaining PDF-export blocker. `bfh_export_pdf()` currently fails on a clean install because the Typst template hard-references a hospital logo image that is intentionally not bundled. Proposes parameter-driven conditional rendering with R-side auto-detect mirroring the existing `.detect_packaged_fonts()` pattern.
- Includes proposal.md, design.md (6 design decisions), tasks.md (18 tasks across 6 sections), and spec delta under `specs/pdf-export/`.
- Implementation deferred to separate PR after proposal review.

### `be381ee` — docs(install): add locked-down / offline deployment patterns
- **FIX SOON 2.2:** README.md gains an "Locked-down / offline environments" subsection covering three deployment patterns for hospital networks behind corporate firewalls: internal Posit Package Manager (recommended), local tarball install, and Posit Connect manifest deployment.

## Implicitly closed (no commit needed)

These items from the review are already resolved in current `main`:

- **2.3 (Rplots.pdf graphics-device leak):** `helper-graphics.R::with_clean_graphics()` wrapper + persistent session-level `pdf()` device in `setup.R` already in place. Verified by code-analyzer subagent.
- **2.4 (biSPCharts >= 0.15.0 migration):** biSPCharts v0.3.3 pins `BFHcharts (>= 0.15.0)` in DESCRIPTION; zero `loebelaengde_signal` legacy references; 7+ references to new `anhoej_signal`/`runs_signal`/`crossings_signal` columns.
- **3.1 (BFHCHARTS_TEST_RENDER in CI):** Already enabled in `pdf-smoke.yaml`, `render-tests.yaml`, `test-coverage.yml`. Intentionally omitted from `R-CMD-check.yaml` for fast-path CI.
- **3.2 (stale tarball):** `BFHcharts_0.9.0.tar.gz` removed from working dir.

## Out of scope (deferred)

- **2.1 restrict_template default flip to TRUE** — design-heavy + breaking change for downstream callers. Deferred to dedicated OpenSpec change `harden-pdf-export-defaults` in a follow-up session.
- **3.3 custom cl warning as summary flag** — additive but touches downstream rendering; needs API design discussion. Deferred to follow-up.

## Test plan

- [x] Fresh `R CMD build .` produces a tarball where `tar -tzf BFHcharts_0.15.0.tar.gz | grep -iE 'arial|mari|tests/testthat/.*\.pdf'` returns empty (215 entries total, down from 237).
- [x] `git diff` reviewed for accidental scope creep.
- [x] Pre-push hook passed (155s, full mode).
- [ ] CI green (R-CMD-check, pdf-smoke, render-tests, lint).
- [ ] Manual review of OpenSpec proposal (`add-conditional-template-image`) before implementation PR is opened.

## References

- Production-readiness review: see conversation context (no external link; review was conducted in-session).
- ADR-001 PDF asset policy (`inst/adr/ADR-001-pdf-asset-policy.md`) — context for the conditional-image proposal.
- `openspec/changes/2026-05-01-fix-pdf-template-asset-contract/tasks.md` task 2.5 — outstanding task that this PR's OpenSpec proposal will close.