### PR TITLE
docs: document PR-base convention in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,21 @@
 3. Tilføj Claude attribution footers:
    - ❌ "🤖 Generated with [Claude Code]"
    - ❌ "Co-Authored-By: Claude <noreply@anthropic.com>"
-   
+
+✅ **BRANCHING + PR-MODEL:**
+
+```
+feature/fix/chore branch  ──PR──▶  develop  ──PR──▶  main  ──tag──▶  release
+```
+
+- **Default PR-base = `develop`** (integration-branch). Feature/fix/chore/docs branches PR'es ALTID til `develop` medmindre brugeren eksplicit beder om andet.
+- **`develop` → `main`** kun via release-PR (typisk efter version bump + NEWS-entry). Eksempel: PR #295.
+- **Direkte PR mod `main`** undtagelsesvis tilladt for:
+  - Hotfixes der skal i produktion straks
+  - Ren-build-hygiejne PRs der ikke er feature-arbejde (ofte forhandles med bruger først)
+- **Branch-fork:** feature-branches forkes fra `develop` (sikrer ren PR-diff). Hvis branch fork'ed fra `main` mens `develop` er bagefter, vil PR mod `develop` vise extra commits — flag det og tilbyd at sync `develop ← main` først.
+- **Pre-commit hook** blokerer direkte commit på `main` (`.git/hooks/pre-commit` step 0).
+
 ---
 
 ## 1) Project Overview


### PR DESCRIPTION
## Summary

Adds explicit branching + PR-model section to `CLAUDE.md` OBLIGATORISKE REGLER. Captures convention previously only encoded in the pre-commit hook output (`opret PR mod develop via GitHub UI`).

## What changes

- Diagram: `feature/fix/chore branch ──PR──▶ develop ──PR──▶ main ──tag──▶ release`
- Rule: default PR-base = `develop` for feature/fix/chore/docs branches
- Rule: `develop → main` only via release-PR (e.g. PR #295)
- Exception: direct `main` PR allowed for hotfixes / build-hygiene (negotiate with user first)
- Branch-fork guidance: fork from `develop` to keep PR diff clean; if forked from `main` while `develop` lags, flag the diff and offer to sync `develop ← main` first
- Reference: pre-commit hook step 0 already blocks direct commits on `main`

## Why

New sessions defaulted to PR mod `main` because no project doc encoded the convention. PR #296 (chore/build hygiene) and PR #297 (feat/conditional-image) both initially branched from main, then surfaced the lag question. Documenting the rule prevents recurrence.

## Test plan

- [x] Pre-push hook passed (full mode, 157s)
- [ ] Reviewer verifies wording matches intent

No code changes; pure docs.