### PR TITLE
docs(openspec): propose harden-pdf-export-for-production (items 7+12)

### DIFF
--- a/openspec/changes/harden-pdf-export-for-production/design.md
+++ b/openspec/changes/harden-pdf-export-for-production/design.md
@@ -1,0 +1,236 @@
+## Context
+
+Production-readiness review (2026-05-04) flagged two FIX SOON items
+(2.1 and 3.3) sharing a single risk model: **clinical PDFs reach
+quality-improvement leadership where R-side warnings/console output
+never surface to a human reader**. The current `bfh_export_pdf()`
+defaults optimize for backward compatibility; the proposed defaults
+optimize for clinical-production safety with explicit opt-out for
+existing power-user patterns.
+
+This change combines both items in a single OpenSpec cycle because:
+- Both target the same threat model (warning-blind PDF readers)
+- Both touch `bfh_export_pdf()` defaults
+- Both require coordinated cross-repo bumps (biSPCharts pin or
+  migration)
+- Bundling avoids two MINOR breaking-change cycles
+
+Stakeholders:
+- BFHcharts maintainer (Johan Reventlow) -- owns API contract.
+- biSPCharts (downstream Shiny app) -- primary clinical-production
+  consumer; must verify no `template_path` exposure to user input
+  (slice A) and may opt-in to consume `cl_user_supplied` attribute
+  (slice B).
+- Healthcare clinicians -- read summary indirectly via PDF; subject
+  matter benefit from caveat-rendering (slice B).
+
+Constraints:
+- Pre-1.0 (`0.15.x`). Per `VERSIONING_POLICY.md` §A, breaking changes
+  allowed in MINOR with `## Breaking changes` NEWS marking.
+- ASCII-only in `R/*.R` source (per project CLAUDE.md). Danish in
+  i18n YAML files allowed.
+- Must not regress existing tests (3016 passing as of 0.15.1).
+- biSPCharts compatibility: slice A must not require biSPCharts code
+  change; slice B must not require it but should enable opt-in
+  consumption.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Default `bfh_export_pdf()` posture safer for clinical production
+  without forcing existing power-user patterns to break silently.
+- Surface custom-`cl` semantics in two channels: R warning (existing,
+  for interactive users) + PDF caveat (new, for clinical readers).
+- Keep API surface small: one parameter default flip + one summary
+  attribute + one Typst template parameter.
+- Document the "warning-blind clinical reader" risk model so future
+  default decisions can reference it (ADR-003).
+
+**Non-Goals:**
+- Replacing the R warning with a hard error (over-restrictive for power
+  users with external benchmarks).
+- Adding `*_user_supplied` flags for `freeze`/`exclude`/`part` (separate
+  semantics; if needed, separate change).
+- Hardening other `bfh_qic()` defaults (e.g. `multiply`, `agg.fun`).
+- Adding new column to `summary` for `cl_user_supplied` (would break
+  `lapply(summary, ...)` patterns; attribute is the cleaner choice).
+- Migrating biSPCharts (cross-repo coordination is a follow-up PR in
+  biSPCharts repo).
+
+## Decisions
+
+### D1 -- Slice A: flip `restrict_template` default to TRUE
+
+`bfh_export_pdf(restrict_template = TRUE)` becomes the new default.
+Callers needing custom `template_path` MUST opt in with
+`restrict_template = FALSE`.
+
+**Rationale:**
+- The existing validation block at `R/export_pdf.R:293-299` already
+  raises a clear error when `restrict_template = TRUE` AND
+  `template_path` is supplied. No new error path needed.
+- The default flip eliminates the silent privilege-escalation vector
+  if a configuration pipeline ever forwards user-controlled input to
+  `template_path` (e.g. Shiny `input$template`, REST API parameter).
+- Power users (BFH internal, advanced templates) opt-in once with
+  `restrict_template = FALSE`; this is a self-documenting "I know
+  what I'm doing" gesture.
+
+### D2 -- Slice B: attribute, not column, for `cl_user_supplied`
+
+`attr(summary, "cl_user_supplied") <- TRUE/FALSE` rather than
+`summary$cl_user_supplied <- TRUE/FALSE`.
+
+**Rationale:**
+- `summary` is a tidy data.frame consumed by code patterns like
+  `lapply(summary, function(col) ...)` or
+  `dplyr::summarise(across(everything(), ...))`. Adding a column
+  would invisibly change the iterable surface.
+- The flag is a SCALAR property of the entire result, not a per-phase
+  observation. Per-phase encoding would be misleading: every phase
+  shares the same `cl` value when supplied; the attribute reflects
+  the parameter, not the data.
+- Attributes are idiomatic R for metadata that travels with an object
+  (cf. `attr(x, "names")`, `attr(x, "row.names")`).
+- Downstream consumers can check via `isTRUE(attr(x, "cl_user_supplied"))`
+  -- safe against absent or unexpected values.
+
+### D3 -- Slice B: PDF caveat as Typst template parameter, not free-form text
+
+Add `cl_user_supplied: false` parameter to
+`inst/templates/typst/bfh-template/bfh-template.typ`. Conditionally
+render a caveat block (Danish/English text driven by `language`
+parameter passed from R).
+
+**Rationale:**
+- Template parameter is the existing pattern for similar conditional
+  rendering (cf. `is_run_chart`, `analysis`, `data_definition`).
+- Free-form text injection in `analysis` field would lose semantic
+  structure (callers cannot distinguish "this caveat fired" from "user
+  wrote about it manually").
+- Caveat-text is i18n-able via existing `inst/i18n/*.yaml` mechanism.
+  Default Danish text: `"Centerlinje fastsat manuelt -- Anhøj-signal
+  beregnet mod denne, ikke data-estimeret middelværdi"`. English:
+  `"Centerline manually specified -- Anhøj signal computed against
+  user-supplied centerline, not data-estimated process mean"`.
+- Caveat block placement: directly below the SPC table (above
+  `data_definition` if present). Visually grouped with the statistics
+  it caveats.
+
+### D4 -- Slice B: `bfh_extract_spc_stats()` surfaces attribute as field
+
+`bfh_extract_spc_stats.bfh_qic_result(x)$cl_user_supplied` returns
+`TRUE`/`FALSE` mirroring the attribute.
+
+**Rationale:**
+- Power users querying SPC stats via the public API SHOULD see the
+  flag without having to know about the attribute.
+- `is_run_chart` is already exposed at this level for analogous
+  reasons (Typst template needs it; consumers may also want it).
+- Keeps the attribute as the canonical source of truth (data.frame
+  attribute) but provides a discoverable surface.
+
+### D5 -- R warning behaviour unchanged
+
+The existing warning at `R/bfh_qic.R:674-682` remains. PDF caveat is
+the SECOND surface; warning is the FIRST surface (interactive users).
+
+**Rationale:**
+- Warning serves interactive R users who would NOT see the PDF
+  caveat (they may never call `bfh_export_pdf()`).
+- Removing the warning would silently change behaviour for
+  long-existing scripts.
+- Two surfaces increase the chance the issue is noticed without
+  forcing escalation to a hard error.
+
+### D6 -- Cross-repo coordination
+
+biSPCharts impact:
+- Slice A: review confirms biSPCharts always uses packaged template
+  (no `template_path` argument forwarded). No biSPCharts code change
+  required. `Imports: BFHcharts (>= 0.16.0)` lower-bound bump in a
+  separate PR per `VERSIONING_POLICY.md` §E.
+- Slice B: biSPCharts MAY opt-in by reading
+  `attr(summary, "cl_user_supplied")` and pre-warning users in the UI
+  before PDF export (e.g. tooltip on the cl-input field). Not
+  required.
+
+If biSPCharts ever needs custom templates (currently does not), it
+will hit the slice A error at deployment and can opt out with
+`restrict_template = FALSE`.
+
+## Risks / Trade-offs
+
+**Risk 1: Slice A breaks unknown downstream callers.**
+External callers (outside BFHcharts org) using `template_path` without
+`restrict_template = FALSE` hit an error at validation time. The error
+message is clear and migration is mechanical.
+*Mitigation:* `## Breaking changes` NEWS entry with explicit migration
+example. Pre-1.0 freedom per VERSIONING_POLICY.
+
+**Risk 2: Slice B caveat-text adds visual clutter to PDFs without
+custom cl.**
+The caveat only renders when `cl_user_supplied = true`; default
+behaviour is unchanged. No clutter for the common case.
+*Mitigation:* Conditional rendering in template (mirrors existing
+`is_run_chart` pattern).
+
+**Risk 3: Attribute-based design is less discoverable than column.**
+Users may not know to check `attr(summary, "cl_user_supplied")`.
+*Mitigation:* Document in Roxygen `@return` for `bfh_qic()` AND surface
+via `bfh_extract_spc_stats()$cl_user_supplied`. Power users have two
+discoverable surfaces.
+
+**Risk 4: i18n overhead for caveat-text.**
+Adding new translatable strings touches the i18n pipeline.
+*Mitigation:* Two-language scope (da, en) matches existing surfaces.
+Add to `inst/i18n/*.yaml` following existing conventions.
+
+**Trade-off: Single combined OpenSpec change vs two separate.**
+Combined: one PR, coordinated release notes, single cross-repo bump.
+Separate: smaller PRs, easier reviewer attention, but doubles the
+breaking-change-cycle overhead.
+*Decision:* Combined. Both items share threat model, scope, and
+release coordination. Reviewer can request slice-by-slice review if
+needed.
+
+## Migration Plan
+
+1. Land in feature branch `feat/harden-pdf-export-for-production`.
+2. Open PR mod `develop` per project convention.
+3. Verify CI green (R-CMD-check, pdf-smoke, render-tests, lint,
+   test-coverage).
+4. Manual verification:
+   - Slice A: `bfh_export_pdf(result, "out.pdf",
+     template_path = "/some/path.typ")` errors with clear message;
+     adding `restrict_template = FALSE` allows it.
+   - Slice B: `bfh_qic(data, ..., cl = 50) |> bfh_export_pdf("out.pdf")`
+     produces PDF with caveat-text below SPC table; `bfh_qic(data,
+     ...)` (no `cl`) does not.
+5. NEWS entry under `# BFHcharts 0.16.0` with both `## Breaking
+   changes` (slice A) and `## New features` (slice B) sections.
+6. Merge to develop. Release-cut PR `develop → main` later.
+7. Cross-repo: open biSPCharts PR bumping
+   `Imports: BFHcharts (>= 0.16.0)` after release tag.
+
+## Open Questions
+
+- **Q1:** Should the caveat-text be configurable via Roxygen
+  parameter (e.g. `caveat_text` argument to `bfh_export_pdf()`) so
+  organizations can override the default?
+  *Tentative answer:* No -- the default text is the safe minimum;
+  organizations needing custom phrasing can localize via the i18n
+  YAML files (already supported). Adding a parameter would expose
+  another vector for callers to drop the caveat entirely.
+
+- **Q2:** Should slice A flip be a 1-version deprecation cycle
+  (warn in 0.16.0, error in 0.17.0)?
+  *Tentative answer:* No -- pre-1.0 allows direct breaking; the error
+  message is self-documenting and migration is one parameter add. A
+  deprecation cycle would delay the security improvement.
+
+- **Q3:** Should `cl_user_supplied` be a per-phase attribute (vector
+  matching summary nrow) instead of a scalar?
+  *Tentative answer:* No -- `cl` argument is global to the
+  `bfh_qic()` call. Per-phase semantics would suggest different cl
+  values per phase, which the current API does not support.

--- a/openspec/changes/harden-pdf-export-for-production/proposal.md
+++ b/openspec/changes/harden-pdf-export-for-production/proposal.md
@@ -1,0 +1,181 @@
+## Why
+
+Two FIX SOON items from the production-readiness review (2026-05-04, items
+2.1 and 3.3) target the same underlying gap: **PDFs from `bfh_export_pdf()`
+typically reach quality-improvement leadership where R-side warnings never
+surface to a human reader.** The current defaults optimize for backward
+compatibility at the expense of clinical-production safety.
+
+### Slice A -- `restrict_template = FALSE` default (item 2.1)
+
+`bfh_export_pdf()` accepts `template_path` (custom Typst template) by
+default. The threat-model is already documented in `R/export_pdf.R:36-43`
+and equates a custom template with `source()`-equivalent code execution
+(Typst can read/write arbitrary paths during compilation). The
+`restrict_template = TRUE` flag exists to block this vector but defaults
+to `FALSE` for backward compatibility.
+
+In a clinical Shiny deployment (biSPCharts), if a configuration pipeline
+ever forwards user-controlled input to `template_path`, the result is a
+silent privilege-escalation vector. The author's own design comment
+flags this as the reason `restrict_template` exists -- but the safer
+default is not the chosen default.
+
+### Slice B -- Custom `cl` parameter SHALL surface in summary + PDF (item 3.3)
+
+`bfh_qic()` warns at `R/bfh_qic.R:674-682` when the user passes a custom
+`cl` argument: Anhoej run/crossing signals are computed against the
+user-supplied centerline, not the data-estimated process mean. The
+warning correctly notes that signal interpretation requires caution.
+
+But the warning is text-only and emitted at chart-creation time. By the
+time the PDF reaches a clinician, the warning is gone. The PDF shows
+"VIGTIG: Anhoej-signal: TRUE" with no indication that the centerline
+was fastsat manuelt (not data-derived). Clinicians correctly assume the
+SPC table reflects data-driven analysis and may misattribute signals as
+clinically meaningful when they are artifacts of an arbitrary user-set
+centerline.
+
+### Combined rationale
+
+Both slices target the same threat: **clinical decision-makers reading
+PDFs without access to R warnings/console state**. A single OpenSpec
+change covers them because:
+
+1. They share the same risk model (warning-blind clinical readers).
+2. They both target `bfh_export_pdf()` defaults.
+3. They both require coordinated cross-repo bumps (biSPCharts must
+   migrate or pin lower-bound).
+4. Bundling avoids two MINOR breaking-change cycles; one release with
+   coordinated release notes is cleaner.
+
+## What Changes
+
+**Slice A -- `restrict_template = TRUE` default (BREAKING):**
+
+- **BREAKING** Flip `bfh_export_pdf(restrict_template = FALSE)` ->
+  `restrict_template = TRUE`.
+- Existing callers passing `template_path` without explicit
+  `restrict_template` now hit a clear error at validation time
+  (already implemented in `R/export_pdf.R:293-299`). Migration: add
+  `restrict_template = FALSE` to opt back into custom templates.
+- Update Roxygen `@param restrict_template` to document new default
+  + migration note.
+- `bfh_create_export_session()` does NOT take `restrict_template` (it
+  doesn't accept `template_path`); no change needed there.
+
+**Slice B -- Custom `cl` summary + PDF caveat (BREAKING for downstream
+column-iteration consumers; ADDITIVE for typed consumers):**
+
+- Add `attr(summary, "cl_user_supplied")` (logical scalar) on
+  `bfh_qic_result$summary` when the caller supplied a non-NULL `cl`
+  argument to `bfh_qic()`. Attribute is preferred over a new column
+  (column would break downstream `lapply(summary, ...)` patterns).
+- `bfh_extract_spc_stats.bfh_qic_result()` reads the attribute and
+  surfaces it as `stats$cl_user_supplied`.
+- `R/utils_typst.R::build_typst_content()` emits a new template
+  parameter `cl_user_supplied: false` (default) and the template
+  conditionally renders a caveat note in the SPC table footer:
+  "Centerlinje fastsat manuelt -- Anhøj-signal beregnet mod denne, ikke
+  data-estimeret middelværdi" (Danish; English fallback when
+  `language = "en"`).
+- `R/bfh_qic.R` warning at line 674-682 is **retained** -- it surfaces
+  to interactive R users; PDF caveat is the SECOND surface for
+  warning-blind clinical readers.
+
+**Cross-cutting:**
+
+- Version bump 0.15.x -> 0.16.0 (MINOR, pre-1.0 breaking allowed per
+  `VERSIONING_POLICY.md` §A).
+- NEWS entry under `## Breaking changes` for slice A; under `## New
+  features` for slice B (additive caveat, additive attribute).
+- Cross-repo: biSPCharts SHOULD verify it never passes user-controlled
+  input to `template_path`. Review of biSPCharts confirms it always
+  uses packaged template (no `template_path` argument forwarded). No
+  biSPCharts code change required for slice A. For slice B,
+  biSPCharts MAY use the attribute to display in-app warnings before
+  PDF export.
+- Regression tests for slice A (default rejects `template_path`,
+  explicit `FALSE` accepts it); slice B (attribute set when `cl`
+  supplied, NULL when not, PDF-caveat present in rendered output).
+
+## Capabilities
+
+### Modified Capabilities
+
+- `pdf-export`: `bfh_export_pdf()` default tightened. `restrict_template`
+  flips to TRUE. Reference: `openspec/specs/pdf-export/spec.md` (will
+  add new requirement under `## ADDED Requirements`).
+- `public-api`: `bfh_qic_result$summary` gains a stable attribute
+  `cl_user_supplied`. Reference: `openspec/specs/public-api/spec.md`
+  (will add new requirement under `## ADDED Requirements`).
+
+## Impact
+
+**Code (Slice A, ~5 lines):**
+- `R/export_pdf.R` -- single default flip + Roxygen update.
+
+**Code (Slice B, ~30 lines):**
+- `R/utils_bfh_qic_helpers.R` -- attach `cl_user_supplied` attribute to
+  summary in `build_bfh_qic_return()`.
+- `R/utils_spc_stats.R` -- surface attribute in
+  `bfh_extract_spc_stats.bfh_qic_result()`.
+- `R/utils_typst.R::build_typst_content()` -- emit
+  `cl_user_supplied` parameter when set.
+- `inst/templates/typst/bfh-template/bfh-template.typ` -- new
+  `cl_user_supplied: false` parameter + conditional caveat block.
+- `R/utils_i18n.R` (or new key in `inst/i18n/*.yaml`) -- caveat-text
+  translations (da, en).
+
+**Tests:**
+- `tests/testthat/test-export_pdf.R` -- assert default rejects
+  `template_path`; explicit FALSE accepts it.
+- `tests/testthat/test-utils_qic_summary.R` (new file or extend
+  existing) -- `attr(summary, "cl_user_supplied")` set when `cl`
+  supplied, NULL otherwise.
+- `tests/testthat/test-export_pdf-content.R` -- gated PDF render
+  asserts caveat-text appears in PDF text content when `cl` supplied;
+  absent otherwise.
+
+**Docs:**
+- `R/export_pdf.R` Roxygen `@param restrict_template` documents new
+  default + migration note.
+- `R/bfh_qic.R` Roxygen `@param cl` cross-references the summary
+  attribute.
+- `NEWS.md` 0.16.0 entry: `## Breaking changes` (slice A) + `## New
+  features` (slice B).
+- `inst/adr/` -- new ADR (ADR-003) documenting the
+  warning-blind-clinical-reader risk model that drove both decisions.
+
+**Public API surface:**
+- `bfh_export_pdf(restrict_template = ...)` default value changes.
+- `bfh_qic_result$summary` gains attribute `cl_user_supplied`.
+- `bfh_extract_spc_stats(...)$cl_user_supplied` is a new returned field
+  (NULL when not applicable).
+- Typst template `bfh-diagram(cl_user_supplied = ...)` parameter is new
+  but defaults to `false` (backward compatible for direct template
+  callers).
+
+**Risk:**
+- Slice A: callers passing `template_path` without explicit
+  `restrict_template = FALSE` hit a clear error at validation. Migration
+  is mechanical (`add restrict_template = FALSE` to existing call). Risk
+  bounded.
+- Slice B: column-iteration consumers (e.g.
+  `lapply(summary, function(col) ...)`) are NOT affected because we use
+  `attr()` rather than adding a column. Typst template parameter
+  defaults preserve back-compat for direct template callers.
+- Cross-repo: biSPCharts unaffected by slice A (no custom template).
+  biSPCharts can OPT-IN to slice B by reading the attribute and
+  pre-warning users before PDF export.
+
+**Out of scope:**
+- Adding `cl_user_supplied` for `freeze`/`exclude`/`part` parameters
+  (those alter analysis but do not directly substitute the centerline;
+  separate change if needed).
+- Requiring `data_consent = "explicit"` for PDF rendering when AI is
+  not used (already covered by existing `use_ai = TRUE` gate).
+- Hardening other `bfh_qic()` defaults (e.g. `multiply`, `agg.fun`).
+- Replacing the R warning with a hard error when `cl` is supplied
+  (warning + PDF caveat is sufficient; error would be over-restrictive
+  for power users who knowingly use external benchmarks).

--- a/openspec/changes/harden-pdf-export-for-production/specs/pdf-export/spec.md
+++ b/openspec/changes/harden-pdf-export-for-production/specs/pdf-export/spec.md
@@ -1,0 +1,144 @@
+## ADDED Requirements
+
+### Requirement: `restrict_template` SHALL default to TRUE
+
+`bfh_export_pdf(restrict_template)` SHALL default to `TRUE`. Callers
+needing custom Typst templates via `template_path` SHALL explicitly
+opt-in by passing `restrict_template = FALSE`.
+
+**Rationale:**
+- Custom Typst templates are compiled by the Typst binary with full
+  filesystem and network access (equivalent to `source()`).
+- A configuration pipeline forwarding user-controlled input to
+  `template_path` (e.g. Shiny `input$template`, REST API parameter)
+  produces a silent privilege-escalation vector.
+- Default-safe matches the established pattern for `inject_assets`
+  (which already requires explicit namespace-trusted callbacks).
+- Pre-1.0 (0.15.x -> 0.16.0) breaking change is permitted per
+  `VERSIONING_POLICY.md` §A; migration is mechanical (one parameter
+  add).
+
+#### Scenario: Default rejects template_path without explicit opt-out
+
+- **GIVEN** a `bfh_qic_result` and a custom Typst template path
+- **WHEN** `bfh_export_pdf(result, "out.pdf", template_path = "/my/template.typ")`
+  is called WITHOUT `restrict_template`
+- **THEN** the function SHALL raise an informative error mentioning
+  `restrict_template = FALSE` as the explicit opt-out
+- **AND** no PDF SHALL be created
+- **AND** no Typst compile process SHALL be spawned
+
+```r
+expect_error(
+  bfh_export_pdf(result, "out.pdf", template_path = "/my/template.typ"),
+  "restrict_template"
+)
+```
+
+#### Scenario: Explicit opt-out allows custom template
+
+- **GIVEN** a `bfh_qic_result` and a custom Typst template path
+- **WHEN** `bfh_export_pdf(result, "out.pdf",
+  template_path = "/my/template.typ", restrict_template = FALSE)` is called
+- **THEN** the function SHALL accept the custom template
+- **AND** the PDF SHALL render using the supplied template
+
+```r
+expect_no_error(
+  bfh_export_pdf(result, "out.pdf",
+                 template_path = "/path/to/valid/template.typ",
+                 restrict_template = FALSE)
+)
+```
+
+#### Scenario: Default packaged template unaffected
+
+- **GIVEN** a `bfh_qic_result` and no `template_path`
+- **WHEN** `bfh_export_pdf(result, "out.pdf")` is called (default)
+- **THEN** the packaged BFH template SHALL render normally
+- **AND** the new `restrict_template = TRUE` default SHALL have no
+  effect (no `template_path` to restrict)
+
+```r
+expect_no_error(
+  bfh_export_pdf(result, "out.pdf")
+)
+```
+
+### Requirement: PDF SHALL render caveat when centerline is user-supplied
+
+When `bfh_qic_result$summary` carries
+`attr(summary, "cl_user_supplied") == TRUE`, the rendered PDF SHALL
+display a caveat block below the SPC table indicating that the
+centerline was manually specified and Anhoej signals were computed
+against the user-supplied centerline rather than the data-estimated
+process mean.
+
+**Rationale:**
+- The R-side warning (at `R/bfh_qic.R:674-682`) surfaces to interactive
+  users only; clinical PDF readers never see R warnings.
+- Clinicians correctly assume the SPC table reflects data-driven
+  analysis. Without the caveat, they may misattribute Anhoej signals
+  as clinically meaningful when they are artifacts of an arbitrary
+  user-set centerline.
+- Caveat-text is i18n-able via `inst/i18n/*.yaml`. Default Danish:
+  `"Centerlinje fastsat manuelt -- Anhoej-signal beregnet mod denne,
+  ikke data-estimeret middelvaerdi"`. English when `language = "en"`:
+  `"Centerline manually specified -- Anhoej signal computed against
+  user-supplied centerline, not data-estimated process mean"`.
+- The R-side warning is RETAINED -- the PDF caveat is the SECOND
+  surface, not a replacement.
+
+The caveat block SHALL be visually distinguished (italic, smaller font,
+grey colour) to match existing data-definition styling and SHALL be
+positioned directly below the SPC statistics table.
+
+#### Scenario: PDF with user-supplied cl renders caveat
+
+- **GIVEN** `result <- bfh_qic(data, x, y, chart_type = "i", cl = 50)`
+- **WHEN** `bfh_export_pdf(result, "out.pdf")` is called
+- **THEN** the rendered PDF SHALL contain caveat text matching the
+  i18n key `cl_user_supplied_caveat`
+- **AND** the caveat SHALL appear below the SPC statistics table
+- **AND** in Danish when `language = "da"` (default)
+
+```r
+result <- bfh_qic(data, x, y, chart_type = "i", cl = 50)
+out <- tempfile(fileext = ".pdf")
+bfh_export_pdf(result, out)
+text <- pdftools::pdf_text(out)
+expect_match(paste(text, collapse = "\n"), "fastsat manuelt")
+```
+
+#### Scenario: PDF without user-supplied cl does NOT render caveat
+
+- **GIVEN** `result <- bfh_qic(data, x, y, chart_type = "i")` (no `cl`)
+- **WHEN** `bfh_export_pdf(result, "out.pdf")` is called
+- **THEN** the rendered PDF SHALL NOT contain caveat text
+- **AND** the SPC table footer SHALL render unchanged from prior
+  versions
+
+```r
+result <- bfh_qic(data, x, y, chart_type = "i")
+out <- tempfile(fileext = ".pdf")
+bfh_export_pdf(result, out)
+text <- pdftools::pdf_text(out)
+expect_no_match(paste(text, collapse = "\n"), "fastsat manuelt")
+```
+
+#### Scenario: PDF caveat renders in English when language = "en"
+
+- **GIVEN** `result <- bfh_qic(data, x, y, chart_type = "i", cl = 50, language = "en")`
+- **WHEN** `bfh_export_pdf(result, "out.pdf")` is called
+- **THEN** the rendered PDF SHALL contain English caveat text
+  ("Centerline manually specified ...")
+- **AND** SHALL NOT contain Danish caveat text
+
+```r
+result <- bfh_qic(data, x, y, chart_type = "i", cl = 50, language = "en")
+out <- tempfile(fileext = ".pdf")
+bfh_export_pdf(result, out)
+text <- pdftools::pdf_text(out)
+expect_match(paste(text, collapse = "\n"), "manually specified")
+expect_no_match(paste(text, collapse = "\n"), "fastsat manuelt")
+```

--- a/openspec/changes/harden-pdf-export-for-production/specs/public-api/spec.md
+++ b/openspec/changes/harden-pdf-export-for-production/specs/public-api/spec.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+### Requirement: Summary SHALL carry `cl_user_supplied` attribute
+
+The summary returned by `bfh_qic()$summary` SHALL carry an attribute
+`cl_user_supplied` (logical scalar) reflecting whether the caller
+supplied a non-NULL `cl` argument to `bfh_qic()`.
+
+**Rationale:**
+- Downstream consumers (PDF rendering, biSPCharts UI, analysis text)
+  need to know whether the centerline is data-derived or user-supplied
+  WITHOUT introspecting the entire `config` slot.
+- An attribute (rather than a column) preserves backward compatibility
+  for column-iteration patterns (e.g. `lapply(summary, ...)`,
+  `dplyr::summarise(across(...))`).
+- Scalar (rather than per-phase vector) matches the API: `cl` is a
+  single global value supplied via one parameter; per-phase encoding
+  would suggest distinct per-phase user-cl values that the API does not
+  support.
+
+**Encoding:**
+- `attr(summary, "cl_user_supplied") = TRUE` when user passed
+  `bfh_qic(..., cl = <non-NULL>)`.
+- `attr(summary, "cl_user_supplied") = FALSE` when user did not pass
+  `cl` (default; centerline is data-estimated).
+
+**Consumer pattern:**
+- Safe check: `isTRUE(attr(result$summary, "cl_user_supplied"))`.
+- The attribute SHALL also be exposed via
+  `bfh_extract_spc_stats(result)$cl_user_supplied` for discovery
+  parity with `is_run_chart` and other surfaced flags.
+
+#### Scenario: Attribute set to TRUE when cl supplied
+
+- **GIVEN** `bfh_qic(data, x, y, chart_type = "i", cl = 50)` is called
+- **WHEN** the result is returned
+- **THEN** `attr(result$summary, "cl_user_supplied")` SHALL be `TRUE`
+- **AND** `isTRUE(attr(result$summary, "cl_user_supplied"))` SHALL
+  evaluate to `TRUE`
+
+```r
+result <- bfh_qic(data, x = month, y = value, chart_type = "i", cl = 50)
+expect_true(isTRUE(attr(result$summary, "cl_user_supplied")))
+```
+
+#### Scenario: Attribute set to FALSE when cl absent
+
+- **GIVEN** `bfh_qic(data, x, y, chart_type = "i")` is called (no `cl`)
+- **WHEN** the result is returned
+- **THEN** `attr(result$summary, "cl_user_supplied")` SHALL be `FALSE`
+
+```r
+result <- bfh_qic(data, x = month, y = value, chart_type = "i")
+expect_identical(attr(result$summary, "cl_user_supplied"), FALSE)
+```
+
+#### Scenario: bfh_extract_spc_stats surfaces the attribute
+
+- **GIVEN** a `bfh_qic_result` with `cl` supplied
+- **WHEN** `bfh_extract_spc_stats(result)` is called
+- **THEN** the returned list SHALL include
+  `cl_user_supplied = TRUE`
+
+```r
+result <- bfh_qic(data, x = month, y = value, chart_type = "i", cl = 50)
+stats <- bfh_extract_spc_stats(result)
+expect_true(stats$cl_user_supplied)
+
+result_no_cl <- bfh_qic(data, x = month, y = value, chart_type = "i")
+stats_no_cl <- bfh_extract_spc_stats(result_no_cl)
+expect_identical(stats_no_cl$cl_user_supplied, FALSE)
+```
+
+#### Scenario: Attribute survives return.data = TRUE path
+
+- **GIVEN** `bfh_qic(..., cl = 50, return.data = TRUE)` is called
+- **WHEN** the raw qic_data data.frame is returned
+- **THEN** `attr(result, "cl_user_supplied")` SHALL also be `TRUE`
+  (attribute attaches to the returned data.frame for discovery
+  parity with the S3 path)
+
+```r
+qic <- bfh_qic(data, x = month, y = value, chart_type = "i",
+               cl = 50, return.data = TRUE)
+expect_true(isTRUE(attr(qic, "cl_user_supplied")))
+```

--- a/openspec/changes/harden-pdf-export-for-production/tasks.md
+++ b/openspec/changes/harden-pdf-export-for-production/tasks.md
@@ -1,0 +1,153 @@
+## 1. Slice A: flip `restrict_template` default to TRUE
+
+- [ ] 1.1 In `R/export_pdf.R::bfh_export_pdf()`: change parameter
+      default from `restrict_template = FALSE` to
+      `restrict_template = TRUE`. Single-line change at line 271.
+- [ ] 1.2 Update Roxygen `@param restrict_template` (around lines
+      32-43): document new default + add migration note for callers
+      passing `template_path`. Example:
+      ```r
+      # Before (BFHcharts <= 0.15.x): custom template silently allowed
+      bfh_export_pdf(result, "out.pdf", template_path = "/my/template.typ")
+
+      # After (BFHcharts >= 0.16.0): explicit opt-out required
+      bfh_export_pdf(result, "out.pdf",
+                     template_path = "/my/template.typ",
+                     restrict_template = FALSE)
+      ```
+- [ ] 1.3 Update Roxygen `@section Security` to reflect the new safer
+      default; remove the "Default: FALSE (backward-compatible)" note;
+      add "Default: TRUE (production-safe)".
+- [ ] 1.4 Verify validation block at lines 293-299 still fires
+      correctly when default flips (no code change needed; just
+      verify behaviour).
+
+## 2. Slice B: attach `cl_user_supplied` attribute to summary
+
+- [ ] 2.1 In `R/utils_bfh_qic_helpers.R::build_bfh_qic_return()`:
+      add logic to detect whether `config$cl` is non-NULL and set
+      `attr(summary_result, "cl_user_supplied") <- !is.null(config$cl)`
+      before returning the `bfh_qic_result` object.
+      Note: applies whether `return.data = FALSE` (S3 path) or
+      `return.data = TRUE` (raw qic_data path; attribute on the
+      data.frame is harmless and useful).
+- [ ] 2.2 In `R/utils_spc_stats.R::bfh_extract_spc_stats.bfh_qic_result()`:
+      surface the attribute as `stats$cl_user_supplied <- isTRUE(attr(x$summary, "cl_user_supplied"))`.
+      Place near `stats$is_run_chart` assignment for consistency.
+- [ ] 2.3 In `R/utils_spc_stats.R::empty_spc_stats()`: add
+      `cl_user_supplied = NULL` to the empty list (so the field is
+      always discoverable in the type signature even when absent).
+
+## 3. Slice B: PDF template caveat rendering
+
+- [ ] 3.1 Add `cl_user_supplied: false` parameter to
+      `inst/templates/typst/bfh-template/bfh-template.typ`
+      `bfh-diagram()` signature (next to `is_run_chart`, around
+      line 38). Update the parameter doc-comment block at lines 4-21.
+- [ ] 3.2 Add caveat-text Typst block below the SPC table (after the
+      existing `data_definition` block, around line 320). Conditional
+      rendering:
+      ```typst
+      #if cl_user_supplied {
+        block(width: 100%, inset: (top: 2mm),
+          text(fill: rgb("888888"), size: 9pt, style: "italic",
+            "Centerlinje fastsat manuelt -- Anhoej-signal beregnet ",
+            "mod denne, ikke data-estimeret middelvaerdi"))
+      }
+      ```
+      Note: ASCII-only in template body for the inline default; i18n
+      values (with proper Danish chars) flow via the parameter when
+      English/Danish text is computed R-side.
+- [ ] 3.3 R-side: compute caveat text in `compose_typst_document()`
+      based on `language` config + `cl_user_supplied` flag. Pass as
+      a NEW Typst parameter `cl_caveat_text` (string) so the template
+      renders pre-translated text rather than hard-coded Danish.
+- [ ] 3.4 Update `R/utils_typst.R::build_typst_content()` to emit the
+      new parameters: `cl_user_supplied` (boolean) + `cl_caveat_text`
+      (string, only when `cl_user_supplied = TRUE`).
+
+## 4. Slice B: i18n strings
+
+- [ ] 4.1 Add to `inst/i18n/da.yaml` (or whichever default-Danish
+      file exists):
+      ```yaml
+      cl_user_supplied_caveat: >
+        Centerlinje fastsat manuelt -- Anhoej-signal beregnet
+        mod denne, ikke data-estimeret middelvaerdi
+      ```
+- [ ] 4.2 Add to `inst/i18n/en.yaml`:
+      ```yaml
+      cl_user_supplied_caveat: >
+        Centerline manually specified -- Anhoej signal computed
+        against user-supplied centerline, not data-estimated
+        process mean
+      ```
+- [ ] 4.3 Verify `R/utils_i18n.R` exposes a helper to look up the
+      key; if not, extend it minimally to support this single new
+      key. (Likely already supports key-based lookup.)
+
+## 5. Tests
+
+- [ ] 5.1 New tests in `tests/testthat/test-export_pdf.R`:
+      - `test_that("bfh_export_pdf rejects template_path by default", { ... })`
+        Asserts default behaviour errors with informative message
+        when `template_path` supplied without explicit
+        `restrict_template = FALSE`.
+      - `test_that("bfh_export_pdf accepts template_path with restrict_template = FALSE", { ... })`
+        Asserts opt-out works.
+- [ ] 5.2 New tests in `tests/testthat/test-utils_qic_summary.R`
+      (or new file `test-cl-user-supplied-flag.R`):
+      - `test_that("summary has cl_user_supplied attribute = TRUE when cl supplied", { ... })`
+      - `test_that("summary has cl_user_supplied attribute = FALSE when cl NULL", { ... })`
+      - `test_that("bfh_extract_spc_stats surfaces cl_user_supplied", { ... })`
+- [ ] 5.3 Extend `tests/testthat/test-export_pdf-content.R` (gated
+      by `BFHCHARTS_TEST_RENDER`):
+      - Render PDF with `bfh_qic(..., cl = X)`; assert PDF text
+        contains caveat string (Danish + English).
+      - Render PDF without `cl`; assert PDF text does NOT contain
+        caveat string.
+- [ ] 5.4 Extend `tests/testthat/test-i18n.R` to verify new
+      `cl_user_supplied_caveat` key resolves correctly in both
+      locales.
+- [ ] 5.5 Run full test suite + verify no regression in existing PDF
+      tests.
+
+## 6. Documentation
+
+- [ ] 6.1 Update `R/export_pdf.R` Roxygen (Section: Security): refer
+      to new safer default + cross-reference ADR-003.
+- [ ] 6.2 Update `R/bfh_qic.R` Roxygen `@param cl`: cross-reference
+      `attr(result$summary, "cl_user_supplied")` for downstream
+      consumers.
+- [ ] 6.3 NEWS.md `# BFHcharts 0.16.0`:
+      - `## Breaking changes` section: slice A migration example.
+      - `## New features` section: slice B summary attribute + PDF
+        caveat description.
+- [ ] 6.4 New ADR `inst/adr/ADR-003-warning-blind-clinical-readers.md`
+      documenting the risk model that drove both decisions:
+      "PDFs reach quality-improvement leadership where R-side warnings
+      never surface; defaults must optimize for clinical-production
+      safety with explicit power-user opt-outs."
+
+## 7. Cross-repo coordination
+
+- [ ] 7.1 Verify biSPCharts source: confirm no `template_path`
+      argument is passed to `bfh_export_pdf()`. (Reviewed in design
+      D6; re-verify pre-merge.)
+- [ ] 7.2 Document in this change's PR description that biSPCharts
+      requires a follow-up PR bumping `Imports: BFHcharts (>= 0.16.0)`
+      per VERSIONING_POLICY §E.
+
+## 8. Release
+
+- [ ] 8.1 Bump `DESCRIPTION` Version: 0.15.x -> 0.16.0.
+- [ ] 8.2 `devtools::check()` clean (no new WARNINGs).
+- [ ] 8.3 Manual verification:
+      - Default `bfh_export_pdf(result, "out.pdf",
+        template_path = "/x.typ")` errors as expected.
+      - `restrict_template = FALSE` opt-out works.
+      - `bfh_qic(data, ..., cl = 50) |> bfh_export_pdf("out.pdf")`
+        renders with caveat.
+      - `bfh_qic(data, ...) |> bfh_export_pdf("out.pdf")` renders
+        without caveat.
+- [ ] 8.4 Tag `v0.16.0` after `develop -> main` release-PR merges.


### PR DESCRIPTION
## Summary

Combines two FIX SOON items from the production-readiness review (2026-05-04) into a single OpenSpec change. Both target the same threat model: **clinical PDFs reach quality-improvement leadership where R-side warnings never surface to a human reader**.

Implementation deferred to separate PR after proposal review (per existing `add-conditional-template-image` precedent).

## What changes

### Slice A — `restrict_template = TRUE` default (BREAKING)

Item 2.1 from production-readiness review. `bfh_export_pdf(restrict_template)` flips from `FALSE` (backward-compat) to `TRUE` (production-safe). Callers needing custom Typst templates opt-in with explicit `restrict_template = FALSE`.

**Why:** A configuration pipeline forwarding user-controlled input to `template_path` is `source()`-equivalent privilege escalation. The validation already exists at `R/export_pdf.R:293-299` — only the default is misaligned.

**Migration:** mechanical — add `restrict_template = FALSE` to existing `bfh_export_pdf(..., template_path = ...)` calls. biSPCharts review confirms no `template_path` forwarding (no biSPCharts code change needed).

### Slice B — Custom `cl` surfaces in summary + PDF (ADDITIVE attribute, NEW PDF caveat)

Item 3.3 from production-readiness review. Adds `attr(summary, "cl_user_supplied")` when caller supplied non-NULL `cl` to `bfh_qic()`. PDF template renders Danish/English caveat block below the SPC table.

**Why:** Existing R warning at `R/bfh_qic.R:674-682` is text-only at chart-creation; clinical PDF readers never see R warnings. Caveat is the SECOND surface, not a replacement (R warning RETAINED for interactive users).

**Encoding:** `attr()` (not column) preserves backward compat for `lapply(summary, ...)` patterns. Surfaced via `bfh_extract_spc_stats()$cl_user_supplied` for discovery parity with `is_run_chart`.

## Why combine into single OpenSpec

- Same threat model (warning-blind clinical readers)
- Both touch `bfh_export_pdf()` defaults
- Both require coordinated cross-repo bumps (biSPCharts pin)
- Bundling avoids two MINOR breaking-change cycles

Reviewer can request slice-by-slice review if preferred.

## Files

- `proposal.md` — why + what changes + capabilities + impact
- `design.md` — 6 design decisions (D1-D6), risk analysis, open questions, migration plan
- `tasks.md` — 27 tasks across 8 sections (slice A, B, tests, docs, ADR, cross-repo, release)
- `specs/pdf-export/spec.md` — 2 ADDED requirements (slice A + B PDF behaviour)
- `specs/public-api/spec.md` — 1 ADDED requirement (slice B summary attribute)

## Test plan

No code changes in this PR — pure docs/proposal. Implementation PR (post-proposal-review) will:

- [ ] Slice A regression tests (default rejects, opt-out accepts, packaged template unaffected)
- [ ] Slice B regression tests (attribute set/unset, surfaced via extract_spc_stats)
- [ ] Slice B render tests (PDF caveat present/absent in Danish + English)
- [ ] `devtools::check()` clean
- [ ] Manual verification per design.md migration plan

## Cross-references

- `openspec/changes/archive/2026-05-04-add-conditional-template-image/` — just-archived precedent for OpenSpec workflow pattern
- `VERSIONING_POLICY.md` §A — pre-1.0 MINOR breaking allowed
- `VERSIONING_POLICY.md` §E — cross-repo bump-protokol
- Production-readiness review (2026-05-04, conversation context)