### PR TITLE
docs(openspec): propose cleanup-stale-spec-issues

### DIFF
--- a/openspec/changes/cleanup-stale-spec-issues/design.md
+++ b/openspec/changes/cleanup-stale-spec-issues/design.md
@@ -1,0 +1,168 @@
+## Context
+
+OpenSpec audit (2026-05-04) gennemgik 7 main specs (totalt 64
+requirements) og fandt 5 issues. To er allerede haandteret (Phase 1):
+
+- pdf-smoke.yaml comment-refresh: deferred (hook-blokeret)
+- batch session regression tests: tilfoejet i PR #302
+
+Resterende 3 issues kraever koordinerede design-aendringer der
+beroerer flere specs og potentielt har downstream-konsekvenser hvis
+forkert haandteret. Bundles i en enkelt OpenSpec change for at:
+
+1. Sikre at boundary-redefinitioner mellem specs (#3) ikke giver
+   inconsistencies hvis kun delvist landet.
+2. Reducere review-overhead -- hver enkelt issue er smaa, men de
+   beroerer beslaegtede specs.
+3. Levere komplet "spec hygiene"-state efter merge.
+
+Stakeholders:
+- BFHcharts maintainer (Johan Reventlow) -- ejer alle specs.
+- Fremtidige bidragsydere -- specs er primaer kontekst-kilde for nye
+  changes; misvisende dokumentation oeger onboarding-cost og introducer
+  risk for incorrect change-proposals.
+
+Constraints:
+- Ingen kode-aendringer (specs beskriver kontrakter; faktisk kode er
+  allerede correct).
+- Pre-1.0 (`0.16.0`); spec-aendringer udloeser ej version bump per
+  `VERSIONING_POLICY.md` §A (kun adfaerd/API udloeser bump).
+- Skal validere `openspec validate --specs --strict` 7/7 efter merge.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `caching-system` afspejler aktuel kode (marquee-cache only).
+- `code-organization` #7 har mening for fremtidige bidragsydere
+  (strukturelle krav, ikke linje-tal).
+- `public-api` ↔ `spc-analysis-api` har klart afgraenset ejerskab uden
+  indholdsduplication.
+- Alle specs har komplete Scenario blocks per
+  `openspec validate --strict`.
+
+**Non-Goals:**
+- Refactor `add_right_labels_marquee.R` til ≤220 lines (line-cap
+  fjernes, faktisk fil-struktur er allerede 3-layer).
+- Fjern `caching-system` spec helt (ville miste design-rationale for
+  marquee-cache; refit er bedre).
+- Tilfoej nye public-api-funktioner.
+- Hard rename mellem `public-api` og `spc-analysis-api` (begge specs
+  bevares; kun ejerskab praeciseret).
+
+## Decisions
+
+### D1 -- `caching-system` refit, ej retire (Slice 1)
+
+`caching-system` spec bevares fordi `marquee_cache` er en bevidst
+design-beslutning med performance-impact (label-rendering hot path).
+Spec'en er det sted hvor invarianter (cache-key beregning, eviction-
+politik, thread-safety) skal dokumenteres for fremtidige bidragsydere.
+
+**Rationale:**
+- Retire ville miste design-rationale.
+- Refit er enklere -- fjern obsolete grob-cache-references, tilfoej
+  Scenario blocks for marquee-cache baseret paa faktisk kode.
+- `R/cache_marquee_styles.R` er ~50 LOC med simpel API; spec-vedlige-
+  hold er minimalt.
+
+### D2 -- `code-organization` #7 line-cap fjernes, strukturelle krav bevares (Slice 2)
+
+220-line hard cap er arbitraer. Vaerdien af 3-layer pattern er
+strukturel:
+
+- **Orchestrator:** parameter binding, helper invocation pipeline-
+  rakkefolge, result aggregation. Ingen inline geometry-resolution,
+  device-acquisition, measurement.
+- **Named helpers:** `@keywords internal @noRd`-praefiks `.`, single
+  responsibility, dependency-injected.
+- **Cleanup-closures:** side-effekt-helpers returnerer cleanup-fn
+  bundtet via `on.exit(..., add = TRUE)`.
+
+`R/utils_add_right_labels_marquee.R` (731 lines) opfylder denne
+struktur med 13+ named helpers. 220-line hard cap er en historisk
+maaling der ikke afspejler kompleksitet -- den incentiverer fragmen-
+tering til flere filer (oeger review-cost) frem for at kontrollere
+kompleksitet inde i en fil.
+
+**Rationale:**
+- Strukturel vurdering kan formuleres som krav (ingen inline
+  device-acquisition).
+- Linje-tal er konsekvens af helper-mengde, ikke kompleksitet.
+- Fremtidige bidragsydere kan vurdere om en orchestrator passer
+  modellen uden at tjekke `wc -l`.
+
+### D3 -- spec-boundary praeciseret, ej hard split (Slice 3)
+
+`public-api` og `spc-analysis-api` er beslaegtede men ortogonale:
+
+| Concern | Owner |
+|---|---|
+| Hvad eksporterer paketten? | public-api |
+| Hvad er signature/return-type? | public-api |
+| Hvilke attributes/contracts laever output? | public-api |
+| Hvad betyder Anhoej-signaler? | spc-analysis-api |
+| Hvordan dispatcher fallback-narrative? | spc-analysis-api |
+| Hvordan computer-resolveres target-direction? | spc-analysis-api |
+
+**Rationale:**
+- `public-api` er stable surface -- aendringer kraever MAJOR/MINOR bump.
+- `spc-analysis-api` er semantic interpretation -- aendringer kan
+  vaere subtilere (e.g. tweaks i tolkning af crossings).
+- Tre specifikke kontrakter (`bfh_extract_spc_stats()` signatur,
+  `bfh_merge_metadata()` signatur, `cl_user_supplied`-attribute)
+  beroerer begge concerns -- per-spec-rolle afgoer hvor de doku-
+  menteres.
+- Krydsreferencer ("See X for Y") sikrer at laesere finder vej uden
+  at indholdet duplikeres.
+
+## Risks / Trade-offs
+
+**Risk 1: Spec-boundary praecisering misforstaas som breaking change.**
+Spec-aendringer er rent dokumentation -- ingen kode-aendringer, ingen
+adfaerds-aendringer. Aendringerne reducerer fremtidig review-friction
+men har ingen runtime-impact. NEWS.md vil bemaerke spec-cleanup.
+
+**Risk 2: Marquee-cache invarianter dokumenteres forkert.**
+Mitigation: implementations-PR validerer mod faktisk kode i
+`R/cache_marquee_styles.R` ved tilfoejelse af Scenario blocks.
+
+**Risk 3: code-organization #7 fortolkes for laxt uden line-cap.**
+Mitigation: kvalitative krav er normative ("orchestrator SHALL NOT
+contain inline X"). Fremtidig review kan nemt vurdere om en orchestra-
+tor matcher modellen.
+
+**Trade-off: Bundlet vs separate proposals.**
+Bundlet: en review-cyklus, koordinerede deltas. Separat: smallere
+diffs, but tre review-cycler for low-impact aendringer.
+*Decision:* Bundlet -- alle slices er rent dokumentation, lav risk,
+faelles audit-context.
+
+## Migration Plan
+
+1. Land i feature-branch `chore/cleanup-stale-spec-issues`.
+2. Aben PR mod develop.
+3. Verify CI green (R-CMD-check, lint, test-coverage).
+4. Verify `openspec validate --specs --strict`: 7/7.
+5. Merge til develop. Ingen tag, ingen NEWS-entry udover en kort
+   "Internal: spec hygiene" note (specs paavirker ikke API-version).
+6. Cross-repo: ingen biSPCharts-impact.
+
+## Open Questions
+
+- **Q1:** Skal `caching-system` spec slettes hvis marquee-cache
+  i fremtiden ogsaa fjernes?
+  *Tentative answer:* Yes -- spec lever saa laenge cachen er en
+  bevidst design-beslutning. Naar koden fjernes, retire spec via
+  proposal med `## REMOVED Capabilities` section.
+
+- **Q2:** Burde `code-organization` #7 erstattes af en helt ny
+  formulering, eller skal den modificeres in-place?
+  *Tentative answer:* Modify in-place. Identiteten ("3-layer
+  decomposition") bevares; kun maaling-mekanismen aendres fra "lines"
+  til "structural attributes".
+
+- **Q3:** Krydsreferencer mellem `public-api` og `spc-analysis-api` --
+  formelt link eller prose-reference?
+  *Tentative answer:* Prose ("See spc-analysis-api Requirement: X for
+  Y"). OpenSpec har ikke et formelt cross-spec-link-system, og prose
+  laekker ej ved versionering af aendringer.

--- a/openspec/changes/cleanup-stale-spec-issues/proposal.md
+++ b/openspec/changes/cleanup-stale-spec-issues/proposal.md
@@ -1,0 +1,123 @@
+## Why
+
+OpenSpec audit (2026-05-04) afsloerede 3 design-issues i de gennemarbejdede
+main specs der kraever koordinerede aendringer:
+
+### 1. `caching-system` refererer fjernet kode
+
+Spec dokumenterer `configure_grob_cache()` + `clear_grob_cache()` som
+public helpers. Begge fjernet i v0.5.0 -- kun `marquee_cache` (intern
+style-cache i `R/cache_marquee_styles.R`) eksisterer i dag. Spec's
+Purpose, alle 4 requirements, og dokumentations-references (e.g.
+`docs/CACHING_SYSTEM.md`) refererer til en feature der ikke laengere
+findes. Resultat: nye bidragsydere foer-laeser dokumentationsstart i
+spec'en og bliver vildledt om paketens caching-strategi.
+
+Yderligere: ingen af de 4 requirements har Scenario blocks (struktur-fejl
+flagget af `openspec validate --specs --strict`).
+
+### 2. `code-organization` requirement #7 har urealistisk linje-target
+
+Requirement: `add_right_labels_marquee` SHALL be ≤220 lines.
+Faktisk: `R/utils_add_right_labels_marquee.R` = 731 lines.
+
+Filen blev decomposed til 3-layer pattern (orchestrator + named helpers
++ isolation-testable side-effekt-helpers) i change
+`2026-05-03-decompose-marquee-labels` -- men 220-line hard cap er en
+arbitraer maeleenhed der ikke afspejler den strukturelle vaerdi af
+3-layer pattern. Files maa naturligt vaere stoerre naar de indeholder
+mange smaa helpers + dokumentation. Hard cap incentiverer fragmentering
+til stoerre antal smaa filer (oeget review-cost) frem for at kontrollere
+kompleksitet via single-responsibility helpers.
+
+Strukturelle krav (named helpers, dependency injection, cleanup-closures)
+er stadig vaerdifulde og skal bevares.
+
+### 3. `public-api` ↔ `spc-analysis-api` har overlappende ejerskab
+
+Tre kontrakter er aktuelt dokumenteret i begge specs:
+
+- `bfh_extract_spc_stats()`-funktionssignaturen
+- `bfh_merge_metadata()`-funktionssignaturen
+- `cl_user_supplied`-attribute (tilfoejet i 0.16.0)
+
+Overlap er ikke ren duplication -- hvert spec beskriver kontrakter fra
+sit perspektiv. Men uden klart afgraenset ejerskab risikerer fremtidige
+changes at opdatere et spec og glemme det andet, foreaarsage
+inconsistencies.
+
+## What Changes
+
+**Slice 1 -- `caching-system` refit:**
+
+- **MODIFIED** `caching-system` spec Purpose: opdater til at beskrive
+  marquee-cache som primaer caching-strategi; fjern referencer til
+  grob-cache.
+- **REMOVED** `caching-system` requirement der dokumenterer
+  `configure_grob_cache()` / `clear_grob_cache()` public helpers
+  (funktioner ej i kode siden v0.5.0).
+- **MODIFIED** resterende requirements: tilfoej Scenario blocks for at
+  daekke marquee-cache lifecycle (cache-key beregning, eviction,
+  thread-safety) baseret paa faktisk kode i
+  `R/cache_marquee_styles.R`.
+
+**Slice 2 -- `code-organization` #7 line-cap fjernes:**
+
+- **MODIFIED** `code-organization` requirement #7 ("Label-pipeline
+  orchestrators SHALL follow 3-layer decomposition"): fjern hard
+  220-line cap; bevar krav om named helpers, isolation-testbarhed, og
+  cleanup-closure-pattern. Tilfoej eksplicit guidance: orchestrator-
+  rolle handler om _ansvar_, ikke linje-tal -- target er at undgaa
+  inline kompleksitet (geometry-resolution, device-acquisition,
+  measurement) i orchestrator, ej at maeke samlet fil-stoerrelse.
+
+**Slice 3 -- spec-boundary cleanup mellem `public-api` og `spc-analysis-api`:**
+
+- **MODIFIED** `public-api` Purpose: praeciseret som ejer af
+  user-facing API contracts (signaturer, eksport-status, return-types,
+  attribute-existence).
+- **MODIFIED** `spc-analysis-api` Purpose: praeciseret som ejer af
+  internal signal-detection logic (Anhoej rules, fallback-narrative
+  dispatch, threshold semantics).
+- **REMOVED** redundant kontrakt-dokumentation:
+  - `spc-analysis-api`: fjern signatur-detaljer for
+    `bfh_extract_spc_stats()` og `bfh_merge_metadata()` (ejes af
+    public-api).
+  - `public-api`: fjern Anhoej-signal interpretations-detaljer
+    (ejes af spc-analysis-api).
+- **MODIFIED** krydsreferencer: hver spec bevarer en kort "See X spec
+  for Y"-reference hvor det er nyttigt.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `caching-system`: refit til marquee-cache only.
+- `code-organization`: req #7 line-cap fjernes; strukturelle krav
+  bevares.
+- `public-api`: ejer user-facing API contracts.
+- `spc-analysis-api`: ejer internal signal-detection logic.
+
+## Impact
+
+**Specs:** 4 specs modified, ingen nye specs.
+
+**Kode:** Ingen kode-aendringer.
+
+**Tests:** Ingen test-aendringer (specs beskriver _kontrakter_, ikke
+implementation; faktisk kode er allerede paa plads og bestaaet
+2995-test-suite).
+
+**Risiko:** Lav. Aendringer er rent dokumentations- og kontrakt-
+oprydning. Ingen API-aendringer, ingen behavior-aendringer.
+
+**Cross-repo:** Ingen impact paa biSPCharts.
+
+**Out of scope:**
+- pdf-smoke.yaml comment-refresh (Phase 1 #14, blokeret af pre-tool-use
+  hook -- separat manuel opgave).
+- code-organization: hvorvidt `add_right_labels_marquee.R` _faktisk_
+  matcher den nye strukturelle definition (audit-opgave for
+  implementation-PR; specs definerer kun kontrakten).
+- batch session regression tests (Phase 1 #5, allerede landet i PR
+  #302).

--- a/openspec/changes/cleanup-stale-spec-issues/specs/caching-system/spec.md
+++ b/openspec/changes/cleanup-stale-spec-issues/specs/caching-system/spec.md
@@ -1,0 +1,56 @@
+## MODIFIED Requirements
+
+### Requirement: Caching documentation SHALL describe current cache topology
+
+The package SHALL document the four active package-private caches
+(`font`, `marquee_style`, `quarto`, `i18n`) and the canonical reset
+helper in a single discoverable file (`docs/CACHING_SYSTEM.md` or
+equivalent reference).
+
+**Rationale:**
+- New contributors need a one-page overview of caching strategy without
+  reading every `R/cache_*.R` file.
+- Current implementation: `.font_cache`, `.marquee_style_cache`,
+  `.quarto_cache`, `.i18n_cache` (per `R/cache_reset.R::bfh_reset_caches()`).
+- The legacy grob-cache was removed in v0.5.0; documentation SHALL
+  reflect the simplified topology rather than retaining stale
+  configuration references.
+
+#### Scenario: Documentation lists active caches
+
+- **GIVEN** the caching documentation file (currently
+  `docs/CACHING_SYSTEM.md`)
+- **WHEN** a contributor reads it
+- **THEN** the file SHALL list all four package-private caches by name
+  and purpose (`font`, `marquee_style`, `quarto`, `i18n`)
+- **AND** the file SHALL NOT reference removed helpers
+  (`configure_grob_cache()`, `clear_grob_cache()`)
+- **AND** the file SHALL document `bfh_reset_caches()` as the canonical
+  reset helper (internal API only)
+
+## REMOVED Requirements
+
+### Requirement: Cache configuration functions SHALL include global state warnings
+
+**Reason:** No exported cache-configuration helpers exist in the package
+since v0.5.0. The legacy `configure_grob_cache()` and
+`clear_grob_cache()` were removed; the only remaining cache helper
+(`bfh_reset_caches()`) is `@keywords internal @noRd` and not part of
+the public API surface. A requirement governing user-facing cache
+configuration warnings has no implementation target.
+
+**Migration:** Internal cache state is now documented at the spec level
+(see modified "Caching documentation SHALL describe current cache
+topology" requirement) rather than in per-function Roxygen warnings.
+
+### Requirement: Caching documentation SHALL include troubleshooting guide
+
+**Reason:** Subsumed by the modified "Caching documentation SHALL
+describe current cache topology" requirement, which sets a discovery
+contract without prescribing a troubleshooting subsection. The previous
+formulation referenced `docs/CACHING_SYSTEM.MD` as the canonical
+location of a troubleshooting section that does not exist; rather than
+mandate a specific subsection (which encourages stale documentation),
+the modified requirement contracts on completeness of the cache list.
+Future troubleshooting content can be added to the same file or
+elsewhere as separate proposals dictate.

--- a/openspec/changes/cleanup-stale-spec-issues/specs/code-organization/spec.md
+++ b/openspec/changes/cleanup-stale-spec-issues/specs/code-organization/spec.md
@@ -1,0 +1,73 @@
+## MODIFIED Requirements
+
+### Requirement: Label-pipeline orchestrators SHALL follow 3-layer decomposition
+
+Internal label-pipeline functions SHALL be decomposed into a thin
+orchestrator plus named private helpers, mirroring the 3-layer split
+pattern established in v0.13.0 for `place_two_labels_npc()` (NIVEAU 1/2/3
+cascade).
+
+The orchestrator's responsibilities are limited to: parameter binding,
+helper invocation in pipeline order, and result aggregation. All
+substantive work -- geometry resolution, device acquisition, measurement,
+x-axis-type detection, label-data construction, placement, grob
+construction -- SHALL live in named helpers prefixed with `.` and marked
+`@keywords internal @noRd`.
+
+Helpers SHALL accept injected dependencies (config providers, device
+handles, measurement estimators, logging flags) so each can be
+unit-tested in isolation without real graphics-device side effects.
+Side-effecting helpers (e.g. those that open a graphics device) SHALL
+return a cleanup closure that the orchestrator binds via
+`on.exit(..., add = TRUE)` (or `withr::defer()` where used); manual
+scattered `dev.off()` patterns SHALL be consolidated through the cleanup
+closure.
+
+**Note on file size:** A hard line-count cap (e.g. orchestrator <=220
+lines) is NOT a requirement. The 3-layer pattern controls complexity via
+single-responsibility helpers, not via file fragmentation. A file
+containing one orchestrator plus 10-15 named helpers may legitimately
+exceed 700 lines without violating the structural contract -- the
+metric is _what each function does_, not _how many lines the file
+holds_.
+
+#### Scenario: orchestrator contains no inline substantive work
+
+- **GIVEN** an orchestrator function in a label-pipeline file (e.g.
+  `add_right_labels_marquee()`, `place_two_labels_npc()`)
+- **WHEN** the function body is inspected
+- **THEN** the orchestrator SHALL only invoke named helpers (no inline
+  gpar resolution, device acquisition, panel-height measurement,
+  label-height estimation, x-axis-type detection, label-data tibble
+  construction, or grob construction logic)
+- **AND** each invoked helper SHALL exist as a separate named function
+  in the same file or in a co-located helpers file
+
+#### Scenario: helpers are unit-testable without a real graphics device
+
+- **WHEN** unit tests for non-side-effect helpers (e.g.
+  `.resolve_label_geometry()`, `.measure_label_heights()`) are run
+- **THEN** the tests SHALL pass without opening any graphics device
+  (no `Rplots.pdf` produced, no `dev.cur()` change observable from
+  outside the test)
+
+#### Scenario: device-acquiring helpers return a cleanup closure
+
+- **WHEN** a helper opens a fallback graphics device (e.g.
+  `.acquire_device_for_measurement()`)
+- **THEN** it SHALL return a list containing a `cleanup_fn` closure that
+  closes the device when invoked
+- **AND** the orchestrator SHALL register the closure via
+  `on.exit(..., add = TRUE)` or `withr::defer()` so it fires on both
+  normal exit and error exit
+
+#### Scenario: helper module file size is not bounded
+
+- **GIVEN** a file containing a label-pipeline orchestrator and its
+  named helpers (e.g. `R/utils_add_right_labels_marquee.R`)
+- **WHEN** the file is inspected
+- **THEN** the file SHALL pass review purely on structural grounds
+  (orchestrator role, named helpers, dependency injection, cleanup
+  closures)
+- **AND** the review SHALL NOT reject the file solely on the basis of
+  line count

--- a/openspec/changes/cleanup-stale-spec-issues/specs/public-api/spec.md
+++ b/openspec/changes/cleanup-stale-spec-issues/specs/public-api/spec.md
@@ -1,0 +1,51 @@
+## MODIFIED Requirements
+
+### Requirement: Public API specification ownership
+
+The `public-api` capability SHALL govern user-facing API contracts:
+exported function signatures, parameter types, return types, attribute
+existence, and stability guarantees. It SHALL NOT govern internal
+signal-detection logic, fallback-narrative dispatch, or threshold
+semantics -- those concerns are owned by `spc-analysis-api`.
+
+When a contract spans both capabilities (e.g.
+`bfh_extract_spc_stats(result)$cl_user_supplied`), the `public-api`
+spec SHALL document the API surface (presence, type, stable name) and
+the `spc-analysis-api` spec SHALL document the underlying meaning
+(when the flag is set, what it implies for Anhoej-signal
+interpretation).
+
+Cross-references SHALL be expressed as prose ("See spc-analysis-api
+Requirement: X for Y") rather than formal links, since OpenSpec does
+not support cross-spec linking and prose remains valid across spec
+versions.
+
+**Rationale:**
+- Stable surface (signatures, return types) and semantic meaning
+  (what signals imply) evolve at different rates -- `public-api`
+  changes require MAJOR/MINOR bumps, while `spc-analysis-api`
+  refinements may be subtler.
+- Without explicit ownership boundaries, future changes risk updating
+  one spec and forgetting the other, producing inconsistencies.
+- Prose cross-references survive renaming and don't fail validation.
+
+#### Scenario: Purpose section identifies ownership
+
+- **WHEN** a contributor reads `openspec/specs/public-api/spec.md`
+- **THEN** the `## Purpose` section SHALL state that this capability
+  owns user-facing API contracts (signatures, eksport status, return
+  types, attribute existence, stability guarantees)
+- **AND** the Purpose SHALL explicitly delegate signal-detection
+  semantics to `spc-analysis-api`
+
+#### Scenario: Cross-reference rather than duplication
+
+- **WHEN** a `public-api` requirement describes a contract that has
+  semantic meaning owned by `spc-analysis-api` (e.g. `cl_user_supplied`
+  attribute, target-direction operator parsing)
+- **THEN** the `public-api` requirement SHALL state the API surface
+  (attribute name, type, when present)
+- **AND** SHALL include a prose cross-reference like "See
+  spc-analysis-api Requirement: <name> for the underlying signal
+  interpretation"
+- **AND** SHALL NOT duplicate the semantic interpretation rules

--- a/openspec/changes/cleanup-stale-spec-issues/specs/spc-analysis-api/spec.md
+++ b/openspec/changes/cleanup-stale-spec-issues/specs/spc-analysis-api/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: SPC analysis API specification ownership
+
+The `spc-analysis-api` capability SHALL govern internal
+signal-detection logic and analysis-text generation: Anhoej rule
+interpretation, fallback-narrative dispatch, threshold semantics,
+target-direction parsing, and percent-target normalization rules.
+It SHALL NOT govern exported API surfaces (function signatures,
+return types, attribute existence) -- those concerns are owned by
+`public-api`.
+
+When a contract spans both capabilities, this spec SHALL document the
+underlying meaning (when a signal fires, what semantic interpretation
+applies, how thresholds are evaluated) without restating the API
+surface details documented in `public-api`.
+
+Cross-references SHALL be expressed as prose ("See public-api
+Requirement: X for the API contract") rather than formal links.
+
+**Rationale:**
+- Anhoej rule interpretation, narrative-text dispatch, and target-
+  direction semantics evolve as the package gains nuance from clinical
+  feedback -- these refinements are typically additive or
+  clarifying, not breaking.
+- API stability concerns (does the function exist? what does it
+  return?) belong with the user-facing surface contract.
+- Without explicit ownership boundaries, requirements describing the
+  same thing from different angles drift apart over time.
+
+#### Scenario: Purpose section identifies ownership
+
+- **WHEN** a contributor reads
+  `openspec/specs/spc-analysis-api/spec.md`
+- **THEN** the `## Purpose` section SHALL state that this capability
+  owns internal signal-detection logic, fallback-narrative dispatch,
+  and threshold/target semantics
+- **AND** the Purpose SHALL explicitly delegate exported API surface
+  contracts (signatures, return types, attribute existence) to
+  `public-api`
+
+#### Scenario: Cross-reference rather than duplication
+
+- **WHEN** an `spc-analysis-api` requirement describes signal
+  semantics whose API surface is governed by `public-api` (e.g.
+  `cl_user_supplied` attribute meaning, custom-`cl` Anhoej-signal
+  caveat)
+- **THEN** the `spc-analysis-api` requirement SHALL state the
+  semantic meaning (what the signal implies for interpretation)
+- **AND** SHALL include a prose cross-reference like "See public-api
+  Requirement: <name> for the API surface contract"
+- **AND** SHALL NOT duplicate signature or return-type details

--- a/openspec/changes/cleanup-stale-spec-issues/tasks.md
+++ b/openspec/changes/cleanup-stale-spec-issues/tasks.md
@@ -1,0 +1,95 @@
+## 1. Slice 1 -- `caching-system` refit
+
+- [ ] 1.1 Inspicer `R/cache_marquee_styles.R` for at dokumentere
+      faktisk cache-API (cache-key beregning, invalidation, eksport-
+      status). Identificer invarianter der skal kontraktes (e.g.
+      idempotent get/set, no-op clear paa empty cache, thread-safety
+      antagelser).
+- [ ] 1.2 Opdater `openspec/specs/caching-system/spec.md`:
+      - Erstat Purpose section med beskrivelse af marquee-cache som
+        primaer caching-mekanisme (label-rendering hot path).
+      - Fjern alle requirements der refererer til
+        `configure_grob_cache()` / `clear_grob_cache()`.
+      - Bevar requirements der dokumenterer principper (hvis nogen
+        er saa generiske at de stadig holder, e.g. "package SHALL
+        document caching strategy").
+      - Tilfoej minimum 1 Scenario block per resterende requirement.
+- [ ] 1.3 Opret delta-spec
+      `openspec/changes/cleanup-stale-spec-issues/specs/caching-system/spec.md`
+      med `## REMOVED Requirements` for grob-cache-references og
+      `## MODIFIED Requirements` / `## ADDED Requirements` for
+      marquee-cache contracts.
+
+## 2. Slice 2 -- `code-organization` #7 line-cap fjernes
+
+- [ ] 2.1 Inspicer `R/utils_add_right_labels_marquee.R` for at
+      verificere faktisk struktur (orchestrator + named helpers +
+      cleanup-closures). Notér helper-listen for at sikre at den
+      omformulerede requirement matcher.
+- [ ] 2.2 Opret delta-spec
+      `openspec/changes/cleanup-stale-spec-issues/specs/code-organization/spec.md`
+      med `## MODIFIED Requirements` for "Label-pipeline orchestrators
+      SHALL follow 3-layer decomposition":
+      - Fjern hard 220-line cap.
+      - Beholdn krav om named helpers, isolation-testbarhed,
+        cleanup-closures.
+      - Tilfoej eksplicit guidance: orchestrator-rolle handler om
+        _ansvar_, ikke linje-tal.
+      - Tilfoej Scenario for "orchestrator SHALL NOT contain inline
+        device-acquisition" (kvalitativ test).
+
+## 3. Slice 3 -- spec-boundary praecisering
+
+- [ ] 3.1 Identificer overlap mellem `public-api` og `spc-analysis-api`:
+      - `bfh_extract_spc_stats()` signatur (begge specs).
+      - `bfh_merge_metadata()` signatur (begge specs).
+      - `cl_user_supplied`-attribute (begge specs efter 0.16.0
+        sync).
+      - Anhoej-signal-interpretation (`public-api` har "what" --
+        `spc-analysis-api` har "how").
+- [ ] 3.2 Opdater `public-api` Purpose: "ejer af user-facing API
+      contracts (signaturer, eksport-status, return-types,
+      attribute-existence)".
+- [ ] 3.3 Opdater `spc-analysis-api` Purpose: "ejer af internal
+      signal-detection logic (Anhoej rules, fallback-narrative
+      dispatch, threshold semantics)".
+- [ ] 3.4 Fjern duplikeret indhold:
+      - I `spc-analysis-api`: fjern signatur-detaljer for
+        `bfh_extract_spc_stats()` og `bfh_merge_metadata()` --
+        erstat med "See public-api Requirement: X for signature".
+      - I `public-api`: fjern Anhoej-signal-tolkning-detaljer --
+        erstat med "See spc-analysis-api Requirement: Y for
+        interpretation".
+- [ ] 3.5 Opret delta-specs:
+      - `openspec/changes/cleanup-stale-spec-issues/specs/public-api/spec.md`
+      - `openspec/changes/cleanup-stale-spec-issues/specs/spc-analysis-api/spec.md`
+      med `## MODIFIED Requirements` for Purpose + de praeciserede
+      requirements.
+
+## 4. Validation
+
+- [ ] 4.1 `openspec validate cleanup-stale-spec-issues --strict` skal
+      vaere green.
+- [ ] 4.2 Sync delta-specs til main specs (haandholdt eller via
+      openspec-sync-specs skill).
+- [ ] 4.3 `openspec validate --specs --strict` skal vaere 7/7
+      green efter sync.
+
+## 5. Documentation
+
+- [ ] 5.1 NEWS.md (development): tilfoej kort entry under
+      `## Interne aendringer`:
+      "Spec-cleanup: refit caching-system til marquee-cache only,
+      fjern arbitraer 220-line target i code-organization #7,
+      praeciseret boundary mellem public-api og spc-analysis-api
+      ejerskab."
+- [ ] 5.2 Ingen ADR -- aendringer er rent dokumentations-cleanup uden
+      arkitekturelle beslutninger der kraever permanent record.
+
+## 6. Out-of-scope follow-up
+
+- [ ] 6.1 Phase 1 #14 (pdf-smoke.yaml comment refresh) -- pre-tool-use
+      hook blokerer; manuel opgave for maintainer.
+- [ ] 6.2 Verify implementation matches new code-organization #7
+      kontrakt for `add_right_labels_marquee.R` (kvalitativ review
+      af helpers, ej i scope for spec-aendringen).


### PR DESCRIPTION
## Sammenfatning

OpenSpec proposal der adresserer 3 design-issues fundet i audit (2026-05-04) af de 7 main specs. Rent dokumentations-cleanup, ingen kode-aendringer.

## Issues addresseret

### 1. \`caching-system\` refererer fjernet kode

Spec dokumenterer \`configure_grob_cache()\` + \`clear_grob_cache()\` som public helpers — fjernet i v0.5.0. Kun 4 active package-private caches (\`font\`, \`marquee_style\`, \`quarto\`, \`i18n\`) findes i dag.

**Slice 1:** REMOVE stale grob-cache requirements; MODIFY til at dokumentere current cache topology + \`bfh_reset_caches()\` helper.

### 2. \`code-organization\` #7 har urealistisk linje-target

Krav: \`add_right_labels_marquee\` ≤220 linjer. Faktisk: 731 linjer. Fil er korrekt 3-layer-decomposed i \`2026-05-03-decompose-marquee-labels\`. Hard cap er arbitraer maaling der ikke afspejler strukturel vaerdi.

**Slice 2:** MODIFY req #7. Fjern hard 220-line cap. Bevarer alle strukturelle krav (named helpers, isolation-testbarhed, cleanup-closures). Tilfoejer eksplicit guidance: orchestrator-rolle handler om _ansvar_, ikke linje-tal.

### 3. \`public-api\` ↔ \`spc-analysis-api\` boundary overlap

Tre kontrakter dokumenteret begge steder: \`bfh_extract_spc_stats()\`, \`bfh_merge_metadata()\`, \`cl_user_supplied\` attribute.

**Slice 3:** Praeciseret ejerskab:

| Capability | Ejer |
|---|---|
| **public-api** | API-kontrakter (signaturer, eksport-status, return-types, attribute-existence) |
| **spc-analysis-api** | Internal signal-detection logic (Anhoej rules, fallback-narrative dispatch, threshold semantics) |

Cross-references via prose (\"See X spec for Y\") — ingen indholds-duplication.

## Hvorfor bundlet

Alle tre slices er rent dokumentations-cleanup uden kode-aendringer. En review-cyklus levere komplet \"spec hygiene\"-state efter merge. Adskilte proposals ville give 3 review-cycler for low-impact aendringer.

## Test plan

- [x] \`openspec validate cleanup-stale-spec-issues --strict\`: green
- [ ] CI: PR-checks (R-CMD-check, lint, test-coverage)
- [ ] Implementation-PR (separat): sync delta-specs til main specs, derefter \`openspec validate --specs --strict\` 7/7

## Out of scope

- Phase 1 #14 (pdf-smoke.yaml comment refresh) — hook-blokeret, manuel maintainer-opgave.
- Verify implementation matches new code-organization #7 kontrakt for \`add_right_labels_marquee.R\` — specs definerer kontrakt, audit af helpers er separat opgave.
- Kode-aendringer (ingen).

## OpenSpec referencer

- \`openspec/changes/cleanup-stale-spec-issues/proposal.md\`
- \`openspec/changes/cleanup-stale-spec-issues/design.md\`
- \`openspec/changes/cleanup-stale-spec-issues/tasks.md\`
- \`openspec/changes/cleanup-stale-spec-issues/specs/{caching-system,code-organization,public-api,spc-analysis-api}/spec.md\`