### PR TITLE
fix(security): harden 0.16.0 export pipeline + release 0.16.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BFHcharts
 Title: SPC Visualization for Healthcare Quality Improvement
-Version: 0.16.0
+Version: 0.16.1
 Authors@R: c(
     person(
       "Johan", "Reventlow",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,57 @@
-# BFHcharts 0.16.0 (development)
+# BFHcharts 0.16.1
+
+## Security
+
+* **`restrict_template` argument-validering haerdet mod non-logical input.**
+  Tidligere `if (isTRUE(restrict_template) && !is.null(template_path))` lod
+  `restrict_template = NA`, `1L`, `"TRUE"`, eller en logical-vektor passere
+  guarden lydloest (`isTRUE()` returnerer `FALSE` for alt andet end et enkelt
+  `TRUE`). Type-validering tilfoejet FOER `isTRUE()`-checket -- ikke-logical
+  scalar fejler nu med klar fejl-besked. Vector for Shiny-/API-kontekster hvor
+  `restrict_template` kunne flyde fra deserialized JSON eller `as.logical()`-
+  coercion. Lukker production-readiness review item 1.1.
+
+* **`metadata$logo_path` faar nu path-traversal + shell-metachar validering**
+  (`R/utils_export_helpers.R:153-181`). Tidligere accepterede valideringen
+  enhver scalar non-empty character string -- "../../etc/secret.png" eller
+  "/home/x/private.png" passerede gennem `escape_typst_string()` direkte til
+  Typst's `image()`. Uden `--root`-sandbox (se naeste punkt) kunne dette
+  laese vilkaarlige filer paa hosten ind i PDF-output (PHI-eksfiltration i
+  multi-tenant deploys) eller fungere som file-existence oracle. Mirror den
+  validering som allerede findes paa `font_path` (`utils_typst.R:389-390`).
+  Lukker production-readiness review item 1.2.
+
+* **Typst-compileren koerer nu med `--root <staged-tempdir>`** (defense in
+  depth, `R/utils_typst.R:418-435`). Confiner alle `image()`/`read()`/
+  `include` access til den staged template-directory, saa selv hvis en
+  fremtidig metadata-felt-validering bliver glemt, kan compileren ikke
+  laese udenfor tempdir-traeet. Mitigerer hele klassen af path-traversal-
+  vektorer paa compiler-niveau. `--root` tilfoejet til
+  `KNOWN_TYPST_FLAGS`-allowlist saa flag-vaerdien shell-quoteres korrekt.
+
+## Bug fixes
+
+* **`bfh_extract_spc_stats.data.frame()` overfoerer nu
+  `cl_user_supplied`-attributtet.** Tidligere returnerede data.frame-
+  dispatch-pathen altid `NULL` for flaget, selv naar `attr(x,
+  "cl_user_supplied")` var sat paa input -- saa downstream-konsumenter der
+  kaldte `bfh_extract_spc_stats(result$summary)` direkte (i stedet for at
+  passere hele `bfh_qic_result`-objektet) tabte caveat-rendering i PDF
+  lydloest. Nu lazet via `isTRUE(attr(x, "cl_user_supplied"))` paralleelt
+  med `bfh_qic_result`-method'en. Lukker production-readiness review item 2.7.
+
+* **`restrict_template`-error-besked vejleder nu om opt-out-pathen.**
+  Tidligere besked: "template_path is not allowed when restrict_template =
+  TRUE." -- ingen migration-hint. Ny besked tilfoejer eksplicit guidance
+  om `restrict_template = FALSE` + warning om compile-niveau trust-model.
+  Lukker production-readiness review item 1.4.
+
+## Internal changes
+
+* CI: `auto-release-pr.yaml`-workflow repareret -- shallow-fetch og
+  pipefail/SIGPIPE-bug der gav exit 141 ved post-merge runs paa develop.
+
+# BFHcharts 0.16.0
 
 ## Breaking changes
 
@@ -78,8 +131,6 @@
     prose -- ingen indholds-duplication.
   - Implementerer OpenSpec change `cleanup-stale-spec-issues`.
 
-# BFHcharts 0.15.1 (development)
-
 ## Bug fixes
 
 * **PDF-eksport rendrer succesfuldt uden hospitals-logo, når companion-pakker
@@ -90,9 +141,7 @@
   forreste logo-slot rendres kun når `logo_path` er sat. R-siden auto-detekterer
   staged logos via `.detect_packaged_logo()` parallelt med eksisterende
   `.detect_packaged_fonts()`-mønster, så companion-pakker (BFHchartsAssets)
-  fortsat får hospital-branding uden caller-side ændringer. Lukker det sidste
-  åbne FIX NOW-blocker fra production-readiness review (item 1.2) og task 2.5
-  i `openspec/changes/2026-05-01-fix-pdf-template-asset-contract`. Implementerer
+  fortsat får hospital-branding uden caller-side ændringer. Implementerer
   OpenSpec change `add-conditional-template-image`.
 
   Migration:
@@ -103,7 +152,7 @@
   - **Avancerede callers** kan supply `metadata$logo_path = "/path/to/custom.png"`
     for at overstyre auto-detect.
 
-## Internal changes
+## Yderligere interne aendringer (logo-conditional)
 
 * `bfh-template.typ` template-signature gains optional `logo_path: none`
   parameter. Foreground `place(image(...))` block er nu konditional.

--- a/R/export_pdf.R
+++ b/R/export_pdf.R
@@ -322,10 +322,29 @@ bfh_export_pdf <- function(x,
   # of the calling R session (equivalent to source()). When restrict_template=TRUE,
   # only the packaged template is allowed, preventing custom-template injection
   # from untrusted Shiny inputs or API parameters.
-  if (isTRUE(restrict_template) && !is.null(template_path)) {
+  #
+  # Type validation runs BEFORE the isTRUE() guard: isTRUE(NA) and
+  # isTRUE("TRUE") return FALSE, which would silently fail-open when a caller
+  # forwards a coerced/serialized non-logical value (e.g. from JSON or a
+  # Shiny input with strict_json = FALSE).
+  if (!is.logical(restrict_template) || length(restrict_template) != 1L ||
+    is.na(restrict_template)) {
     stop(
-      "template_path is not allowed when restrict_template = TRUE. ",
-      "Only the packaged BFHcharts template may be used in this configuration.",
+      "restrict_template must be TRUE or FALSE (single non-NA logical)",
+      "\n  Got: ", paste(class(restrict_template), collapse = "/"),
+      " (length ", length(restrict_template), ")",
+      call. = FALSE
+    )
+  }
+  if (restrict_template && !is.null(template_path)) {
+    stop(
+      "template_path is not allowed when restrict_template = TRUE.",
+      "\n  Only the packaged BFHcharts template may be used in this configuration.",
+      "\n  To opt in to a trusted custom Typst template, pass",
+      " restrict_template = FALSE explicitly.",
+      "\n  WARNING: custom templates are compiled with full filesystem access",
+      " (equivalent to source()) -- never forward user-supplied input to",
+      " template_path.",
       call. = FALSE
     )
   }

--- a/R/utils_export_helpers.R
+++ b/R/utils_export_helpers.R
@@ -156,6 +156,14 @@ validate_bfh_export_pdf_inputs <- function(x, output, metadata, dpi,
         # path kan vaere relativ til staged template-dir paa compile-tid,
         # ikke validation-tid; companion-pakker kan skrive filen i
         # inject_assets callback efter validering.
+        #
+        # Path-traversal + shell-metachars valideres dog ALTID. Typst's
+        # image() resolver paths relativt til den .typ-fil der indeholder
+        # kaldet (staged template-dir), men uden --root-flag i
+        # bfh_compile_typst() kan en path som "../../etc/secret.png"
+        # eskapere staging-dir og laese vilkaarlige filer paa hosten.
+        # Mirror den validering der allerede findes paa font_path
+        # (R/utils_typst.R:389-390).
         if (is.null(value)) next
         if (!is.character(value) || length(value) != 1L || is.na(value) ||
           !nzchar(value)) {
@@ -166,6 +174,8 @@ validate_bfh_export_pdf_inputs <- function(x, output, metadata, dpi,
             call. = FALSE
           )
         }
+        .check_traversal(value)
+        .check_metachars(value)
         next
       }
 

--- a/R/utils_spc_stats.R
+++ b/R/utils_spc_stats.R
@@ -38,8 +38,10 @@
 #'     non-NULL `cl` argument to `bfh_qic()`; Anhoej run/crossing signals
 #'     in this case were computed against the user-supplied centerline,
 #'     not the data-estimated process mean. Mirrors
-#'     `attr(result$summary, "cl_user_supplied")`. Present only for
-#'     `bfh_qic_result` input.}
+#'     `attr(result$summary, "cl_user_supplied")` and is present in both
+#'     the `bfh_qic_result` and `data.frame` (summary) dispatch paths.
+#'     Always `FALSE` for `NULL` input or summaries without the
+#'     attribute.}
 #' }
 #'
 #' @details
@@ -84,6 +86,13 @@ bfh_extract_spc_stats.default <- function(x) {
 #' @rdname bfh_extract_spc_stats
 bfh_extract_spc_stats.data.frame <- function(x) {
   stats <- empty_spc_stats()
+
+  # Surface the user-supplied centerline flag if the caller passed
+  # `result$summary` directly (the data.frame is the canonical carrier
+  # for this attribute -- set in build_bfh_qic_return()). Mirrors the
+  # bfh_qic_result method so downstream consumers (PDF caveat, biSPCharts
+  # UI) get the same flag regardless of which dispatch path they hit.
+  stats$cl_user_supplied <- isTRUE(attr(x, "cl_user_supplied"))
 
   if (nrow(x) == 0) {
     return(stats)

--- a/R/utils_typst.R
+++ b/R/utils_typst.R
@@ -299,7 +299,7 @@ bfh_create_typst_document <- function(chart_image,
 # These are the only double-dash flags this package passes to the Typst compiler.
 # Any arg starting with "--" that is NOT in this list is treated as a path/value
 # and will be quoted, preventing RCE via crafted flag-like strings (e.g. --rce).
-KNOWN_TYPST_FLAGS <- c("--ignore-system-fonts", "--font-path")
+KNOWN_TYPST_FLAGS <- c("--ignore-system-fonts", "--font-path", "--root")
 
 # Helper: returns TRUE on Windows. Extracted for testability via
 # local_mocked_bindings() -- callers mock .is_windows, not .Platform directly.
@@ -413,9 +413,20 @@ bfh_compile_typst <- function(typst_file, output, font_path = NULL,
   # Note: shQuote() is applied inside .safe_system2_capture() for path-like
   # args. system2(stdout=TRUE, stderr=TRUE) routes through /bin/sh on
   # macOS/Linux for stream capture, so paths with spaces/parens/brackets/$
-  # must be quoted. Flag args (--ignore-system-fonts, --font-path) are
-  # passed through without quoting so Quarto's flag parser sees them intact.
-  compile_args <- c("typst", "compile", typst_file, output)
+  # must be quoted. Flag args (--ignore-system-fonts, --font-path, --root)
+  # are passed through without quoting so Quarto's flag parser sees them
+  # intact.
+  #
+  # --root <typst_dir> confines all template file accesses (image(),
+  # read(), include) to the staged template directory tree. Defense in
+  # depth: even if a caller-supplied logo_path or future metadata field
+  # bypasses the per-field traversal validation, Typst's compiler-level
+  # sandbox prevents reads outside the staged tempdir.
+  typst_dir <- dirname(typst_file)
+  compile_args <- c(
+    "typst", "compile", typst_file, output,
+    "--root", typst_dir
+  )
   if (!is.null(font_path)) {
     compile_args <- c(compile_args, "--font-path", font_path)
   }

--- a/man/bfh_extract_spc_stats.Rd
+++ b/man/bfh_extract_spc_stats.Rd
@@ -41,8 +41,10 @@ outliers are not discussed as if they were current). Present only for
 non-NULL \code{cl} argument to \code{bfh_qic()}; Anhoej run/crossing signals
 in this case were computed against the user-supplied centerline,
 not the data-estimated process mean. Mirrors
-\code{attr(result$summary, "cl_user_supplied")}. Present only for
-\code{bfh_qic_result} input.}
+\code{attr(result$summary, "cl_user_supplied")} and is present in both
+the \code{bfh_qic_result} and \code{data.frame} (summary) dispatch paths.
+Always \code{FALSE} for \code{NULL} input or summaries without the
+attribute.}
 }
 }
 \description{

--- a/tests/testthat/test-cl-user-supplied.R
+++ b/tests/testthat/test-cl-user-supplied.R
@@ -102,3 +102,58 @@ test_that("i18n caveat key resolves in da and en", {
   expect_match(da, "fastsat manuelt")
   expect_match(en, "manually specified")
 })
+
+# Run charts hide outlier rows in PDF; the early-return in
+# bfh_extract_spc_stats.bfh_qic_result() must NOT drop cl_user_supplied
+# (set BEFORE the early-return). A future refactor that swaps the
+# ordering would silently omit the clinical caveat for run charts.
+test_that("cl_user_supplied survives the run-chart early-return path", {
+  set.seed(42)
+  data <- data.frame(
+    month = seq(as.Date("2024-01-01"), by = "month", length.out = 18),
+    value = rnorm(18, mean = 50, sd = 5)
+  )
+
+  result <- suppressWarnings(
+    bfh_qic(data, x = month, y = value, chart_type = "run", cl = 50)
+  )
+  stats <- bfh_extract_spc_stats(result)
+  expect_true(stats$cl_user_supplied)
+  expect_true(stats$is_run_chart)
+  # Run charts have no control limits -> outlier fields must remain NULL.
+  expect_null(stats$outliers_actual)
+  expect_null(stats$outliers_expected)
+})
+
+# v0.16.1: data.frame dispatch must surface cl_user_supplied via attr,
+# parallel with the bfh_qic_result method. Prior to v0.16.1, calling
+# bfh_extract_spc_stats(result$summary) directly returned NULL for the
+# flag, silently omitting the PDF caveat for any consumer that routed
+# through the data.frame method (e.g. partial-stats users).
+test_that("bfh_extract_spc_stats.data.frame surfaces cl_user_supplied", {
+  set.seed(42)
+  data <- data.frame(
+    month = seq(as.Date("2024-01-01"), by = "month", length.out = 18),
+    value = rnorm(18, mean = 50, sd = 5)
+  )
+
+  result_with <- suppressWarnings(
+    bfh_qic(data, x = month, y = value, chart_type = "i", cl = 50)
+  )
+  stats_summary_with <- bfh_extract_spc_stats(result_with$summary)
+  expect_true(stats_summary_with$cl_user_supplied)
+
+  result_without <- bfh_qic(data, x = month, y = value, chart_type = "i")
+  stats_summary_without <- bfh_extract_spc_stats(result_without$summary)
+  expect_identical(stats_summary_without$cl_user_supplied, FALSE)
+})
+
+test_that("bfh_extract_spc_stats.data.frame returns FALSE for plain data.frame", {
+  # No attr set -> NULL attr -> isTRUE(NULL) = FALSE. Defensive sanity check.
+  df <- data.frame(
+    "længste_løb_max" = 5L,
+    antal_kryds = 3L, check.names = FALSE
+  )
+  stats <- BFHcharts::bfh_extract_spc_stats(df)
+  expect_identical(stats$cl_user_supplied, FALSE)
+})

--- a/tests/testthat/test-harden-export-pipeline-security.R
+++ b/tests/testthat/test-harden-export-pipeline-security.R
@@ -414,7 +414,9 @@ test_that(".safe_system2_capture quotes --rce flag (not in allowlist)", {
 
 test_that("KNOWN_TYPST_FLAGS contains exactly the expected flags", {
   flags <- BFHcharts:::KNOWN_TYPST_FLAGS
-  expect_setequal(flags, c("--ignore-system-fonts", "--font-path"))
+  # `--root` added in 0.16.1 as defense-in-depth: confines Typst's
+  # image()/read()/include access to the staged template tempdir.
+  expect_setequal(flags, c("--ignore-system-fonts", "--font-path", "--root"))
 })
 
 # ============================================================================

--- a/tests/testthat/test-path-policy.R
+++ b/tests/testthat/test-path-policy.R
@@ -381,10 +381,13 @@ test_that(".safe_system2_capture applies shQuote on non-Windows (mocked)", {
     }
   )
 
-  # On POSIX path, non-flag args must be shQuote'd (single-quote wrapping)
+  # On POSIX path, non-flag args must be shQuote'd (single-quote wrapping).
+  # `--root` was added to KNOWN_TYPST_FLAGS in 0.16.1; the flag itself is not
+  # quoted, but its value (the staged tempdir) IS a path arg that must be
+  # quoted -- so it falls through to the path_args bucket below.
   path_args <- captured_args[!captured_args %in% c(
     "typst", "compile",
-    "--ignore-system-fonts", "--font-path"
+    "--ignore-system-fonts", "--font-path", "--root"
   )]
   expect_true(
     all(startsWith(path_args, "'")),

--- a/tests/testthat/test-quarto-isolation.R
+++ b/tests/testthat/test-quarto-isolation.R
@@ -496,7 +496,8 @@ test_that(".system2 mock: success path verifies arg construction og returnerer o
   # .safe_system2_capture() applies shQuote() to non-flag args so that
   # system2(stdout=TRUE, stderr=TRUE) shell-mode handles paths with special
   # characters safely. Verify structure and that output path is recoverable.
-  expect_equal(length(captured_args), 5L) # typst compile <input> <output> --ignore-system-fonts
+  # 0.16.1: added "--root <typst_dir>" defense-in-depth flag (2 extra args).
+  expect_equal(length(captured_args), 7L) # typst compile <in> <out> --root <dir> --ignore-system-fonts
   # Positional args are quoted; flags are not
   expect_true(all(startsWith(captured_args[startsWith(captured_args, "--")], "--")))
   # The quoted output path must contain the original output filename

--- a/tests/testthat/test-security-export-pdf.R
+++ b/tests/testthat/test-security-export-pdf.R
@@ -206,3 +206,140 @@ test_that("bfh_export_pdf warns about unknown metadata fields", {
     "Unknown metadata fields will be ignored: unknown_field"
   )
 })
+
+# ============================================================================
+# logo_path VALIDATION (added v0.16.1)
+# ============================================================================
+
+test_that("bfh_export_pdf rejects path traversal in metadata$logo_path", {
+  chart <- fixture_test_chart()
+  temp_file <- withr::local_tempfile(fileext = ".pdf")
+
+  # Without --root sandbox + without per-field traversal validation, a path
+  # like "../../etc/secret.png" could resolve outside the staged template
+  # directory and embed arbitrary host filesystem content into the PDF.
+  expect_error(
+    bfh_export_pdf(chart, temp_file,
+      metadata = list(logo_path = "../../etc/secret.png")
+    ),
+    "path traversal"
+  )
+
+  expect_error(
+    bfh_export_pdf(chart, temp_file,
+      metadata = list(logo_path = "subdir/../../sensitive/logo.png")
+    ),
+    "path traversal"
+  )
+})
+
+test_that("bfh_export_pdf rejects shell metachars in metadata$logo_path", {
+  chart <- fixture_test_chart()
+  temp_file <- withr::local_tempfile(fileext = ".pdf")
+
+  expect_error(
+    bfh_export_pdf(chart, temp_file,
+      metadata = list(logo_path = "logo.png; rm -rf /")
+    ),
+    "disallowed"
+  )
+
+  expect_error(
+    bfh_export_pdf(chart, temp_file,
+      metadata = list(logo_path = "logo\nfile.png")
+    ),
+    "disallowed"
+  )
+})
+
+test_that("bfh_export_pdf rejects non-scalar logo_path", {
+  chart <- fixture_test_chart()
+  temp_file <- withr::local_tempfile(fileext = ".pdf")
+
+  expect_error(
+    bfh_export_pdf(chart, temp_file,
+      metadata = list(logo_path = c("a.png", "b.png"))
+    ),
+    "logo_path must be a single non-empty character string"
+  )
+
+  expect_error(
+    bfh_export_pdf(chart, temp_file,
+      metadata = list(logo_path = NA_character_)
+    ),
+    "logo_path must be a single non-empty character string"
+  )
+
+  expect_error(
+    bfh_export_pdf(chart, temp_file,
+      metadata = list(logo_path = "")
+    ),
+    "logo_path must be a single non-empty character string"
+  )
+
+  expect_error(
+    bfh_export_pdf(chart, temp_file,
+      metadata = list(logo_path = 42)
+    ),
+    "logo_path must be a single non-empty character string"
+  )
+})
+
+# ============================================================================
+# restrict_template TYPE GUARD (added v0.16.1)
+# ============================================================================
+
+test_that("bfh_export_pdf rejects non-logical restrict_template", {
+  chart <- fixture_test_chart()
+  temp_file <- withr::local_tempfile(fileext = ".pdf")
+
+  # NA bypassed isTRUE() prior to v0.16.1 -- guard now validates type FIRST.
+  expect_error(
+    bfh_export_pdf(chart, temp_file,
+      template_path = "/tmp/whatever.typ",
+      restrict_template = NA
+    ),
+    "restrict_template must be TRUE or FALSE"
+  )
+
+  expect_error(
+    bfh_export_pdf(chart, temp_file,
+      template_path = "/tmp/whatever.typ",
+      restrict_template = "TRUE"
+    ),
+    "restrict_template must be TRUE or FALSE"
+  )
+
+  expect_error(
+    bfh_export_pdf(chart, temp_file,
+      template_path = "/tmp/whatever.typ",
+      restrict_template = 1L
+    ),
+    "restrict_template must be TRUE or FALSE"
+  )
+
+  expect_error(
+    bfh_export_pdf(chart, temp_file,
+      template_path = "/tmp/whatever.typ",
+      restrict_template = c(TRUE, TRUE)
+    ),
+    "restrict_template must be TRUE or FALSE"
+  )
+})
+
+test_that("bfh_export_pdf restrict_template error message guides migration", {
+  chart <- fixture_test_chart()
+  temp_file <- withr::local_tempfile(fileext = ".pdf")
+
+  # Default (TRUE) + non-NULL template_path should error AND mention the
+  # opt-out path so callers don't have to grep NEWS to recover.
+  err <- tryCatch(
+    bfh_export_pdf(chart, temp_file,
+      template_path = "/some/path/template.typ"
+    ),
+    error = function(e) e
+  )
+  expect_s3_class(err, "error")
+  expect_match(conditionMessage(err), "restrict_template = TRUE")
+  expect_match(conditionMessage(err), "restrict_template = FALSE")
+})


### PR DESCRIPTION
## Summary

Patch release 0.16.1 closing four production-readiness review findings against the 0.16.0 release. Three security issues, one API consistency bug, plus NEWS hygiene.

**Severity:** all FIX NOW per the production-readiness review. The `restrict_template` bypass and `logo_path` traversal both reach exploitable end-states (custom-template injection / arbitrary host filesystem image inclusion in PDF) when caller input flows from a Shiny / API surface.

## Changes

### Security (commit 8cb2f63)

- **`restrict_template` type-validation guard** (`R/export_pdf.R`). `isTRUE(NA)` returns FALSE -- prior guard silently fail-opened on non-logical input (NA, ``"TRUE"``, 1L, vectors). Type validation now runs before the isTRUE check. Mirrors the pattern already used for ``strict_baseline``.
- **`metadata\$logo_path` path-traversal + shell-metachar validation** (`R/utils_export_helpers.R`). Prior validator only checked scalar non-empty character. ``escape_typst_string()`` does not neutralize ``..`` -- ``../../etc/secret.png`` reached Typst's ``image()``. ``.check_traversal`` + ``.check_metachars`` added (mirrors ``font_path`` validation).
- **Typst compiler `--root <staged-tempdir>` sandbox** (`R/utils_typst.R`). Defense in depth -- confines ``image()/read()/include`` to the staged template directory regardless of any per-field validation gap. Closes the entire class of path-traversal vectors at compiler level.
- **`restrict_template` error message migration hint**. Tells caller to use ``restrict_template = FALSE`` instead of forcing them to grep NEWS.

### API consistency (commit dd2e723)

- **`bfh_extract_spc_stats.data.frame()` surfaces `cl_user_supplied`** via ``isTRUE(attr(x, "cl_user_supplied"))``, parallel with the ``bfh_qic_result`` method. Prior to 0.16.1, calling ``bfh_extract_spc_stats(result\$summary)`` directly silently lost the warning-blind-clinical-reader caveat indicator.

### Release (commit 81ab668)

- DESCRIPTION 0.16.0 -> 0.16.1 (PATCH).
- NEWS: 0.16.1 entry, dropped ``(development)`` from already-tagged 0.16.0, consolidated stale 0.15.1 (development) snapshot into 0.16.0 (logo-conditional content shipped as part of 0.16.0).

## Test plan

- [x] Full suite: 3019 PASS / 0 FAIL / 76 SKIP (render/CRAN-gated)
- [x] ``BFHCHARTS_TEST_RENDER=true NOT_CRAN=true`` render-tests for ``test-export_pdf-content.R`` (43/43 pass) -- verifies ``--root`` sandbox does not break packaged template compile + caveat block renders correctly with cl_user_supplied
- [x] First 5/6 of ``test-production-template-renders.R`` pass under render flag (the 6th failure is pre-existing, unrelated -- inject_assets globalenv namespace check)
- [x] ``tools::showNonASCIIfile()`` clean for all changed ``R/*.R`` files
- [x] New negative-case tests:
  - ``restrict_template = NA / "TRUE" / 1L / c(TRUE,TRUE)`` -> rejected
  - ``logo_path`` traversal / metachar / non-scalar -> rejected
  - run-chart + ``cl_user_supplied`` early-return path
  - data.frame dispatch + ``cl_user_supplied`` parity
  - ``KNOWN_TYPST_FLAGS`` includes ``--root``
  - compile arg-count + path-quote tests updated

## Cross-repo

Per ``VERSIONING_POLICY.md §E``: separate biSPCharts PR needed to bump ``Imports: BFHcharts (>= 0.16.1)``. Will open after this merges.

## Closes

Production-readiness review items 1.1, 1.2, 1.3, 1.4, 2.1, 2.7, plus test-coverage gaps 2.3 + 2.5.