### PR TITLE
test: add set.seed() to random-data tests

### DIFF
--- a/tests/testthat/test-arrow-symbols.R
+++ b/tests/testthat/test-arrow-symbols.R
@@ -43,6 +43,7 @@ test_that("has_arrow_symbol handles edge cases", {
 
 test_that("Arrow symbol detection suppresses target line in plots", {
   skip_if_fonts_unavailable()
+  set.seed(42)
 
   data <- data.frame(
     month = seq(as.Date("2024-01-01"), by = "month", length.out = 12),
@@ -120,6 +121,7 @@ test_that("Arrow symbol detection suppresses target line in plots", {
 
 test_that("Comparison operators with numbers do NOT suppress target line", {
   skip_if_fonts_unavailable()
+  set.seed(42)
 
   data <- data.frame(
     month = seq(as.Date("2024-01-01"), by = "month", length.out = 12),

--- a/tests/testthat/test-bfh_qic_result.R
+++ b/tests/testthat/test-bfh_qic_result.R
@@ -4,6 +4,7 @@
 
 test_that("new_bfh_qic_result creates valid S3 object", {
   skip_if_fonts_unavailable()
+  set.seed(42)
 
   # Create mock components
   data <- data.frame(
@@ -70,6 +71,7 @@ test_that("new_bfh_qic_result creates valid S3 object", {
 
 test_that("new_bfh_qic_result validates inputs", {
   skip_if_fonts_unavailable()
+  set.seed(42)
 
   # Create valid components
   data <- data.frame(
@@ -138,6 +140,7 @@ test_that("new_bfh_qic_result validates inputs", {
 
 test_that("print.bfh_qic_result displays plot", {
   skip_if_fonts_unavailable()
+  set.seed(42)
 
   # bfh_qic() triggers ggplot_gtable internally (for label placement),
   # which can open a default device (Rplots.pdf) if none is open.
@@ -173,6 +176,7 @@ test_that("print.bfh_qic_result displays plot", {
 
 test_that("plot.bfh_qic_result displays plot", {
   skip_if_fonts_unavailable()
+  set.seed(42)
 
   # bfh_qic() triggers ggplot_gtable internally (for label placement),
   # which can open a default device (Rplots.pdf) if none is open.
@@ -208,6 +212,7 @@ test_that("plot.bfh_qic_result displays plot", {
 
 test_that("accessor functions work", {
   skip_if_fonts_unavailable()
+  set.seed(42)
 
   data <- data.frame(
     month = seq(as.Date("2024-01-01"), by = "month", length.out = 12),
@@ -245,6 +250,7 @@ test_that("accessor functions work", {
 
 test_that("is_bfh_qic_result identifies objects correctly", {
   skip_if_fonts_unavailable()
+  set.seed(42)
 
   data <- data.frame(
     month = seq(as.Date("2024-01-01"), by = "month", length.out = 12),


### PR DESCRIPTION
## Summary
- Adds `set.seed(42)` before all `rpois`/`rnorm` calls in `test-bfh_qic_result.R` and `test-arrow-symbols.R`
- Eliminates hidden coupling to test execution order (file order changes could alter random sequences)
- Follows existing pattern from `test-bfh_qic_edge_cases.R`

## Test plan
- [x] Full test suite passed (pre-push hook, 179s)
- [ ] `devtools::test(filter = "bfh_qic_result")` — verify locally
- [ ] `devtools::test(filter = "arrow-symbols")` — verify locally

Fixes K5 from comprehensive code review.