### PR TITLE
fix: propagate language param through format_y_value()

### DIFF
--- a/R/fct_add_spc_labels.R
+++ b/R/fct_add_spc_labels.R
@@ -211,7 +211,7 @@ add_spc_labels <- function(
     } else {
       NULL
     }
-    formatted_cl <- format_y_value(cl_value, y_axis_unit, y_range, target = target_for_precision)
+    formatted_cl <- format_y_value(cl_value, y_axis_unit, y_range, target = target_for_precision, language = language)
     label_cl <- create_responsive_label(
       header = cl_header,
       value = formatted_cl,
@@ -245,7 +245,7 @@ add_spc_labels <- function(
         }
       }
     } else {
-      formatted_target <- format_y_value(target_value, y_axis_unit, y_range)
+      formatted_target <- format_y_value(target_value, y_axis_unit, y_range, language = language)
       target_operator <- ""
       target_value_text <- formatted_target
     }

--- a/R/utils_label_formatting.R
+++ b/R/utils_label_formatting.R
@@ -15,12 +15,13 @@
 #' @param val numeric vaerdi (0-1 skala, f.eks. 0.887 for 88.7%)
 #' @param target numeric target vaerdi (0-1 skala), eller NULL
 #' @param threshold numeric afstand i procentpoint hvor decimaler vises (default 0.02 = 2%)
-#' @return character formateret string med dansk notation
+#' @param language Locale code: "da" (default, Danish) or "en" (English)
+#' @return character formateret string
 #'
 #' @details
 #' Logik:
 #' - Hvis target er NULL eller val er > threshold fra target: hele procent ("89%")
-#' - Hvis val er <= threshold fra target: en decimal med dansk komma ("88,7%")
+#' - Hvis val er <= threshold fra target: en decimal ("88,7%" da / "88.7%" en)
 #'
 #' @examples
 #' \dontrun{
@@ -36,7 +37,7 @@
 #'
 #' @keywords internal
 #' @noRd
-format_percent_contextual <- function(val, target = NULL, threshold = 0.02) {
+format_percent_contextual <- function(val, target = NULL, threshold = 0.02, language = "da") {
   if (length(val) != 1 || !(is.numeric(val) || is.na(val))) {
     stop("val must be a single numeric value", call. = FALSE)
   }
@@ -62,8 +63,9 @@ format_percent_contextual <- function(val, target = NULL, threshold = 0.02) {
     return(paste0(round(pct), "%"))
   }
 
-  # Taet paa target: vis en decimal med dansk komma (altid nsmall=1 for konsistens)
-  formatted <- format(round(pct, 1), decimal.mark = ",", nsmall = 1)
+  # Near target: show one decimal with locale-appropriate separator
+  dm <- if (language == "en") "." else ","
+  formatted <- format(round(pct, 1), decimal.mark = dm, nsmall = 1)
   return(paste0(formatted, "%"))
 }
 
@@ -79,6 +81,7 @@ format_percent_contextual <- function(val, target = NULL, threshold = 0.02) {
 #'   auto-detekterer minutter/timer/dage) og bruges kun som signatur-
 #'   placeholder for andre enheder.
 #' @param target numeric target vaerdi for kontekstuel praecision (kun for "percent")
+#' @param language Locale code: "da" (default, Danish) or "en" (English)
 #' @return character formateret string
 #'
 #' @details
@@ -110,7 +113,7 @@ format_percent_contextual <- function(val, target = NULL, threshold = 0.02) {
 #'
 #' @keywords internal
 #' @noRd
-format_y_value <- function(val, y_unit, y_range = NULL, target = NULL) {
+format_y_value <- function(val, y_unit, y_range = NULL, target = NULL, language = "da") {
   # Input validation
   if (is.na(val)) {
     return(NA_character_)
@@ -123,17 +126,17 @@ format_y_value <- function(val, y_unit, y_range = NULL, target = NULL) {
 
   # Percent formatting - kontekstuel praecision naar target er sat
   if (y_unit == "percent") {
-    return(format_percent_contextual(val, target = target))
+    return(format_percent_contextual(val, target = target, language = language))
   }
 
-  # Count formatting - delegates to canonical format_count_danish()
+  # Count formatting - locale-aware dispatcher
   if (y_unit == "count") {
-    return(format_count_danish(val))
+    return(format_count(val, language))
   }
 
-  # Rate formatting - delegates to canonical format_rate_danish()
+  # Rate formatting - locale-aware dispatcher
   if (y_unit == "rate") {
-    return(format_rate_danish(val))
+    return(format_rate(val, language))
   }
 
   # Time formatting - komposit-format ("30m", "1t 30m", "2d 13t")
@@ -143,12 +146,13 @@ format_y_value <- function(val, y_unit, y_range = NULL, target = NULL) {
     return(format_time_composite(val))
   }
 
-  # Default formatting - kontekstuel dansk notation
+  # Default formatting - locale-aware notation
+  dm <- if (language == "en") "." else ","
   if (is_effective_integer(val)) {
-    return(format(round(val), decimal.mark = ","))
+    return(format(round(val), decimal.mark = dm))
   } else if (abs(val) < 1) {
-    return(format(round(val, 2), decimal.mark = ",", nsmall = 2))
+    return(format(round(val, 2), decimal.mark = dm, nsmall = 2))
   } else {
-    return(format(round(val, 1), decimal.mark = ",", nsmall = 1))
+    return(format(round(val, 1), decimal.mark = dm, nsmall = 1))
   }
 }

--- a/tests/testthat/test-locale-en-formatting.R
+++ b/tests/testthat/test-locale-en-formatting.R
@@ -102,6 +102,53 @@ test_that("bfh_qic(language='da') (default) bevarer dansk y-akse-format", {
 })
 
 # ----------------------------------------------------------------------------
+# format_y_value() locale-awareness (utils_label_formatting.R)
+# ----------------------------------------------------------------------------
+
+test_that("format_y_value count: 'da' producerer dansk format", {
+  expect_equal(format_y_value(1234, "count", language = "da"), "1,2K")
+  expect_equal(format_y_value(123.5, "count", language = "da"), "123,5")
+})
+
+test_that("format_y_value count: 'en' producerer engelsk format", {
+  expect_equal(format_y_value(1234, "count", language = "en"), "1.2K")
+  expect_equal(format_y_value(123.5, "count", language = "en"), "123.5")
+})
+
+test_that("format_y_value rate: 'da' producerer dansk decimal-tegn", {
+  result <- format_y_value(1.5, "rate", language = "da")
+  expect_true(grepl(",", result, fixed = TRUE))
+})
+
+test_that("format_y_value rate: 'en' producerer engelsk decimal-tegn", {
+  result <- format_y_value(1.5, "rate", language = "en")
+  expect_true(grepl(".", result, fixed = TRUE))
+  expect_false(grepl(",", result, fixed = TRUE))
+})
+
+test_that("format_y_value percent: 'da' producerer dansk komma naer target", {
+  result <- format_y_value(0.887, "percent", target = 0.90, language = "da")
+  expect_true(grepl(",", result, fixed = TRUE))
+})
+
+test_that("format_y_value percent: 'en' producerer engelsk punktum naer target", {
+  result <- format_y_value(0.887, "percent", target = 0.90, language = "en")
+  expect_false(grepl(",", result, fixed = TRUE))
+  expect_true(grepl(".", result, fixed = TRUE))
+})
+
+test_that("format_y_value default: 'en' producerer engelsk decimal-tegn", {
+  result <- format_y_value(1.5, "other", language = "en")
+  expect_true(grepl(".", result, fixed = TRUE))
+  expect_false(grepl(",", result, fixed = TRUE))
+})
+
+test_that("format_y_value default language = 'da' (bagudkompatibilitet)", {
+  result <- format_y_value(1234, "count")
+  expect_equal(result, "1,2K")
+})
+
+# ----------------------------------------------------------------------------
 # spc_plot_config validation
 # ----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem
`format_y_value()` always called `format_count_danish()`/`format_rate_danish()` regardless of `language="en"` setting. When `add_spc_labels()` was called with `language="en"`, centerline and target labels still showed Danish decimal separators (`","` instead of `"."`), while axis labels correctly showed English format.

## Changes
- Add `language = "da"` parameter to `format_y_value()` and `format_percent_contextual()`
- Route `count` and `rate` to existing `format_count(val, language)` and `format_rate(val, language)` locale-aware dispatchers
- Make default branch (non-standard units) locale-aware via `decimal.mark`
- Pass `language` from both `add_spc_labels()` call sites (lines 214, 248 in `fct_add_spc_labels.R`)
- 8 new tests in `test-locale-en-formatting.R`

## Test plan
- [x] Full test suite passed (pre-push, 176s)
- [x] `test-locale-en-formatting.R`: 35 tests (8 new), all pass

Fixes K1 from comprehensive code review.