### PR TITLE
fix(security): validate paths in bfh_create_typst_document + redact tempdir

### DIFF
--- a/R/utils_typst.R
+++ b/R/utils_typst.R
@@ -62,6 +62,10 @@ bfh_create_typst_document <- function(chart_image,
                                       template = "bfh-diagram",
                                       template_path = NULL,
                                       skip_template_copy = FALSE) {
+  # Validate output and chart_image paths to prevent traversal/injection
+  validate_export_path(output)
+  validate_export_path(chart_image)
+
   # Get output directory (where document.typ will be created)
   output_dir <- dirname(output)
 
@@ -199,10 +203,13 @@ bfh_create_typst_document <- function(chart_image,
 }
 
 # Afkorter compile-output til max `max` tegn for at undgaa laekage af
-# filsystem-stier i fejlbeskeder. Bruges i begge fejl-branches i
-# bfh_compile_typst() saa truncation er konsistent.
+# filsystem-stier i fejlbeskeder. Redacter tempdir-stier foerst, derefter
+# truncation. Bruges i begge fejl-branches i bfh_compile_typst().
 .truncate_compile_output <- function(output, max = 500L) {
-  substr(paste(output, collapse = "\n"), 1L, max)
+  text <- paste(output, collapse = "\n")
+  td <- normalizePath(tempdir(), winslash = "/", mustWork = FALSE)
+  text <- gsub(td, "<tmpdir>", text, fixed = TRUE)
+  substr(text, 1L, max)
 }
 
 # Auto-detect packaged fonts in the staged template directory.

--- a/tests/testthat/test-harden-export-pipeline-security.R
+++ b/tests/testthat/test-harden-export-pipeline-security.R
@@ -164,6 +164,40 @@ test_that(".truncate_compile_output sammenhaenger vector med newline foer afkort
   expect_true(grepl("\n", result, fixed = TRUE))
 })
 
+test_that(".truncate_compile_output redacter tempdir-stier", {
+  td <- normalizePath(tempdir(), winslash = "/", mustWork = FALSE)
+  output_with_path <- paste0("error at: ", td, "/bfh_pdf_abc/document.typ")
+  result <- BFHcharts:::.truncate_compile_output(output_with_path)
+  expect_false(grepl(td, result, fixed = TRUE))
+  expect_true(grepl("<tmpdir>", result, fixed = TRUE))
+})
+
+test_that("bfh_create_typst_document afviser output med path-traversal", {
+  tmp <- withr::local_tempfile(fileext = ".png")
+  writeLines("", tmp)
+  expect_error(
+    BFHcharts:::bfh_create_typst_document(
+      chart_image = tmp,
+      output = "../../../etc/evil.typ",
+      metadata = list(),
+      spc_stats = list()
+    ),
+    "path traversal"
+  )
+})
+
+test_that("bfh_create_typst_document afviser chart_image med path-traversal", {
+  expect_error(
+    BFHcharts:::bfh_create_typst_document(
+      chart_image = "../../../etc/passwd",
+      output = withr::local_tempfile(fileext = ".typ"),
+      metadata = list(),
+      spc_stats = list()
+    ),
+    "path traversal"
+  )
+})
+
 test_that("bfh_compile_typst truncerer output i PDF-not-created-branch til <= 500 tegn", {
   # Mock system2 der returnerer exit 0 men en lang output-streng
   long_output_vec <- rep(paste(rep("z", 100), collapse = ""), 20)


### PR DESCRIPTION
## Problem

**V12:** `bfh_create_typst_document()` is exported but bypasses `validate_bfh_export_pdf_inputs()`. The `output` and `chart_image` parameters had no path traversal or metacharacter checks before file operations.

**V13:** `.truncate_compile_output()` truncated to 500 chars to prevent path leakage, but Quarto echoes the full compile command (incl. tempdir path) in the first ~100 chars, leaking e.g. `/tmp/RtmpXXXX/bfh_pdf_abc/document.typ`.

## Changes

- `R/utils_typst.R`: Add `validate_export_path()` calls on `output` and `chart_image` at the top of `bfh_create_typst_document()` — blocks `../`-traversal and shell metacharacters before any `dirname()`/`file.copy()` operations
- `R/utils_typst.R`: Extend `.truncate_compile_output()` to `gsub()` the `tempdir()` path → `<tmpdir>` before truncation
- 4 new tests in `test-harden-export-pipeline-security.R`

## Test plan
- [x] Full test suite passed (pre-push, 679s)
- [x] `test-harden-export-pipeline-security.R`: 60 tests (4 new), all pass

Fixes V12 + V13 from comprehensive code review.