### PR TITLE
fix(analysis): preserve stretch-targets > 1 on percent proportion scale (cycle 01 E1)

### DIFF
--- a/R/spc_analysis.R
+++ b/R/spc_analysis.R
@@ -97,7 +97,7 @@ resolve_target <- function(target_input) {
 #'
 #' Internal helper. When `y_axis_unit` is `"percent"` and the target appears
 #' to be expressed on the 0-100 scale (either because `display` contains a
-#' literal `"%"` character, or because `value > 1` for a numeric-only input),
+#' literal `"%"` character, or because `value > 1.5` for a numeric-only input),
 #' the value is divided by 100 so downstream comparisons work on the same
 #' 0-1 proportion scale as the centerline.
 #'
@@ -106,8 +106,12 @@ resolve_target <- function(target_input) {
 #'
 #' **Heuristic:**
 #' Normalize when `y_axis_unit == "percent"` AND
-#'   (`grepl("%", display)` OR `value > 1`)
-#' Preserve otherwise (proportion already correct, or non-percent chart).
+#'   (`grepl("%", display)` OR `value > 1.5`)
+#' Preserve otherwise (proportion already correct, or stretch-target on
+#' proportion scale, or non-percent chart). The 1.5 threshold matches
+#' `validate_target_for_unit()`'s upper bound for `multiply = 1`, so
+#' legitimate stretch-targets like 1.05 (=105% on proportion scale) are
+#' preserved instead of being misclassified as percent-scale input.
 #'
 #' @param value Numeric target value as parsed by `resolve_target()`.
 #' @param display Character display string (may be empty `""` for numeric input).
@@ -140,9 +144,17 @@ resolve_target <- function(target_input) {
   if (is.na(value) || !is.numeric(value)) {
     return(value)
   }
-  # Normalise when display contains "%" OR value > 1
+  # Normalise when display contains "%" OR value > 1.5
   # (OR heuristic covers both string input and numeric input on a 0-100 scale)
-  should_normalize <- isTRUE(grepl("%", display, fixed = TRUE)) || isTRUE(value > 1)
+  #
+  # Threshold rationale: validate_target_for_unit() allows target_value up to
+  # multiply * 1.5 = 1.5 (default multiply=1) for percent charts, supporting
+  # legitimate stretch-targets > 100% on the proportion scale. The previous
+  # threshold (value > 1) misclassified such stretch-targets (1.0, 1.5] as
+  # 0-100 input and divided by 100, producing wrong narrative text in
+  # bfh_generate_analysis(). 1.5 is the validator's max bound -- values above
+  # are unambiguously 0-100 input that needs normalising.
+  should_normalize <- isTRUE(grepl("%", display, fixed = TRUE)) || isTRUE(value > 1.5)
   if (should_normalize) value / 100 else value
 }
 

--- a/tests/testthat/test-spc_analysis.R
+++ b/tests/testthat/test-spc_analysis.R
@@ -694,6 +694,46 @@ test_that(".normalize_percent_target: lower-direction percent target normalisere
   expect_equal(result, 0.05, tolerance = 1e-9)
 })
 
+test_that("E1 regression: percent-chart preserves numeric stretch-target in (1, 1.5]", {
+  # Cycle 01 finding E1 (review 2026-05-10):
+  # validate_target_for_unit() allows target_value up to multiply*1.5 = 1.5
+  # for percent charts (legitimate stretch goals > 100% on proportion scale).
+  # Previous 'value > 1' threshold misclassified such targets as percent-scale
+  # input and divided by 100, producing wrong narrative text in
+  # bfh_generate_analysis(). Threshold is now 'value > 1.5' (validator's max).
+  expect_equal(
+    BFHcharts:::.normalize_percent_target(1.05, "", "percent"),
+    1.05,
+    tolerance = 1e-9
+  )
+  expect_equal(
+    BFHcharts:::.normalize_percent_target(1.5, "", "percent"),
+    1.5,
+    tolerance = 1e-9
+  )
+  # Boundary: value just above 1.5 IS percent-scale input -> normalize
+  expect_equal(
+    BFHcharts:::.normalize_percent_target(1.51, "", "percent"),
+    0.0151,
+    tolerance = 1e-9
+  )
+})
+
+test_that("E1 regression: percent-chart still normalizes values clearly on 0-100 scale", {
+  # Sanity: confirm that values comfortably above 1.5 still normalize.
+  # This is the dominant production case and must not regress.
+  expect_equal(
+    BFHcharts:::.normalize_percent_target(50, "", "percent"),
+    0.50,
+    tolerance = 1e-9
+  )
+  expect_equal(
+    BFHcharts:::.normalize_percent_target(100, "", "percent"),
+    1.00,
+    tolerance = 1e-9
+  )
+})
+
 
 # ==============================================================================
 # Regressions-tests: percent-target skalafejl (bug 2026-04-29)


### PR DESCRIPTION
## Summary

Cycle 01 finding **E1 (HIGH)** — release-blocking. `.normalize_percent_target()` previously misclassified legitimate stretch-targets in (1, 1.5] on the proportion scale (multiply=1) as percent-scale input and divided by 100, producing wrong narrative text in `bfh_generate_analysis()` and PDF export.

**Empirically verified (Codex peer-review 2026-05-10):**

```r
> BFHcharts:::.normalize_percent_target(1.05, "", "percent")
[1] 0.0105   # WRONG: 105% stretch -> 1.05% after normalize
```

Threshold changed from `value > 1` to `value > 1.5` (matches `validate_target_for_unit()` upper bound for multiply=1). All existing `test-spc_analysis.R:655-694` tests still pass.

## Test plan

- [x] 4 new regression tests in `tests/testthat/test-spc_analysis.R`
- [x] 142 PASS / 0 FAIL on `test-spc_analysis.R`
- [x] 14 PASS / 0 FAIL on `test-percent-target-contract.R`
- [x] Empirical repro confirmed before + after fix

Refs: `docs/reviews/01-production-readiness-2026-05-10.md` E1