### PR TITLE
fix(analysis): thread language through format_target_value (cycle 01 E4)

### DIFF
--- a/R/spc_analysis.R
+++ b/R/spc_analysis.R
@@ -721,7 +721,7 @@ bfh_generate_analysis <- function(x,
 # i18n-lookup foregaar her (ikke i orchestrator) for at holde
 # orchestrator fri af cascade-strukturer.
 .evaluate_target_arm <- function(context, flags, texts, target_budget,
-                                 target_tolerance) {
+                                 target_tolerance, language = "da") {
   result <- list(target_text = "", goal_met = FALSE, at_target = FALSE)
   if (!flags$has_target) {
     return(result)
@@ -731,12 +731,17 @@ bfh_generate_analysis <- function(x,
   target_direction <- context$target_direction
   centerline <- context$centerline
 
-  # Foretraek display-streng fra input (fx "<= 2,5"), ellers format numerisk
+  # Foretraek display-streng fra input (fx "<= 2,5"), ellers format numerisk.
+  # language threades igennem til format_target_value() saa engelsk
+  # analyse-tekst faar "1.5" og dansk faar "1,5" (cycle 01 finding E4).
   display_target <- if (!is.null(context$target_display) &&
     nzchar(context$target_display)) {
     context$target_display
   } else {
-    format_target_value(target_value, y_axis_unit = context$y_axis_unit)
+    format_target_value(target_value,
+      y_axis_unit = context$y_axis_unit,
+      language = language
+    )
   }
 
   if (!is.null(target_direction)) {
@@ -839,7 +844,10 @@ build_fallback_analysis <- function(context,
   # --- 1. Stabilitetstekst ---
   if (no_variation) {
     cl_fmt <- if (!is.null(centerline) && !is.na(centerline)) {
-      format_target_value(centerline, y_axis_unit = context$y_axis_unit)
+      format_target_value(centerline,
+        y_axis_unit = context$y_axis_unit,
+        language = language
+      )
     } else {
       i18n_lookup("labels.misc.ukendt", language)
     }
@@ -859,7 +867,8 @@ build_fallback_analysis <- function(context,
   # --- 2. Maalvurdering ---
   target_eval <- .evaluate_target_arm(
     context, flags, texts,
-    target_budget, target_tolerance
+    target_budget, target_tolerance,
+    language = language
   )
   target_text <- target_eval$target_text
   goal_met <- target_eval$goal_met
@@ -885,8 +894,11 @@ build_fallback_analysis <- function(context,
 
 
 # Formater maalvaerdi til visning
-# y_axis_unit bruges til at afgoere om vaerdien skal vises som procent
-format_target_value <- function(x, y_axis_unit = NULL) {
+# y_axis_unit bruges til at afgoere om vaerdien skal vises som procent.
+# language styrer decimal-separator: "da" -> "," (default), "en" -> "."
+# (cycle 01 finding E4: previously hardcoded "," produced danish decimals
+# in english analysis-text, eg. "1,5" instead of "1.5").
+format_target_value <- function(x, y_axis_unit = NULL, language = "da") {
   if (is.null(x) || is.na(x)) {
     return("")
   }
@@ -904,6 +916,7 @@ format_target_value <- function(x, y_axis_unit = NULL) {
   if (is_effective_integer(x)) {
     as.character(as.integer(x))
   } else {
-    format(round(x, 2), decimal.mark = ",", nsmall = 1)
+    decimal_mark <- if (identical(language, "en")) "." else ","
+    format(round(x, 2), decimal.mark = decimal_mark, nsmall = 1)
   }
 }

--- a/tests/testthat/test-summary-precision.R
+++ b/tests/testthat/test-summary-precision.R
@@ -164,3 +164,33 @@ test_that("format_target_value haandterer raa centerlinje korrekt", {
     info = "format_target_value skal producere samme output pre/post Slice C"
   )
 })
+
+test_that("E4: format_target_value uses locale-aware decimal-mark", {
+  # Cycle 01 finding E4 (review 2026-05-10):
+  # format_target_value previously hardcoded decimal.mark = "," for the
+  # non-percent + non-integer path, producing danish decimals ("1,5") in
+  # english analysis-text. language="en" must produce "1.5".
+  expect_equal(
+    BFHcharts:::format_target_value(1.5, y_axis_unit = "count", language = "da"),
+    "1,5"
+  )
+  expect_equal(
+    BFHcharts:::format_target_value(1.5, y_axis_unit = "count", language = "en"),
+    "1.5"
+  )
+  # Default is danish (backward compatible)
+  expect_equal(
+    BFHcharts:::format_target_value(1.5, y_axis_unit = "count"),
+    "1,5"
+  )
+  # Integer path is locale-independent (always integer string)
+  expect_equal(
+    BFHcharts:::format_target_value(5, y_axis_unit = "count", language = "en"),
+    "5"
+  )
+  # Percent path is locale-independent (always rounds to whole %)
+  expect_equal(
+    BFHcharts:::format_target_value(0.5, y_axis_unit = "percent", language = "en"),
+    "50%"
+  )
+})


### PR DESCRIPTION
## Summary

Cycle 01 finding **E4 (MEDIUM)**. `format_target_value()` hardcoded `decimal.mark = ","` so `bfh_generate_analysis(..., language = "en")` produced english analysis-text containing danish decimals (e.g. `"1,5"` instead of `"1.5"`). Codex confirmed via direct probe.

Threaded `language` parameter through the formatter and both call sites in `R/spc_analysis.R`. Default stays `"da"` (backward compatible). Integer + percent paths remain locale-independent.

## Test plan

- [x] 5 new test assertions in `tests/testthat/test-summary-precision.R`
- [x] format_target_value(1.5, "count", "da") -> "1,5"
- [x] format_target_value(1.5, "count", "en") -> "1.5"
- [x] Integer path unchanged across languages
- [x] Percent path unchanged across languages
- [x] 416 PASS / 0 FAIL on signal/analysis/summary cluster

Refs: `docs/reviews/01-production-readiness-2026-05-10.md` E4