### PR TITLE
docs(api): clarify summary class as data.frame not tibble (cycle 01 E5)

### DIFF
--- a/R/bfh_qic_result.R
+++ b/R/bfh_qic_result.R
@@ -17,13 +17,20 @@ NULL
 #' backwards-compatible console behavior.
 #'
 #' @param plot ggplot2 object containing the SPC chart
-#' @param summary tibble with SPC statistics (runs, crossings, control limits)
+#' @param summary data.frame with SPC statistics (runs, crossings, control
+#'   limits). Plain \code{data.frame} -- not a \code{tibble}; downstream
+#'   consumers should not rely on tibble-specific subscripting behavior.
 #' @param qic_data data.frame with raw qicharts2 calculation results
 #' @param config list with original function parameters
 #'
 #' @return An object of class \code{bfh_qic_result} containing:
 #'   \item{plot}{ggplot2 object with the SPC chart}
-#'   \item{summary}{tibble with summary statistics}
+#'   \item{summary}{data.frame with summary statistics (Danish column names).
+#'     Returned as plain \code{data.frame} -- the previous documentation
+#'     incorrectly described it as a \code{tibble}; cycle 01 review aligned
+#'     the doc with the implementation. The class is part of the public
+#'     contract and will not silently flip to \code{tibble} without a
+#'     deprecation cycle.}
 #'   \item{qic_data}{data.frame with qicharts2 calculations}
 #'   \item{config}{list with original parameters}
 #'

--- a/man/new_bfh_qic_result.Rd
+++ b/man/new_bfh_qic_result.Rd
@@ -9,7 +9,9 @@ new_bfh_qic_result(plot, summary, qic_data, config)
 \arguments{
 \item{plot}{ggplot2 object containing the SPC chart}
 
-\item{summary}{tibble with SPC statistics (runs, crossings, control limits)}
+\item{summary}{data.frame with SPC statistics (runs, crossings, control
+limits). Plain \code{data.frame} -- not a \code{tibble}; downstream
+consumers should not rely on tibble-specific subscripting behavior.}
 
 \item{qic_data}{data.frame with raw qicharts2 calculation results}
 
@@ -18,7 +20,12 @@ new_bfh_qic_result(plot, summary, qic_data, config)
 \value{
 An object of class \code{bfh_qic_result} containing:
 \item{plot}{ggplot2 object with the SPC chart}
-\item{summary}{tibble with summary statistics}
+\item{summary}{data.frame with summary statistics (Danish column names).
+Returned as plain \code{data.frame} -- the previous documentation
+incorrectly described it as a \code{tibble}; cycle 01 review aligned
+the doc with the implementation. The class is part of the public
+contract and will not silently flip to \code{tibble} without a
+deprecation cycle.}
 \item{qic_data}{data.frame with qicharts2 calculations}
 \item{config}{list with original parameters}
 }


### PR DESCRIPTION
## Summary

Cycle 01 finding **E5 (MEDIUM)**. Doc-only fix. `R/bfh_qic_result.R` roxygen documented `\$summary` as 'tibble', but `R/utils_qic_summary.R` returns plain `data.frame`. Codex grep confirmed biSPCharts only accesses `\$summary` in one site without tibble-style subscripting (no `[, "col"]` patterns), so doc-update is low-risk.

Added explicit contract note: class is part of the public API and won't silently flip to `tibble` without a deprecation cycle.

## Test plan

- [x] No code changes — doc-only
- [x] roxygen2 regenerated (1 file: `man/new_bfh_qic_result.Rd`)
- [x] Cross-package validation: biSPCharts has no tibble-style subscripting on `\$summary`

Refs: `docs/reviews/01-production-readiness-2026-05-10.md` E5