### PR TITLE
fix(validation): reject non-finite numeric parameters (cycle 01 E2)

### DIFF
--- a/R/utils_helpers.R
+++ b/R/utils_helpers.R
@@ -112,6 +112,21 @@ validate_numeric_parameter <- function(value,
     )), call. = FALSE)
   }
 
+  # Check finiteness explicitly. Without this, Inf/-Inf slip through bounds
+  # checks (Inf < Inf is FALSE, Inf > Inf is FALSE) and reach downstream
+  # qicharts2 / yA_npc machinery where they fail with cryptic messages
+  # like "yA_npc must be finite" after the user-supplied-cl warning has
+  # already been emitted (cycle 01 finding E2). Bypass param_msg() so the
+  # finiteness violation surfaces directly instead of via the more generic
+  # "must be a single numeric value" fallback (Inf IS a single numeric
+  # value -- the issue is finiteness specifically).
+  if (any(!is.finite(value))) {
+    stop(sprintf(
+      "%s must be finite, got: %s",
+      param_name, paste(value, collapse = ", ")
+    ), call. = FALSE)
+  }
+
   # Check length
   if (!is.null(len) && length(value) != len) {
     stop(param_msg(sprintf(

--- a/tests/testthat/test-bfh_qic_edge_cases.R
+++ b/tests/testthat/test-bfh_qic_edge_cases.R
@@ -116,6 +116,29 @@ test_that("bfh_qic med cl parameter sætter custom centerlinje", {
   expect_true(all(result$qic_data$cl == 42))
 })
 
+test_that("E2 regression: bfh_qic rejects non-finite cl with clear error", {
+  # Cycle 01 finding E2 (review 2026-05-10):
+  # validate_numeric_parameter() admitted Inf because is.na(Inf)=FALSE and
+  # bounds checks Inf < Inf / Inf > Inf both return FALSE. Inf flowed to
+  # qicharts2 / yA_npc machinery where it failed with cryptic
+  # "yA_npc must be finite" -- AFTER the user-supplied-cl warning had
+  # already been emitted, masking the actual root cause.
+  set.seed(42)
+  data <- data.frame(
+    date = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 12),
+    value = rpois(12, lambda = 50)
+  )
+
+  expect_error(
+    bfh_qic(data, x = date, y = value, chart_type = "run", cl = Inf),
+    "cl must be finite"
+  )
+  expect_error(
+    bfh_qic(data, x = date, y = value, chart_type = "run", cl = -Inf),
+    "cl must be finite"
+  )
+})
+
 test_that("bfh_qic med part parameter opretter faser", {
   set.seed(42)
 


### PR DESCRIPTION
## Summary

Cycle 01 finding **E2 (MEDIUM)**. `validate_numeric_parameter()` admitted `Inf`/`-Inf` because `is.na(Inf) == FALSE` and bounds checks `Inf < Inf`/`Inf > Inf` both return FALSE. `bfh_qic(..., cl = Inf)` flowed downstream to qicharts2/yA_npc and failed with cryptic "yA_npc must be finite" AFTER the user-supplied-cl warning had already been emitted.

Codex recalibrated the original "produces NaN limits" claim — the failure is downstream and misleading, not silent corruption. Severity stays MEDIUM on validator-fail-fast grounds.

## Test plan

- [x] 2 new regression tests in `tests/testthat/test-bfh_qic_edge_cases.R`
- [x] cl=Inf raises "cl must be finite"
- [x] cl=-Inf raises "cl must be finite"
- [x] 46 PASS / 0 FAIL on edge-cases test cluster

Refs: `docs/reviews/01-production-readiness-2026-05-10.md` E2