### PR TITLE
fix(security): create staging tempdirs atomically with mode=0700 (cycle 01 S1)

### DIFF
--- a/R/export_session.R
+++ b/R/export_session.R
@@ -87,7 +87,10 @@ bfh_create_export_session <- function(font_path = NULL, inject_assets = NULL,
   }
 
   tmpdir <- tempfile("bfh_batch_")
-  dir.create(tmpdir, recursive = TRUE)
+  # Atomic perms; cycle 01 finding S1 (TOCTOU on staging dir).
+  # Sys.chmod below stays as belt-and-suspenders for platforms with
+  # inconsistent mode= honoring on dir.create (older R / Windows).
+  dir.create(tmpdir, recursive = TRUE, mode = "0700")
   # Sikkerhed: tempfile() leverer en per-bruger isoleret sti i tempdir(),
   # og Sys.chmod(0700) fjerner group/other-permissions. UID-baseret
   # ownership validation is intentionally omitted -- UID is shell-internal and typically

--- a/R/utils_export_helpers.R
+++ b/R/utils_export_helpers.R
@@ -338,7 +338,14 @@ prepare_temp_workspace <- function(batch_session) {
   chart_svg <- tempfile(pattern = "chart-", tmpdir = temp_dir, fileext = ".svg")
   typst_file <- tempfile(pattern = "document-", tmpdir = temp_dir, fileext = ".typ")
 
-  dir.create(temp_dir, recursive = TRUE)
+  # Atomic perms via mode= so the dir is never world-readable, even briefly.
+  # Cycle 01 finding S1: the previous two-step (dir.create then chmod)
+  # left a microsecond window where a co-tenant could open a directory-fd
+  # while perms were still default 0755/0775, then continue enumerating
+  # contents after chmod tightened the inode. The Sys.chmod below remains
+  # as belt-and-suspenders for platforms where mode= is honored
+  # inconsistently (older R versions, Windows).
+  dir.create(temp_dir, recursive = TRUE, mode = "0700")
 
   # Sikkerhed: tempfile() leverer en per-bruger isoleret sti i tempdir(),
   # og Sys.chmod(0700) fjerner group/other-permissions. UID-baseret

--- a/R/utils_typst.R
+++ b/R/utils_typst.R
@@ -328,7 +328,10 @@ bfh_create_typst_document <- function(chart_image,
     return(cached_path)
   }
   dir <- tempfile("bfh_tpl_")
-  dir.create(dir, recursive = TRUE)
+  # Create with restrictive perms atomically; the subsequent Sys.chmod is
+  # belt-and-suspenders for older R versions / Windows where mode= on
+  # dir.create may be ignored. Cycle 01 finding S1 (TOCTOU on staging dir).
+  dir.create(dir, recursive = TRUE, mode = "0700")
   Sys.chmod(dir, mode = "0700", use_umask = FALSE)
   src <- system.file("templates/typst/bfh-template", package = "BFHcharts")
   if (!dir.exists(src)) {


### PR DESCRIPTION
## Summary

Cycle 01 finding **S1 (LOW, defense-in-depth)**. Three staging-tempdir creation sites used the two-step pattern `dir.create()` then `Sys.chmod(0700)`, leaving a microsecond TOCTOU window where the dir was world-readable (0755/0775 default after umask) before chmod tightened it.

In practice mitigated under current Connect Cloud config (per-tenant parent tempdir is 0700); fixed defensively to remove the timing window.

Sites: `R/utils_typst.R:330-332`, `R/utils_export_helpers.R:341-349`, `R/export_session.R:89-96`. `Sys.chmod()` retained as belt-and-suspenders for older R / Windows where mode= may be honored inconsistently.

## Test plan

- [x] 103 PASS / 0 FAIL on isolation/export-session/pdf-content cluster (no behavior change)
- [x] No new tests — TOCTOU racing is hard to assert deterministically; the static fix is correct by construction

Refs: `docs/reviews/01-production-readiness-2026-05-10.md` S1