### PR TITLE
fix(security): re-validate chart_image after symlink resolution (cycle 01 S3)

### DIFF
--- a/R/utils_typst.R
+++ b/R/utils_typst.R
@@ -152,8 +152,15 @@ bfh_create_typst_document <- function(chart_image,
   chart_basename <- basename(chart_image)
   local_chart <- file.path(output_dir, chart_basename)
 
-  # Normalize paths to compare (handles relative vs absolute, symlinks, etc.)
+  # Normalize paths to compare (handles relative vs absolute, symlinks, etc.).
+  # Cycle 01 finding S3: validate_export_path() ran on the syntactic input
+  # path BEFORE symlink resolution, so a symlink chart_image -> /var/lib/
+  # connect/tenant-a/data/cached.svg would pass validation but file.copy()
+  # would follow the symlink and pull tenant-A's PHI into the calling
+  # tenant's PDF. Re-validate the resolved (post-symlink) path so the
+  # path-traversal + shell-metachar guards apply to the real target too.
   chart_image_norm <- normalizePath(chart_image, mustWork = TRUE)
+  validate_export_path(chart_image_norm)
   local_chart_norm <- normalizePath(local_chart, mustWork = FALSE)
 
   # Only copy if source and destination are different files


### PR DESCRIPTION
## Summary

Cycle 01 finding **S3 (LOW, defensive)**. `bfh_create_typst_document()` ran `validate_export_path()` on the syntactic input BEFORE `normalizePath()` resolved symlinks. A symlink `chart.png -> /var/lib/connect/tenant-a/data/cached_qic.svg` would pass syntactic validation but `file.copy()` follows symlinks for source files, so tenant-A's PHI-bearing SVG would land in the calling tenant's PDF.

Mitigation: under current biSPCharts flow, `chart_image` is generated locally via `ggsave()` and never accepts user-controlled paths. Fixed defensively because the function is `@export`'d for future companion packages.

Fix: re-run `validate_export_path(chart_image_norm)` after `normalizePath(mustWork = TRUE)` so guards apply to the real target.

## Test plan

- [x] 224 PASS / 0 FAIL on full security cluster (no behavior change)
- [x] Single-line additive change; existing tests cover validate_export_path() behavior

Refs: `docs/reviews/01-production-readiness-2026-05-10.md` S3