### PR TITLE
fix(summary): early-return empty data.frame on empty qic_data (cycle 01 E6)

### DIFF
--- a/R/utils_qic_summary.R
+++ b/R/utils_qic_summary.R
@@ -104,6 +104,20 @@ format_qic_summary <- function(qic_data, y_axis_unit = "count") {
   # Check which columns exist (run charts don't have lcl/ucl)
   available_cols <- intersect(summary_cols, names(qic_data))
 
+  # Defensive early-return for empty qic_data. bfh_qic() blocks
+  # nrow(data) == 0 upstream (utils_bfh_qic_helpers.R:310), so this only
+  # triggers if qicharts2 itself returns zero rows (extreme exclude=
+  # configuration). Without this, qic_data[1, ] returns a 1-row NA frame
+  # that propagates NAs into runs_signal / crossings_signal columns.
+  # Cycle 01 finding E6.
+  if (nrow(qic_data) == 0L) {
+    empty <- as.data.frame(setNames(
+      replicate(length(available_cols), logical(0), simplify = FALSE),
+      available_cols
+    ), stringsAsFactors = FALSE)
+    return(empty)
+  }
+
   # Extract unique summary rows per part
   # Use split + per-part aggregation for correct Anhoej statistics
   if ("part" %in% names(qic_data)) {


### PR DESCRIPTION
## Summary

Cycle 01 finding **E6 (LOW, defensive)**. `format_qic_summary()` unconditionally indexed `qic_data[1, ]` / split-by-part. If qic_data has zero rows (extreme exclude= configuration), the path produced a 1-row NA frame propagating NAs into runs_signal/crossings_signal columns.

`bfh_qic()` already blocks `nrow(data) == 0` upstream so this path only triggers if qicharts2 itself returns empty after include= filtering. LOW severity defensive fix; no production scenario currently exercises it.

Fix: explicit early-return with empty data.frame matching the column-set so downstream nrow()-checks behave correctly.

## Test plan

- [x] 75 PASS / 0 FAIL on `test-utils_qic_summary.R` (no behavior change for non-empty inputs)
- [x] Manual verification: empty qic_data -> 0-row data.frame with correct cols

Refs: `docs/reviews/01-production-readiness-2026-05-10.md` E6