### PR TITLE
fix(validation): reject freeze=1 on 1-row data cleanly (cycle 01 E7)

### DIFF
--- a/R/utils_bfh_qic_helpers.R
+++ b/R/utils_bfh_qic_helpers.R
@@ -396,10 +396,15 @@ validate_bfh_qic_inputs <- function(data,
     require_sorted = TRUE, require_unique = TRUE,
     min = 2L, max = nrow(data)
   )
+  # Cycle 01 finding E7: previously max = max(nrow(data) - 1L, 1L), which
+  # admitted freeze = 1 on 1-row data (max(0, 1) = 1, freeze == nrow). That
+  # left zero rows after the baseline and produced a cryptic qicharts2
+  # error downstream. Remove the floor so 1-row data fails cleanly with
+  # the validator's own bounds-message ("freeze must be within data bounds").
   validate_position_indices(freeze, "freeze", nrow(data),
     require_sorted = FALSE, require_unique = TRUE,
     require_scalar = TRUE,
-    min = 1L, max = max(nrow(data) - 1L, 1L)
+    min = 1L, max = nrow(data) - 1L
   )
 
   # Warn if freeze baseline is too short for reliable signal detection

--- a/tests/testthat/test-bfh_qic_edge_cases.R
+++ b/tests/testthat/test-bfh_qic_edge_cases.R
@@ -200,6 +200,21 @@ test_that("bfh_qic med enkelt-række data returnerer objekt (ingen crash)", {
   expect_equal(nrow(result$qic_data), 1)
 })
 
+test_that("E7 regression: freeze=1 on 1-row data is rejected cleanly", {
+  # Cycle 01 finding E7 (review 2026-05-10):
+  # validate_position_indices() previously had max = max(nrow(data)-1, 1L)
+  # which floored at 1, admitting freeze=1 on 1-row data (zero baseline
+  # rows after split). qicharts2 then errored cryptically downstream.
+  # Now: max = nrow(data)-1 directly, so 1-row + freeze=1 is rejected at
+  # validation time with the standard bounds-error.
+  data <- data.frame(date = as.Date("2024-01-01"), value = 42)
+
+  expect_error(
+    bfh_qic(data, x = date, y = value, chart_type = "run", freeze = 1),
+    "data bounds"
+  )
+})
+
 # ============================================================================
 # BASELINE MINIMUM ADVARSEL TESTS (enforce-baseline-minimum-and-cl-warnings)
 # ============================================================================


### PR DESCRIPTION
## Summary

Cycle 01 finding **E7 (LOW, defensive)**. `validate_position_indices()` set `max = max(nrow(data) - 1L, 1L)` for the freeze parameter. The `max(., 1L)` floor admitted `freeze=1` on 1-row data, where freeze == nrow leaves zero observations after baseline split. qicharts2 then failed downstream cryptically.

Marginal frequency (1-row clinical data is rare), but the floor was the wrong defense. Drop it; max = nrow(data) - 1L. With nrow=1, max=0, so any non-NULL freeze is rejected at validation time. NULL freeze still works.

## Test plan

- [x] 1 new regression test in `tests/testthat/test-bfh_qic_edge_cases.R`
- [x] freeze=1 on 1-row data raises "data bounds" error
- [x] Existing single-row test (no freeze) still passes
- [x] 45 PASS / 0 FAIL on edge-cases cluster

Refs: `docs/reviews/01-production-readiness-2026-05-10.md` E7