### PR TITLE
fix(validation): reject negative y on count-style charts (cycle 01 E8)

### DIFF
--- a/R/utils_bfh_qic_helpers.R
+++ b/R/utils_bfh_qic_helpers.R
@@ -349,6 +349,30 @@ validate_bfh_qic_inputs <- function(data,
         call. = FALSE
       )
     }
+
+    # Cycle 01 finding E8: count-style charts (c, g, t, p, pp, u, up)
+    # require non-negative y. qicharts2 silently rendered negative counts
+    # without warning, producing statistically meaningless charts that
+    # appeared valid to clinicians. Catch at validation time with a
+    # clear chart-type-aware error.
+    count_chart_types <- c("c", "g", "t", "p", "pp", "u", "up")
+    if (chart_type %in% count_chart_types) {
+      neg_idx <- which(!is.na(y_data) & y_data < 0)
+      if (length(neg_idx) > 0L) {
+        stop(
+          sprintf(
+            paste0(
+              "column '%s' (y) contains negative values at row(s): %s. ",
+              "Chart type '%s' requires non-negative counts/proportions."
+            ),
+            y_expr_char,
+            paste(head(neg_idx, 5), collapse = ", "),
+            chart_type
+          ),
+          call. = FALSE
+        )
+      }
+    }
   }
 
   # notes must be a character vector (or all-NA) with same length as data.

--- a/tests/testthat/test-bfh_qic_edge_cases.R
+++ b/tests/testthat/test-bfh_qic_edge_cases.R
@@ -46,11 +46,36 @@ test_that("bfh_qic håndterer negative værdier", {
     value = rnorm(12, mean = -10, sd = 5)
   )
 
+  # i-chart accepterer negative værdier (continuous metric, fx temperaturer)
   result <- bfh_qic(data, x = date, y = value, chart_type = "i")
 
   expect_s3_class(result, "bfh_qic_result")
   # Y-værdier skal afspejle de negative inputdata
   expect_true(any(result$qic_data$y < 0))
+})
+
+test_that("E8 regression: count-style charts reject negative y values", {
+  # Cycle 01 finding E8 (review 2026-05-10):
+  # qicharts2 silently rendered negative counts on c/g/t/p/u-charts,
+  # producing statistically meaningless charts that appeared valid to
+  # clinicians. Now caught at validation time with chart-type-aware error.
+  data <- data.frame(
+    date = as.Date("2024-01-01") + 0:9,
+    val = c(5, 3, 8, -1, 4, 6, 2, 7, 5, 3)
+  )
+
+  for (ct in c("c", "g", "t", "u")) {
+    expect_error(
+      bfh_qic(data, x = date, y = val, chart_type = ct),
+      "non-negative",
+      info = paste0("chart_type='", ct, "' should reject negative y")
+    )
+  }
+
+  # i-chart (and run-chart) still accept negative values
+  expect_no_error(
+    bfh_qic(data, x = date, y = val, chart_type = "i")
+  )
 })
 
 test_that("bfh_qic håndterer stor dataset (200 punkter)", {


### PR DESCRIPTION
## Summary

Cycle 01 finding **E8 (LOW, statistical-correctness)**. qicharts2 silently rendered negative counts on chart types requiring non-negative inputs (c, g, t, p, pp, u, up). The chart appeared valid to clinicians but was statistically meaningless.

Fix: chart-type-aware validation in `validate_bfh_qic_inputs()` rejects negative y for c/g/t/p/pp/u/up with a clear error citing offending row(s) (first 5 shown). i-chart and run-chart still accept negatives (continuous metrics like temperatures or differences).

## Test plan

- [x] 1 new regression test in `tests/testthat/test-bfh_qic_edge_cases.R`
- [x] c, g, t, u-charts reject negative y with "non-negative"
- [x] i-chart still accepts negative y
- [x] Existing "negative values" test re-scoped to i-chart only
- [x] 49 PASS / 0 FAIL on edge-cases cluster
- [x] 531 PASS / 0 FAIL on broader bfh_qic/spc_analysis/qic_summary/statistical cluster

Refs: `docs/reviews/01-production-readiness-2026-05-10.md` E8