### PR TITLE
fix(bfh_qic): auto-mean per-phase + respects exclude= (cycle 02)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # BFHcharts 0.19.0
 
+## Bug fixes
+
+* **Auto-substitution af median → gennemsnit håndterer nu multi-phase
+  og `exclude=` korrekt** (cycle 02 dual-review). Tidligere version
+  fra 0.18.0 evaluerede kun sidste fase: tidligere fase med ≥50 % obs
+  tied til sin median forblev på median-CL og producerede degenererede
+  Anhøj-signaler. Detection iterer nu pr. fase og swapper hver fase
+  uafhængigt. Samtidigt respekteres `exclude=` nu både i trigger-
+  beregning og replacement-mean: tidligere indgik excluded outliers i
+  begge, hvilket gav misvisende ny CL. Cycle 02 review:
+  `docs/reviews/02-cl-auto-mean-validation-2026-05-16.md`.
+
 ## Breaking changes
 
 * `validate_denominator_data()` tillader nu `n = 0` for ratio-charts

--- a/R/bfh_qic.R
+++ b/R/bfh_qic.R
@@ -683,26 +683,35 @@ bfh_qic <- function(data,
   )
   qic_data <- invoke_qicharts2(qic_args, envir = qic_envir)
 
-  # Auto-mean substitution for run charts: when >=50% of last-phase
-  # observations sit exactly on the qicharts2-computed median, switch the
-  # last-phase centerline to mean. Skipped when:
+  # Auto-mean substitution for run charts: when >=50% of a phase's included
+  # observations sit exactly on the qicharts2-computed median, switch that
+  # phase's centerline to its mean. Skipped when:
   #   - user supplied cl= explicitly (cl is non-NULL)
   #   - freeze is set: freeze deliberately fixes CL to the freeze-window
   #     median, so a high tie-ratio is by design (baseline = 10, later
   #     phase = 20 -> 50% on CL is expected and informative)
-  # Implementation piggybacks on qicharts2's NA-fallback: earlier phases
-  # get NA cl -> qic.run() falls back to median per phase for those; last
-  # phase gets mean -> no NA -> qic.run uses our value.
+  # Implementation piggybacks on qicharts2's NA-fallback: non-trigger
+  # phases get NA cl -> qic.run() falls back to median per phase for
+  # those; trigger phases get their mean -> qic.run uses our value.
+  #
+  # Cycle 02 fixes:
+  # - H1: detection iterates ALL phases (not just last) so earlier phases
+  #   tied to median are also substituted.
+  # - H3: include-mask respected for both trigger ratio + replacement mean
+  #   (rows excluded via exclude= no longer skew CL).
   cl_auto_mean_substituted <- FALSE
-  if (is.null(cl) && is.null(freeze) &&
-    detect_majority_at_median_lastphase(qic_data, chart_type)) {
-    qic_args$cl <- build_last_phase_auto_cl(
-      raw_data = data,
-      qic_data = qic_data,
-      x_col_name = as.character(x_expr)
-    )
-    qic_data <- invoke_qicharts2(qic_args, envir = qic_envir)
-    cl_auto_mean_substituted <- TRUE
+  if (is.null(cl) && is.null(freeze)) {
+    trigger_phases <- detect_majority_at_median_per_phase(qic_data, chart_type)
+    if (length(trigger_phases) > 0L) {
+      qic_args$cl <- build_auto_cl_for_phases(
+        raw_data = data,
+        qic_data = qic_data,
+        x_col_name = as.character(x_expr),
+        trigger_phases = trigger_phases
+      )
+      qic_data <- invoke_qicharts2(qic_args, envir = qic_envir)
+      cl_auto_mean_substituted <- TRUE
+    }
   }
 
   # Warn when custom cl overrides the data-estimated process mean in Anhoej calculation

--- a/R/utils_bfh_qic_helpers.R
+++ b/R/utils_bfh_qic_helpers.R
@@ -211,60 +211,85 @@ build_bfh_qic_return <- function(qic_data, plot, summary_result, config,
   }
 }
 
-#' Detect auto-mean substitution trigger in the last phase of qic_data
+#' Detect auto-mean substitution triggers per phase of qic_data
 #'
-#' Returns TRUE if (a) chart_type is "run", AND (b) at least 50% of
-#' observations in the last phase lie exactly on the qicharts2-computed
-#' median centerline (|y - cl| < 1e-9). Pure function over qic_data.
+#' Iterates each phase in `qic_data` and returns the integer part-IDs of
+#' phases where at least `threshold` of the included observations lie
+#' exactly on the qicharts2-computed median centerline
+#' (|y - cl| < `tol`).
 #'
-#' Detection is scoped to the LAST phase only -- matches the
-#' filter_qic_to_last_phase() convention used elsewhere in
-#' bfh_build_analysis_context() and bfh_extract_spc_stats(). Clinically
-#' the last phase represents current-process state, which is the
-#' interesting case for auto-substitution.
+#' Pure function over `qic_data`. Detection scopes per-phase (cycle 02 H1
+#' fix) rather than last-phase-only: a multi-phase run chart with an
+#' earlier phase tied on its phase median otherwise retained median CL +
+#' degenerate Anhoej output.
+#'
+#' Cycle 02 H3 fix: respects qicharts2's `include` column. Rows with
+#' `include = FALSE` (excluded via `exclude=`) are not counted toward
+#' numerator or denominator -- matches qicharts2's own CL-computation
+#' contract.
 #'
 #' @param qic_data Output from a probe call to `qicharts2::qic()` with
 #'   `cl = NULL` (median centerline)
 #' @param chart_type Character; only "run" triggers detection
 #' @param threshold Fraction in [0, 1]; default 0.5
 #' @param tol Numeric tolerance for exact match against cl; default 1e-9
-#' @return Logical scalar
+#' @return Integer vector of part-IDs that should receive auto-mean
+#'   substitution. Empty integer vector when no phase triggers or
+#'   chart_type != "run".
 #' @keywords internal
 #' @noRd
-detect_majority_at_median_lastphase <- function(qic_data,
+detect_majority_at_median_per_phase <- function(qic_data,
                                                 chart_type,
                                                 threshold = 0.5,
                                                 tol = 1e-9) {
   if (!identical(chart_type, "run")) {
-    return(FALSE)
+    return(integer(0))
   }
   if (is.null(qic_data) || !all(c("y", "cl") %in% names(qic_data))) {
-    return(FALSE)
+    return(integer(0))
   }
-  qd <- filter_qic_to_last_phase(qic_data)
-  if (is.null(qd) || nrow(qd) == 0L) {
-    return(FALSE)
+  if (nrow(qic_data) == 0L) {
+    return(integer(0))
   }
-  y <- qd$y
-  cl <- qd$cl
-  valid <- !is.na(y) & !is.na(cl)
-  if (sum(valid) < 2L) {
-    return(FALSE)
+  has_part <- "part" %in% names(qic_data)
+  part_ids <- if (has_part) {
+    sort(unique(qic_data$part))
+  } else {
+    1L
   }
-  # Guard: constant y -> no-variation path owns this case; skip auto-sub.
-  if (stats::var(y[valid]) < tol) {
-    return(FALSE)
+  trigger <- integer(0)
+  for (p in part_ids) {
+    qd_p <- if (has_part) {
+      qic_data[qic_data$part == p, , drop = FALSE]
+    } else {
+      qic_data
+    }
+    y <- qd_p$y
+    cl <- qd_p$cl
+    include <- if ("include" %in% names(qd_p)) {
+      !is.na(qd_p$include) & qd_p$include
+    } else {
+      rep(TRUE, length(y))
+    }
+    valid <- !is.na(y) & !is.na(cl) & include
+    if (sum(valid) < 2L) next
+    # Guard: constant y -> no-variation path owns this case; skip auto-sub.
+    if (stats::var(y[valid]) < tol) next
+    on_cl <- abs(y[valid] - cl[valid]) < tol
+    if (sum(on_cl) / sum(valid) >= threshold) {
+      trigger <- c(trigger, as.integer(p))
+    }
   }
-  on_cl <- abs(y[valid] - cl[valid]) < tol
-  sum(on_cl) / sum(valid) >= threshold
+  trigger
 }
 
-#' Build raw-data-length cl-vector that substitutes mean for the last phase
+#' Build raw-data-length cl-vector that substitutes mean per trigger phase
 #'
 #' Returns a numeric vector of length `nrow(raw_data)` suitable for passing
-#' to `qicharts2::qic(cl = ...)`. Rows belonging to the last phase get the
-#' last-phase mean; rows in earlier phases get NA so that qicharts2's
-#' per-phase median fallback applies.
+#' to `qicharts2::qic(cl = ...)`. Rows belonging to a trigger phase get
+#' that phase's mean (computed over included observations only); rows in
+#' non-trigger phases get NA so that qicharts2's per-phase median fallback
+#' applies.
 #'
 #' qicharts2 contract relied upon (verified empirically via probe):
 #' - `qic()` evaluates `cl` in the data environment and bundles it as a
@@ -273,40 +298,51 @@ detect_majority_at_median_lastphase <- function(qic_data,
 #'   cl over raw rows survives mean/median/sum aggregation unchanged.
 #' - `qic.run()` checks `anyNA(x$cl)` per phase; if any aggregated row in
 #'   a phase has cl=NA, the entire phase is replaced with median(y) for
-#'   that phase. This is precisely what we want for non-substituted phases.
+#'   that phase. This is precisely what we want for non-trigger phases.
 #'
-#' Implementation matches raw rows to the last phase via x-value membership
-#' against the last-phase x-values from the probe qic_data.
+#' Cycle 02 H3 fix: replacement mean uses only `include = TRUE` rows.
+#' Excluded outliers (via `exclude=`) no longer contaminate the new CL.
 #'
 #' @param raw_data Original data frame passed to bfh_qic() (pre-aggregation)
 #' @param qic_data Output from probe qic-call (post-aggregation)
 #' @param x_col_name Character; name of the x column in raw_data
-#' @return Numeric vector of length nrow(raw_data) -- NA for non-last-phase
-#'   rows, last-phase-mean for last-phase rows
+#' @param trigger_phases Integer vector of part-IDs to substitute (from
+#'   `detect_majority_at_median_per_phase()`). Empty vector returns an
+#'   all-NA cl-vector.
+#' @return Numeric vector of length nrow(raw_data) -- NA for non-trigger-
+#'   phase rows, phase-specific mean for trigger-phase rows.
 #' @keywords internal
 #' @noRd
-build_last_phase_auto_cl <- function(raw_data, qic_data, x_col_name) {
-  qd_last <- filter_qic_to_last_phase(qic_data)
-  if (is.null(qd_last) || nrow(qd_last) == 0L) {
+build_auto_cl_for_phases <- function(raw_data, qic_data, x_col_name,
+                                     trigger_phases) {
+  if (length(trigger_phases) == 0L ||
+    is.null(qic_data) || nrow(qic_data) == 0L) {
     return(rep(NA_real_, nrow(raw_data)))
   }
-  # Compute last-phase mean from POST-aggregation y (correct statistical
-  # level; mean of already-aggregated subgroup means).
-  last_mean <- mean(qd_last$y, na.rm = TRUE)
-  if (!is.finite(last_mean)) {
-    return(rep(NA_real_, nrow(raw_data)))
-  }
-  # Match raw rows to last phase by x-value membership. Works for charts
-  # with duplicate raw x (daily->monthly agg): all raw rows with x in the
-  # last-phase x-set get the same mean -> qic.agg collapses to cl[1] =
-  # mean (constant input).
+  has_part <- "part" %in% names(qic_data)
   raw_x <- raw_data[[x_col_name]]
-  last_x_values <- qd_last$x
   new_cl <- rep(NA_real_, nrow(raw_data))
-  # Equality semantics for Date / numeric / character / factor all
-  # handled by %in% via match() -- consistent with qicharts2's own
-  # x-value handling.
-  new_cl[raw_x %in% last_x_values] <- last_mean
+  for (p in trigger_phases) {
+    qd_p <- if (has_part) {
+      qic_data[qic_data$part == p, , drop = FALSE]
+    } else {
+      qic_data
+    }
+    if (nrow(qd_p) == 0L) next
+    # Include-filter: replacement mean must respect qicharts2's
+    # include-contract. Excluded rows (via exclude=) must not skew CL.
+    include_mask <- if ("include" %in% names(qd_p)) {
+      !is.na(qd_p$include) & qd_p$include
+    } else {
+      rep(TRUE, nrow(qd_p))
+    }
+    if (sum(include_mask) == 0L) next
+    phase_mean <- mean(qd_p$y[include_mask], na.rm = TRUE)
+    if (!is.finite(phase_mean)) next
+    # Match raw rows by x-value membership. Equality semantics for
+    # Date / numeric / character / factor all handled by %in% via match().
+    new_cl[raw_x %in% qd_p$x] <- phase_mean
+  }
   new_cl
 }
 

--- a/docs/reviews/02-cl-auto-mean-validation-2026-05-16.md
+++ b/docs/reviews/02-cl-auto-mean-validation-2026-05-16.md
@@ -1,0 +1,271 @@
+# Cycle 02 — Auto-mean centerline-substitution validation (2026-05-16)
+
+**Område:** Run-chart median→mean auto-substitution når ≥50 % af obs ligger eksakt på centerlinjen.
+**Trigger:** Brugerrapport: "jeg kan generere charts hvor medianen så IKKE bliver ændret til gennemsnittet".
+**Baseline-kommit:** `ae5cfd7` (feat run-chart auto-mean, merged via PR #371).
+
+---
+
+## Scope
+
+Validerer:
+1. `detect_majority_at_median_lastphase()` (R/utils_bfh_qic_helpers.R:234-260)
+2. `build_last_phase_auto_cl()` (R/utils_bfh_qic_helpers.R:288-311)
+3. Trigger-betingelser i `bfh_qic()` (R/bfh_qic.R:686-706)
+4. Test-suite (tests/testthat/test-cl-auto-mean.R, 19 tests)
+
+---
+
+## H1 [MEDIUM] — Multi-phase: earlier phases beholder median selvom majority-on-median
+
+**Lokation:** R/utils_bfh_qic_helpers.R:244 + R/bfh_qic.R:697-705
+
+**Symptom:** I `part`-baserede multi-phase run-charts evalueres trigger KUN mod sidste fase. Hvis en tidligere fase har ≥50 % obs tied til sin (faseinterne) median, beholder den fase median som CL — Anhøj run/crossing-detection får degenererede tællinger for den fase, og `cl_auto_mean`-flaget bliver `FALSE` overall (intet PDF-caveat).
+
+**Verifikation (empirisk reproduceret 2026-05-16):**
+```r
+# Phase 1: 12/18 obs (66 %) tied paa median(=1)
+# Phase 2: kontinuert normalfordeling
+phase1 <- c(rep(1, 12), 2, 2, 3, 3, 4, 4)
+phase2 <- rnorm(15, 8, 2)
+d <- data.frame(x = 1:33, y = c(phase1, phase2))
+r <- bfh_qic(d, x = x, y = y, chart_type = "run", part = 18, return.data = TRUE)
+# Phase 1 cl: 1 (median, IKKE swap'et)
+# Phase 1 obs on cl: 12/18
+# Phase 1 runs.signal: TRUE  -- degenereret Anhoej-output
+# Phase 2 cl: median(phase2)
+# attr(r, "cl_auto_mean"): FALSE
+```
+
+**Konsekvens:**
+- Kliniker ser run-chart hvor fase 1 hævder "long run" (runs.signal=TRUE), men signalet er artefakt af diskret skala (12 ud af 18 obs ligger eksakt på CL — Anhøj-rules antager kontinuert data uden ties).
+- PDF-caveat surfaces ikke (`cl_auto_mean`-attr afspejler kun sidste fase).
+- Bryder den klinisk-statistiske kontrakt: "vi har fjernet tie-degenererings-problemet" — fjernet kun for sidste fase.
+
+**Designintent (eksplicit i kode-kommentar):**
+```r
+# Detection is scoped to the LAST phase only -- matches the
+# filter_qic_to_last_phase() convention used elsewhere in
+# bfh_build_analysis_context() and bfh_extract_spc_stats(). Clinically
+# the last phase represents current-process state, which is the
+# interesting case for auto-substitution.
+```
+
+Begrundelsen "last phase = current process" gælder for tekstanalyse + summary-tabel (hvor man kun ser aktuel tilstand). Men for plot-rendering ses alle faser — derfor skal CL-swap pr. fase, ikke kun for last.
+
+**Foreslået fix (Option A — pr.-fase detection):**
+
+Udskift last-phase-scoping med per-phase iteration. Hver fase får sin egen `on_cl_ratio` evalueret; hvis ≥50 %, swap'es den fase's CL til fase-mean. `cl_auto_mean`-attr sættes TRUE hvis MINDST én fase trigger'er. Caveat-tekst tilpasses til at angive evt. fase-nummer.
+
+Skeleton:
+```r
+detect_majority_at_median_per_phase <- function(qic_data, chart_type,
+                                                threshold = 0.5, tol = 1e-9) {
+  if (!identical(chart_type, "run")) return(integer(0))
+  if (is.null(qic_data) || !all(c("y", "cl") %in% names(qic_data))) return(integer(0))
+  if (!"part" %in% names(qic_data)) {
+    # single-phase: brug eksisterende last-phase-helper
+    if (detect_majority_at_median_lastphase(qic_data, chart_type, threshold, tol)) {
+      return(1L)
+    } else {
+      return(integer(0))
+    }
+  }
+  parts <- sort(unique(qic_data$part))
+  trigger_phases <- integer(0)
+  for (p in parts) {
+    qd_p <- qic_data[qic_data$part == p, , drop = FALSE]
+    y <- qd_p$y; cl <- qd_p$cl
+    valid <- !is.na(y) & !is.na(cl)
+    if (sum(valid) < 2L) next
+    if (stats::var(y[valid]) < tol) next       # no_variation-guard
+    on_cl <- abs(y[valid] - cl[valid]) < tol
+    if (sum(on_cl) / sum(valid) >= threshold) {
+      trigger_phases <- c(trigger_phases, as.integer(p))
+    }
+  }
+  trigger_phases
+}
+```
+
+`build_last_phase_auto_cl()` rebuilder til at acceptere vektor af trigger-phases og skrive fase-mean i hver match.
+
+**Option B (defer):** Dokumentér multi-phase-begrænsning i `?bfh_qic` + NEWS, og lad fix ligge. Klinisk impact er lav for typiske use-cases (folk laver enten single-phase eller phases hvor sidste fase er den interessante).
+
+**Anbefaling:** Option A — fixen er <50 LOC og fjerner et kontrakt-brud. Multi-phase run-charts findes i biSPCharts'  produktion.
+
+---
+
+## H3 [MEDIUM] — `exclude=` ignoreres af både trigger-detection og replacement-mean (Codex-found)
+
+**Lokation:** R/utils_bfh_qic_helpers.R:248-259 (detection) + R/utils_bfh_qic_helpers.R:288-311 (replacement)
+
+**Symptom:** `qicharts2::qic(exclude = ...)` markerer rækker med `include = FALSE` i return.data og bruger kun `include=TRUE`-rækker til CL-beregning. Men:
+
+1. **Trigger:** `detect_majority_at_median_lastphase()` tæller `abs(y - cl) < tol` over ALLE last-phase rækker uden at konsultere `qic_data$include`. Excluded rækker tæller med i numerator OG denominator.
+2. **Replacement:** `build_last_phase_auto_cl()` beregner `mean(qd_last$y, na.rm = TRUE)` over alle last-phase rækker uden include-filter. Excluded outliers forurener den nye CL.
+
+**Verifikation (empirisk reproduceret 2026-05-16):**
+```r
+# 10/16 included rows tied at 1, 4 excluded rows = 100 (extreme outliers)
+d <- data.frame(x = 1:20, y = c(rep(1, 10), 2, 2, 3, 3, 4, 4, 100, 100, 100, 100))
+r <- bfh_qic(d, x = x, y = y, chart_type = "run", exclude = 17:20, return.data = TRUE)
+# cl[1]: 21.4   <-- mean af alle 20 vaerdier
+# expected: 1.75  <-- mean af kun de 16 included
+# auto_mean: TRUE
+```
+
+`r$include` viser korrekt `TRUE×16, FALSE×4`, men `cl_auto_mean` ignorerer feltet.
+
+**Konsekvens:**
+- Excluded outliers (typisk: ekstreme events, data-rensning) drager CL massivt mod sig selv → kontrakten "excluded points contribute nothing to calculations" brydes.
+- Detection-fasen kan også flippe forkert vej: hvis excluded rækker er tied til median, kan ratio kryds 50 %-tærsklen mod brugerens forventning.
+- Bryder kontrakt-konsistens med qicharts2's eget include-respektive CL (median for run-charts beregnes kun over included).
+
+**Foreslået fix:**
+```r
+detect_majority_at_median_lastphase <- function(qic_data, chart_type,
+                                                threshold = 0.5, tol = 1e-9) {
+  # ... eksisterende guards ...
+  y <- qd$y
+  cl <- qd$cl
+  # NY: include-filter naar feltet findes
+  include <- if ("include" %in% names(qd)) qd$include else rep(TRUE, length(y))
+  valid <- !is.na(y) & !is.na(cl) & isTRUE_vec(include)
+  # ... resten af logik ...
+}
+
+build_last_phase_auto_cl <- function(raw_data, qic_data, x_col_name) {
+  qd_last <- filter_qic_to_last_phase(qic_data)
+  # ... existing guards ...
+  # NY: kun included rows i mean-beregning
+  include_mask <- if ("include" %in% names(qd_last)) {
+    qd_last$include
+  } else {
+    rep(TRUE, nrow(qd_last))
+  }
+  last_mean <- mean(qd_last$y[include_mask], na.rm = TRUE)
+  # ... resten ...
+}
+```
+
+Bemærk: `raw_data %in% last_x_values` matching skal også respektere exclude — men exclude er typisk specificeret som row-indices mod ORIGINAL data, så den enkleste path er at lade qicharts2's interne aggregation håndtere det (excluded raw-rows får alligevel ikke ny cl via vores `%in%`-match, fordi de ikke har x-værdi i `qd_last$x`). Verificeret: nuværende matching giver excluded raw-rows den nye mean, men qicharts2 lægger `include = FALSE` på dem efterfølgende, så CL'en for excluded points er kosmetisk irrelevant. **Det er KUN replacement-mean-beregningen der skal include-filtreres**.
+
+**Anbefaling:** Fix sammen med H1 i samme PR — begge rører de samme to helpers.
+
+**Test-gap:** Ingen eksisterende test dækker `exclude` i kombination med auto-mean. Tilføj regression:
+```r
+test_that("auto-mean respects exclude= for both trigger and replacement", {
+  # 10 included tied + 6 included non-tied + 4 excluded extreme outliers
+  d <- data.frame(x = 1:20, y = c(rep(1, 10), 2, 2, 3, 3, 4, 4, 100, 100, 100, 100))
+  r <- bfh_qic(d, x = x, y = y, chart_type = "run", exclude = 17:20,
+               return.data = TRUE)
+  expect_true(isTRUE(attr(r, "cl_auto_mean")))
+  expect_equal(r$cl[1], mean(c(rep(1, 10), 2, 2, 3, 3, 4, 4)), tolerance = 1e-6)
+})
+```
+
+---
+
+## H2 [LOW] — Test "respects threshold boundary" matcher ikke real-world qic-output
+
+**Lokation:** tests/testthat/test-cl-auto-mean.R:33-49
+
+**Symptom:** Testen konstruerer `qic_data` med syntetisk `cl = rep(1, 10)`, hvor 5 obs har y=1. Det giver 5/10 = 50 % on-CL → trigger fyrer.
+
+Men i REAL `bfh_qic`-kald med `y = c(rep(1, 5), 2, 3, 4, 5, 6)`, beregner qicharts2 `median(y) = 1.5` (10 obs, even count → mean af 5. og 6. = (1+2)/2). Ingen obs ligger på 1.5 → trigger fyrer IKKE.
+
+**Verifikation:**
+```r
+d <- data.frame(x = 1:10, y = c(rep(1, 5), 2, 3, 4, 5, 6))
+r <- bfh_qic(d, x = x, y = y, chart_type = "run", return.data = TRUE)
+# cl[1]: 1.5
+# auto_mean: FALSE   (testen passer pga. synthetic cl=1, men real-world: ingen trigger)
+```
+
+**Konsekvens:** Testen påstår "respects threshold boundary" med en konstruktion der aldrig kan opstå organisk. 50 % boundary-testen verificerer kun `>=`-vs-`>`-operatoren, ikke real-world boundary-adfærd.
+
+For at konstruere ægte 50 %-on-median kræves at median falder på en obs-værdi der præcis halvdelen af datasæt deler. Codex (2026-05-16-recalibration) påpegede at det er muligt med even-count konstruktioner — fx `y = c(0, 0, 1, 1, 1, 1, 1, 2, 2, 2)`: median = (sort[5]+sort[6])/2 = (1+1)/2 = 1, tied = 5, ratio = 5/10 = 50 %. → trigger fyrer korrekt.
+
+**Foreslået fix:** Erstat den syntetiske test med en real-data testcase ved `y = c(0, 0, 1, 1, 1, 1, 1, 2, 2, 2)` så testen samtidigt verificerer (a) at `>=` ikke `>` bruges, og (b) at real qicharts2-pipeline producerer det forventede ratio.
+
+**Anbefaling:** Lav-prioritet test-quality-fix; ingen produktionsbug. Kan implementeres sammen med H1+H3 eller defer.
+
+---
+
+## M1 [LOW] — qicharts2 NA-fallback-kontrakt udokumenteret som test-invariant
+
+**Lokation:** R/utils_bfh_qic_helpers.R:269-275 (kun roxygen-kommentar)
+
+**Symptom:** `build_last_phase_auto_cl()` afhænger af `qic.run()`'s `anyNA(x$cl)` → fallback til fase-median for NA-rækker. Kontrakten er beskrevet i en kode-kommentar, men der er INGEN test der ville fange en future qicharts2-opdatering der ændrer NA-håndteringen (fx kaster fejl, eller fallbacker til global median).
+
+**Verifikation:** Søg i tests/testthat/ for `anyNA\|NA-fallback\|qic_contract` → ingen matches.
+
+**Konsekvens:** Hvis qicharts2 v0.8.x ændrer kontrakten silently, vil `build_last_phase_auto_cl()` producere forkerte CL'er for tidligere faser uden test-suite-failure.
+
+**Foreslået fix:** Tilføj en kontrakt-test der konstruerer en simpel multi-phase `cl`-vektor med NA i fase 1 og konstant i fase 2, kalder `qicharts2::qic()` direkte, og asserterer:
+- Fase 1 returneret cl == median(y[fase 1])
+- Fase 2 returneret cl == den konstante værdi vi sendte ind
+
+```r
+test_that("qicharts2 NA-cl-fallback-contract (regression guard)", {
+  d <- data.frame(x = 1:20, y = c(rnorm(10, 5, 1), rep(10, 10)),
+                  cl_in = c(rep(NA_real_, 10), rep(99, 10)))
+  out <- qicharts2::qic(x, y, cl = cl_in, data = d, chart = "run",
+                       part = 10, return.data = TRUE)
+  expect_equal(unique(out$cl[out$part == 1])[1], median(d$y[1:10]),
+               tolerance = 1e-6)
+  expect_equal(unique(out$cl[out$part == 2])[1], 99, tolerance = 1e-6)
+})
+```
+
+**Anbefaling:** Tilføj test ved næste mulighed; ej blokerende for H1-fix.
+
+---
+
+## Bekræftet OK
+
+- Single-phase trigger (12/20 = 60 %) → ✅ swap'er korrekt til mean.
+- `freeze`-guard → ✅ skip'er som dokumenteret.
+- `cl`-user-supplied-guard → ✅ user wins.
+- `chart_type != "run"` (i, p, u, c, mr, t, xbar, s, g, pp, up) → ✅ ingen swap.
+- `agg.fun = "median"`/`"sum"` → ✅ swap virker efter post-aggregation.
+- `multiply` 0.1/100 → ✅ swap respekterer floating-point.
+- Counts/proportions med `n=` → ✅ swap virker.
+- Last-phase swap i multi-phase når last phase er den ramte → ✅ virker.
+- `cl_user_supplied` + `cl_auto_mean` mutually exclusive → ✅ invariant holder.
+- PDF-caveat i18n (da/en) → ✅ resolves.
+
+---
+
+## Konklusion (Phase 4 — post Codex-reconcile, 2026-05-16)
+
+Codex adversarial-review (verdict: needs-attention) bekræftede H1 + M1 og recalibrerede H2, OG fandt ny H3 jeg havde overset.
+
+**Verified empirisk i reconcile:**
+- **H1 [MEDIUM, confirmed]:** multi-phase tidligere-fase forbliver på median trods majority-on-CL. Reproduceret med phase1 = 12/18 tied → cl=1 retained, runs.signal=TRUE.
+- **H3 [MEDIUM, confirmed, Codex-found]:** `exclude=` ignoreres af både trigger-tæller og replacement-mean. Reproduceret: `cl = 21.4` (mean of all 20) i stedet for `1.75` (mean of 16 included).
+- **M1 [LOW, confirmed]:** qicharts2 NA-cl-fallback-kontrakt udokumenteret som test-invariant. Lav prioritet.
+
+**Recalibreret:**
+- **H2 [LOW]:** Codex korrekt om at exakte 50 %-real-world cases findes (even-count konstruktioner med median på obs-værdi). Mit oprindelige "real-world impossible" var for kategorisk. Test-fix skifter fra "skriv kommentar" til "erstat med real-data konstruktion".
+
+**Impact-bucketing:**
+- Hard runtime-saves: 0 (ingen crash-fixes)
+- Semantic/silent-corruption-saves: 2 (H1 = phase 1 viser degenererede signaler; H3 = excluded outliers forurener CL)
+- False-confidence/process-saves: 1 (M1 = contract-regression-guard)
+- Sub-optimal/cleanup: 1 (H2 = test-clarity)
+
+**Forhold til brugerrapport ("kan generere charts hvor median IKKE bliver ændret"):**
+- H1 forklarer multi-phase-tilfælde.
+- H3 forklarer single-phase med exclude-tilfælde (excluded rows kan trække ratio under 50 % og blokere trigger, ELLER trække ratio over 50 % og fyre trigger forkert).
+- Begge er reproducible match til den observerede adfærd.
+
+**Læring (cycle 02):** Codex's empirical-reproduction af exclude-bug viste igen, at cross-contract-claims ("qicharts2 respekterer include") kræver runtime-verification, ikke kun roxygen-kommentar-læsning. Self-review missede H3 fordi jeg fokuserede på "trigger correctness" (chart_type, freeze, cl-user-supplied) og ikke spurgte "hvilke andre data-filtre påvirker beregningen".
+
+**Næste skridt (afventer bruger-approval):**
+1. Fix H1 + H3 i samme PR — begge rører `detect_majority_at_median_lastphase()` + `build_last_phase_auto_cl()`.
+2. Tilføj regression-tests for begge.
+3. Tilføj M1 contract-test som separat lavprio-PR eller bundle med H1/H3.
+4. H2 docfix: erstat syntetisk threshold-test med real-data construction.
+5. NEWS-entry under v0.18.x: "Auto-mean centerline substitution now respects multi-phase and exclude= correctly."

--- a/inst/i18n/da.yaml
+++ b/inst/i18n/da.yaml
@@ -166,7 +166,7 @@ analysis:
       # Som stable_near_target men ustabil proces -- stabiliseringsfokus.
       short: "Niveauet er tæt på målet. Stabilisér processen."
       standard: "Målet er næsten nået, men processen er ustabil. Undersøg, hvad der påvirker den naturlige variation."
-      detailed: "Undersøg hvad der påvirker processen, og arbejd for at stabilisere den. Vurdér så om niveauet er tilfredsstillende."
+      detailed: "Undersøg, hvad der påvirker processen, og arbejd for at stabilisere den. Vurdér så, om niveauet er tilfredsstillende."
     unstable_goal_not_met:
       short: "Stabilisér processen først, og arbejd derefter mod målet."
       standard: "Identificér først årsager til variationen i data, og stabilisér processen - derefter kan målrettede forbedringstiltag iværksættes."

--- a/tests/testthat/test-cl-auto-mean.R
+++ b/tests/testthat/test-cl-auto-mean.R
@@ -1,43 +1,44 @@
-# Tests for auto-mean substitution in run charts when >=50% of last-phase
-# observations sit exactly on the median centerline.
+# Tests for auto-mean substitution in run charts when >=50% of a phase's
+# included observations sit exactly on the median centerline.
 #
 # Background: qicharts2 hardcodes median as centerline for run charts.
 # With discrete/coarse-reported data, Anhoej run/crossing analysis
 # degenerates when many points sit exactly on the CL. bfh_qic() detects
-# this condition in the last phase and auto-substitutes the centerline
-# with the mean for that phase. Earlier phases keep the median.
+# this condition per-phase and auto-substitutes the centerline with the
+# mean for any phase that triggers. Non-trigger phases keep the median.
 #
-# Detection scope: LAST phase only (mirrors filter_qic_to_last_phase()
-# convention used by bfh_build_analysis_context and bfh_extract_spc_stats).
+# Detection scope: per-phase (cycle 02 H1 fix). Earlier work scoped only
+# the last phase, which left earlier phases of multi-phase run charts on
+# degenerate median CLs.
 
-test_that("detect_majority_at_median_lastphase returns FALSE for non-run charts", {
+test_that("detect_majority_at_median_per_phase returns integer(0) for non-run charts", {
   qic_data <- data.frame(
     x = 1:10,
     y = c(rep(1, 6), 2, 3, 4, 5),
     cl = rep(1, 10)
   )
-  expect_false(BFHcharts:::detect_majority_at_median_lastphase(qic_data, "i"))
-  expect_false(BFHcharts:::detect_majority_at_median_lastphase(qic_data, "p"))
+  expect_length(BFHcharts:::detect_majority_at_median_per_phase(qic_data, "i"), 0L)
+  expect_length(BFHcharts:::detect_majority_at_median_per_phase(qic_data, "p"), 0L)
 })
 
-test_that("detect_majority_at_median_lastphase fires when >=50% on median", {
-  # 6 out of 10 on median (60%) -> trigger
+test_that("detect_majority_at_median_per_phase returns synthetic part 1 when >=50% on median (no part column)", {
+  # 6 of 10 on median (60%) -> trigger; no part column -> single synthetic phase 1
   qic_data <- data.frame(
     x = 1:10,
     y = c(rep(1, 6), 2, 3, 4, 5),
     cl = rep(1, 10)
   )
-  expect_true(BFHcharts:::detect_majority_at_median_lastphase(qic_data, "run"))
+  expect_equal(BFHcharts:::detect_majority_at_median_per_phase(qic_data, "run"), 1L)
 })
 
-test_that("detect_majority_at_median_lastphase respects threshold boundary", {
+test_that("detect_majority_at_median_per_phase respects threshold boundary", {
   # Exactly 50%: 5 of 10 on median -> trigger (>=, not >)
   qic_data_50 <- data.frame(
     x = 1:10,
     y = c(rep(1, 5), 2, 3, 4, 5, 6),
     cl = rep(1, 10)
   )
-  expect_true(BFHcharts:::detect_majority_at_median_lastphase(qic_data_50, "run"))
+  expect_equal(BFHcharts:::detect_majority_at_median_per_phase(qic_data_50, "run"), 1L)
 
   # 4 of 10 (40%) -> no trigger
   qic_data_40 <- data.frame(
@@ -45,33 +46,35 @@ test_that("detect_majority_at_median_lastphase respects threshold boundary", {
     y = c(rep(1, 4), 2, 3, 4, 5, 6, 7),
     cl = rep(1, 10)
   )
-  expect_false(BFHcharts:::detect_majority_at_median_lastphase(qic_data_40, "run"))
+  expect_length(
+    BFHcharts:::detect_majority_at_median_per_phase(qic_data_40, "run"), 0L
+  )
 })
 
-test_that("detect_majority_at_median_lastphase skips no_variation (constant y)", {
+test_that("detect_majority_at_median_per_phase skips no_variation (constant y)", {
   qic_data <- data.frame(
     x = 1:10,
     y = rep(5, 10),
     cl = rep(5, 10)
   )
-  expect_false(BFHcharts:::detect_majority_at_median_lastphase(qic_data, "run"))
+  expect_length(BFHcharts:::detect_majority_at_median_per_phase(qic_data, "run"), 0L)
 })
 
-test_that("detect_majority_at_median_lastphase filters to last phase only", {
-  # Phase 1: 10 continuous points; Phase 2: 10 points with 6 on median.
-  # Only phase 2 should trigger -> overall TRUE.
+test_that("detect_majority_at_median_per_phase returns only the last phase when only it triggers", {
+  # Phase 1: continuous; Phase 2: 6/10 on median. Only phase 2 should trigger.
+  set.seed(123)
   qic_data <- data.frame(
     x = 1:20,
     y = c(rnorm(10, 5, 2), rep(1, 6), 2, 3, 4, 5),
     cl = c(rep(5, 10), rep(1, 10)),
     part = c(rep(1, 10), rep(2, 10))
   )
-  expect_true(BFHcharts:::detect_majority_at_median_lastphase(qic_data, "run"))
+  expect_equal(BFHcharts:::detect_majority_at_median_per_phase(qic_data, "run"), 2L)
 })
 
-test_that("detect_majority_at_median_lastphase ignores prior-phase majority", {
-  # Phase 1 has 60% on median; Phase 2 continuous. Last-phase scope
-  # means we evaluate only phase 2 -> no trigger.
+test_that("detect_majority_at_median_per_phase fires for earlier phase (cycle 02 H1)", {
+  # Phase 1 has 60% on median; Phase 2 continuous. Per-phase scope picks
+  # phase 1 -- earlier behaviour (last-phase-only) wrongly returned FALSE.
   set.seed(42)
   qic_data <- data.frame(
     x = 1:20,
@@ -79,7 +82,34 @@ test_that("detect_majority_at_median_lastphase ignores prior-phase majority", {
     cl = c(rep(1, 10), rep(10, 10)),
     part = c(rep(1, 10), rep(2, 10))
   )
-  expect_false(BFHcharts:::detect_majority_at_median_lastphase(qic_data, "run"))
+  expect_equal(BFHcharts:::detect_majority_at_median_per_phase(qic_data, "run"), 1L)
+})
+
+test_that("detect_majority_at_median_per_phase returns both phases when both trigger", {
+  qic_data <- data.frame(
+    x = 1:20,
+    y = c(rep(1, 6), 2, 3, 4, 5, rep(7, 6), 8, 9, 10, 11),
+    cl = c(rep(1, 10), rep(7, 10)),
+    part = c(rep(1, 10), rep(2, 10))
+  )
+  expect_equal(
+    BFHcharts:::detect_majority_at_median_per_phase(qic_data, "run"), c(1L, 2L)
+  )
+})
+
+test_that("detect_majority_at_median_per_phase ignores excluded rows (cycle 02 H3)", {
+  # 4 included tied + 6 included non-tied (4/10 = 40%, no trigger)
+  # + 4 EXCLUDED rows tied to median. With include-respect, ratio stays
+  # 4/10 = 40%. Without include-respect, ratio would be 8/14 = 57%.
+  qic_data <- data.frame(
+    x = 1:14,
+    y = c(rep(1, 4), 2, 3, 4, 5, 6, 7, rep(1, 4)),
+    cl = rep(1, 14),
+    include = c(rep(TRUE, 10), rep(FALSE, 4))
+  )
+  expect_length(
+    BFHcharts:::detect_majority_at_median_per_phase(qic_data, "run"), 0L
+  )
 })
 
 test_that("bfh_qic auto-substitutes median to mean for discrete run-chart data", {
@@ -130,7 +160,7 @@ test_that("bfh_qic skips auto-sub when freeze is set", {
   expect_equal(result$qic_data$cl[1], 10)
 })
 
-test_that("bfh_qic auto-subs only the last phase in multi-phase charts", {
+test_that("bfh_qic auto-subs only the triggering phase (last) in multi-phase charts", {
   set.seed(42)
   # Phase 1: continuous (no auto-sub). Phase 2: 9/15 on median (60%).
   phase1 <- rnorm(15, 10, 2)
@@ -147,6 +177,68 @@ test_that("bfh_qic auto-subs only the last phase in multi-phase charts", {
   expect_length(cl_phase2, 1L)
   expect_equal(cl_phase1, median(phase1), tolerance = 1e-6)
   expect_equal(cl_phase2, mean(phase2), tolerance = 1e-6)
+})
+
+test_that("bfh_qic auto-subs an EARLIER phase when it triggers (cycle 02 H1)", {
+  set.seed(42)
+  # Phase 1: 12/18 tied at 1 (66% on median); Phase 2: continuous.
+  # Pre-fix: phase 1 retained median, cl_auto_mean=FALSE overall.
+  # Post-fix: phase 1 switches to mean, cl_auto_mean=TRUE.
+  phase1 <- c(rep(1, 12), 2, 2, 3, 3, 4, 4)
+  phase2 <- rnorm(15, 8, 2)
+  data <- data.frame(x = 1:33, y = c(phase1, phase2))
+
+  result <- bfh_qic(data, x = x, y = y, chart_type = "run", part = 18)
+  expect_true(isTRUE(attr(result$summary, "cl_auto_mean")))
+
+  cl_phase1 <- unique(result$qic_data$cl[result$qic_data$part == 1])
+  cl_phase2 <- unique(result$qic_data$cl[result$qic_data$part == 2])
+  expect_length(cl_phase1, 1L)
+  expect_length(cl_phase2, 1L)
+  expect_equal(cl_phase1, mean(phase1), tolerance = 1e-6)
+  expect_equal(cl_phase2, median(phase2), tolerance = 1e-6)
+})
+
+test_that("bfh_qic auto-subs BOTH phases when both trigger (cycle 02 H1)", {
+  phase1 <- c(rep(1, 12), 2, 2, 3, 3, 4, 4)
+  phase2 <- c(rep(5, 12), 6, 6, 7, 7, 8, 8)
+  data <- data.frame(x = 1:36, y = c(phase1, phase2))
+
+  result <- bfh_qic(data, x = x, y = y, chart_type = "run", part = 18)
+  expect_true(isTRUE(attr(result$summary, "cl_auto_mean")))
+
+  cl_phase1 <- unique(result$qic_data$cl[result$qic_data$part == 1])
+  cl_phase2 <- unique(result$qic_data$cl[result$qic_data$part == 2])
+  expect_equal(cl_phase1, mean(phase1), tolerance = 1e-6)
+  expect_equal(cl_phase2, mean(phase2), tolerance = 1e-6)
+})
+
+test_that("bfh_qic respects exclude= when computing replacement mean (cycle 02 H3)", {
+  # 10 included tied at 1 + 6 included non-tied + 4 EXCLUDED extreme outliers.
+  # Pre-fix: replacement mean = mean(all 20) = 21.4 (extreme outliers leak in).
+  # Post-fix: replacement mean = mean(included 16) = 1.75 (outliers ignored).
+  d <- data.frame(
+    x = 1:20,
+    y = c(rep(1, 10), 2, 2, 3, 3, 4, 4, 100, 100, 100, 100)
+  )
+  result <- bfh_qic(d, x = x, y = y, chart_type = "run", exclude = 17:20)
+  expect_true(isTRUE(attr(result$summary, "cl_auto_mean")))
+  expected_mean <- mean(c(rep(1, 10), 2, 2, 3, 3, 4, 4))
+  # qic_data$cl is constant for the phase; pick first INCLUDED row.
+  cl_first_included <- result$qic_data$cl[result$qic_data$include][1]
+  expect_equal(cl_first_included, expected_mean, tolerance = 1e-6)
+})
+
+test_that("bfh_qic ignores excluded rows when evaluating trigger ratio (cycle 02 H3)", {
+  # 4 included tied + 6 included non-tied (4/10 = 40%, below threshold).
+  # + 4 EXCLUDED rows that ARE tied. Without include-respect, ratio
+  # would be 8/14 = 57% and wrongly fire. Post-fix: stays 40%, no fire.
+  d <- data.frame(
+    x = 1:14,
+    y = c(rep(1, 4), 2, 3, 4, 5, 6, 7, rep(1, 4))
+  )
+  result <- bfh_qic(d, x = x, y = y, chart_type = "run", exclude = 11:14)
+  expect_false(isTRUE(attr(result$summary, "cl_auto_mean")))
 })
 
 test_that("cl_user_supplied and cl_auto_mean are mutually exclusive", {


### PR DESCRIPTION
## Summary

Cycle 02 dual-review (Claude+Codex, 2026-05-16). Bruger rapporterede at auto-mean swap fra PR #371 sommetider IKKE fyrede som forventet. Empirisk reproduktion bekraeftede TO distinkte bugs:

- **H1 (multi-phase)**: `detect_majority_at_median_lastphase()` scopede til `max(part)`. Multi-phase run charts hvor tidligere fase var tied til sin fase-median beholdt median-CL der + producerede degenererede Anhoej-tællinger. `cl_auto_mean`-attr forblev FALSE → intet PDF-caveat.
- **H3 (exclude-bug, Codex-found)**: baade trigger-tæller OG replacement-mean ignorerede `qic_data$include`. Rækker excluded via `exclude=` leakede ind i begge → forkert ny CL.

## Fix

- `detect_majority_at_median_lastphase()` → `detect_majority_at_median_per_phase()` returnerer integer-vektor af trigger-fase-IDs. Per-fase iteration + `include`-mask.
- `build_last_phase_auto_cl()` → `build_auto_cl_for_phases(trigger_phases)` substituerer pr. trigger-fase med fase-mean over included rows only.
- `bfh_qic.R` caller propagerer vektoren til `cl=` retry-kald.

qicharts2-kontrakt bevaret: pr. trigger-fase er cl-vektoren konstant så `qic.agg()` kollapser korrekt; non-trigger faser beholder cl=NA så `qic.run()`'s anyNA-fallback substituerer fase-median som før.

## Empirisk verifikation (post-fix)

```r
# H1
phase1 <- c(rep(1, 12), 2, 2, 3, 3, 4, 4)
phase2 <- rnorm(15, 8, 2)
bfh_qic(data.frame(x=1:33, y=c(phase1,phase2)), x=x, y=y, chart_type="run", part=18, return.data=TRUE)
# Pre-fix: phase1 cl=1 (median), 12/18 obs tied, auto_mean=FALSE
# Post-fix: phase1 cl=1.667 (mean), 0/18 tied, auto_mean=TRUE

# H3
bfh_qic(data.frame(x=1:20, y=c(rep(1,10), 2,2,3,3,4,4, 100,100,100,100)),
        x=x, y=y, chart_type="run", exclude=17:20, return.data=TRUE)
# Pre-fix: cl=21.4 (mean of all 20)
# Post-fix: cl=1.75 (mean of 16 included)
```

## Tests

- `tests/testthat/test-cl-auto-mean.R`: 53 tests, 0 fail
- Updated detect_* tests til ny vector-return API
- Nye regression-tests: earlier-phase trigger (H1), both-phases-trigger, exclude i detection (H3), exclude i replacement mean (H3)
- Existing single-phase / freeze / cl-user-supplied / mutual-exclusivity invariants uændrede
- Full suite: 5108 pass, 0 fail (via pre-push hook)

## Refs

- Review-doc: `docs/reviews/02-cl-auto-mean-validation-2026-05-16.md`
- Original feature: PR #371 (auto-mean v0.18.0)
- Codex adversarial-review: `/tmp/codex-cycle-02.txt`

## Test plan

- [x] Empirisk reproduktion af H1 + H3 pre-fix
- [x] Empirisk verifikation af H1 + H3 post-fix
- [x] Full test suite pass via pre-push hook
- [ ] Manuel review af `docs/reviews/02-cl-auto-mean-validation-2026-05-16.md`
- [ ] Smoke check: multi-phase run chart fra biSPCharts (downstream) renderer korrekt