### PR TITLE
fix(i18n): shorten cl_auto_mean caveat

### DIFF
--- a/inst/i18n/da.yaml
+++ b/inst/i18n/da.yaml
@@ -223,4 +223,4 @@ labels:
     cl_user_supplied: >-
       Midtlinje fastsat manuelt — Anhøj-signal beregnet mod denne, ikke data-estimeret middelværdi.
     cl_auto_mean: >-
-      Niveaulinjen er skiftet til gennemsnit, fordi mindst halvdelen af observationerne i seneste fase lå præcis på medianen. Anhøj-analysen er beregnet mod gennemsnittet for at undgå falske negative signaler ved diskrete data.
+      Niveaulinjen er skiftet til gennemsnit, fordi mindst halvdelen af observationerne i seneste fase lå præcis på medianen.

--- a/inst/i18n/en.yaml
+++ b/inst/i18n/en.yaml
@@ -196,4 +196,4 @@ labels:
     cl_user_supplied: >-
       Centerline manually specified — Anhøj signal computed against the user-supplied centerline, not the data-estimated process mean.
     cl_auto_mean: >-
-      Centerline switched to mean because at least half of the observations in the last phase fell exactly on the median. The Anhøj analysis is computed against the mean to avoid false-negative signals from discrete data.
+      Centerline switched to mean because at least half of the observations in the last phase fell exactly on the median.


### PR DESCRIPTION
## Summary
- Fjerner anden sætning af cl_auto_mean-caveat ("Anhøj-analysen er beregnet
  mod gennemsnittet for at undgå falske negative signaler ved diskrete data")
- Trigger-betingelsen (>=50% på medianen) er det handlingsanvisende; selve
  implementations-rationalet hører til i kodekommentarer, ikke i PDF-tekst
- Parallel ændring i da.yaml + en.yaml

## Test plan
- [ ] Manuel inspektion: generér en SPC-PDF for et datasæt der trigger
      cl_auto_mean (≥50% af obs præcis på medianen) — verificér at caveat
      stadig forklarer triggerbetingelsen
- [ ] `devtools::test()` — ingen test refererer den fjernede sætning, men
      bekræft at intet uventet brækker