### PR TITLE
fix(i18n): revert cl_auto_mean to short variant

### DIFF
--- a/inst/i18n/da.yaml
+++ b/inst/i18n/da.yaml
@@ -311,7 +311,7 @@ labels:
     cl_user_supplied: >-
       Midtlinje fastsat manuelt — Anhøj-signal beregnet mod denne, ikke data-estimeret middelværdi.
     cl_auto_mean: >-
-      Niveaulinjen er skiftet til gennemsnit, fordi mindst halvdelen af observationerne i seneste fase lå præcis på medianen — Anhøj-analysen er beregnet mod gennemsnittet for at undgå falske signaler.
+      Niveaulinjen er skiftet til gennemsnit, fordi mindst halvdelen af observationerne i seneste fase lå præcis på medianen.
     # Slice 14 INCLUDE: discrete-scale mild/moderate tail-caveats.
     # extreme tier haandteres via stability.majority_at_centerline-template.
     discrete_scale_mild: >-


### PR DESCRIPTION
## Summary

Bruger-override af cycle 07 reviewer finding #3 (rationale-genindfoersel) efter end-to-end test via BFHddl-pipeline.

Kort variant matcher develop's PR #379-fix og vurderes klinisk tilstraekkelig:

> Niveaulinjen er skiftet til gennemsnit, fordi mindst halvdelen af observationerne i seneste fase laa praecis paa medianen.

EN-locale beholder fuld variant for symmetri med eksisterende detail-level i andre engelske templates.

## Context

Cycle 07 reviewer #3 anbefalede genindfoersel af Anhoej-rationale ('-- Anhoej-analysen er beregnet mod gennemsnittet for at undgaa falske signaler'). Bruger testede via BFHddl + reel klinisk data og vurderede at den korte variant er tilstraekkelig.

## Test plan

- [x] Affected tests passerer (i18n + golden_corpus + spc_render: 156 pass)
- [x] Pre-push hook OK (215s, mode=full, 5481 pass / 0 fail)
- [x] User-verificeret via BFHddl integration-test