### PR TITLE
fix(plot): connect data line across NA-y within same part

### DIFF
--- a/R/plot_core.R
+++ b/R/plot_core.R
@@ -202,6 +202,9 @@ bfh_spc_plot <- function(qic_data,
   # Core data visualization layers ----
   plot_layers <- c(plot_layers, list(
     ggplot2::geom_line(
+      # Drop NA-y rows so the line connects across missing observations
+      # within the same part; part boundaries still break the line via group.
+      data = function(d) d[!is.na(d$y), ],
       ggplot2::aes(y = y, group = part),
       colour = cols$grey,
       linewidth = data_linewidth,

--- a/tests/testthat/test-plot_core.R
+++ b/tests/testthat/test-plot_core.R
@@ -322,6 +322,62 @@ test_that("bfh_spc_plot() renders 3 phases correctly", {
   expect_equal(length(unique(result$data$part)), 3)
 })
 
+# Helper: locate the grey data-line layer (mapping y = y, not cl/ucl/lcl/target)
+locate_data_line_layer <- function(plot_obj) {
+  is_data_line <- vapply(plot_obj$layers, function(l) {
+    if (!inherits(l$geom, "GeomLine")) {
+      return(FALSE)
+    }
+    y_mapping <- l$mapping$y
+    if (is.null(y_mapping)) {
+      return(FALSE)
+    }
+    identical(rlang::as_label(y_mapping), "y")
+  }, logical(1))
+  idx <- which(is_data_line)
+  if (length(idx) == 0) NA_integer_ else idx[1]
+}
+
+test_that("bfh_spc_plot() connects data line across NA-y within same part", {
+  qic_data <- fixture_plot_qic_data(n = 6)
+  qic_data$y[3] <- NA_real_
+
+  config <- spc_plot_config(chart_type = "i", y_axis_unit = "count")
+  viewport <- viewport_dims(base_size = 14)
+
+  result <- bfh_spc_plot(qic_data, config, viewport)
+  built <- ggplot2::ggplot_build(result)
+
+  layer_idx <- locate_data_line_layer(result)
+  expect_false(is.na(layer_idx))
+
+  # The data-line layer must drop the NA-y row so the line connects across
+  # the gap. Otherwise ggplot2 splits the line at every NA.
+  layer_built <- built$data[[layer_idx]]
+  expect_true(all(!is.na(layer_built$y)))
+  expect_equal(nrow(layer_built), 5L)
+})
+
+test_that("bfh_spc_plot() preserves part-boundary break in data line", {
+  parts <- c(rep(1L, 3), rep(2L, 3))
+  qic_data <- fixture_plot_qic_data(n = 6, parts = parts)
+
+  config <- spc_plot_config(chart_type = "i", y_axis_unit = "count")
+  viewport <- viewport_dims(base_size = 14)
+
+  result <- bfh_spc_plot(qic_data, config, viewport)
+  built <- ggplot2::ggplot_build(result)
+
+  layer_idx <- locate_data_line_layer(result)
+  expect_false(is.na(layer_idx))
+
+  # group = part keeps each phase as its own line segment; ggplot2 renders
+  # a visual break between groups.
+  layer_built <- built$data[[layer_idx]]
+  expect_true("group" %in% names(layer_built))
+  expect_equal(length(unique(layer_built$group)), 2L)
+})
+
 # ============================================================================
 # 9. CHART TITLE AND LABELS
 # ============================================================================


### PR DESCRIPTION
## Summary

- Grey data line in `bfh_spc_plot()` previously broke at every NA-y row because `geom_line(na.rm = TRUE)` only suppresses warnings, not the line break.
- Filter NA-y rows for the data-line layer only via per-layer `data = function(d) d[!is.na(d$y), ]`. Points + CL + UCL/LCL layers unchanged.
- `group = part` retained so phase boundaries still break the line (intended).

Triggered by HOFTER 15 SPC chart in BFHdata where a missing month produced a visible gap.

## Test plan

- [x] New regression test: data line connects across NA-y within same part
- [x] New regression test: part boundary still breaks data line
- [x] Full test suite: 5487 pass / 0 fail / 0 err / 69 skip (font-skip on CI)
- [x] Manual verification: 10-point input with 2 NAs → line layer has 8 rows, no NA-y
- [ ] Re-render HOFTER 15 PDF in BFHdata ddl pipeline to visually confirm gap is closed