### PR TITLE
chore(adr): consolidate ADR location + renumber structured-spc to ADR-004

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,6 +288,25 @@ devtools::build_vignettes() # Build vignettes
 
 **See:** `openspec/AGENTS.md` for detailed workflow instructions
 
+### /end-Skill R-Package Adaptation
+
+Generisk `/end`-skill (`~/.claude/skills/end/`) antager web/app-konventioner.
+For dette R-package gælder følgende override-mapping:
+
+| Generisk skill-punkt | R-package-ækvivalent |
+|----------------------|----------------------|
+| `docs/changelog.md` | `NEWS.md` (CRAN-standard) |
+| `docs/decisions.md` | `inst/adr/ADR-NNN-*.md` (canonical ADR-location) |
+| CLAUDE.md Phase status | Ej anvendt — R-package er semver-driven |
+
+**Konsekvens for `/end`-run:** skip ovenstående tre punkter uden yderligere
+diskussion. Opdatér kun `NEWS.md` ved adfærdsændrende code-merge; ADR
+oprettes per arkitektur-beslutning (ikke per session).
+
+**Canonical ADR-location:** `inst/adr/` (ships med installed package; ADR'er
+tilgængelige via `system.file("adr", ..., package = "BFHcharts")`). `docs/adr/`
+deprecated efter consolidation 2026-05-26.
+
 ---
 
 ## 6) Domain-Specific Guidance

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## Nye features
 
 * **Struktureret SPC-analyse via `bfh_analyse()` + `bfh_render_analysis()`**
-  (ADR-003). Tre-lags arkitektur erstatter monolitisk
+  (ADR-004). Tre-lags arkitektur erstatter monolitisk
   `build_fallback_analysis()`-cascade:
 
   - `bfh_extract_spc_features(x, metadata)` — pure deterministisk
@@ -197,7 +197,7 @@ identificerede 4 fund:
 
 ## Refs
 
-* ADR-003: `docs/adr/ADR-003-structured-spc-analysis-architecture.md`
+* ADR-004: `inst/adr/ADR-004-structured-spc-analysis-architecture.md`
 * Openspec change (archived): `openspec/changes/archive/2026-05-18-
   restructure-spc-analysis-architecture/`
 * Dual-review-cycle 03: `docs/reviews/03-structured-spc-analysis-

--- a/docs/MIGRATION_STRUCTURED_ANALYSIS.md
+++ b/docs/MIGRATION_STRUCTURED_ANALYSIS.md
@@ -7,7 +7,7 @@
 Eksisterende kald fortsætter med at virke. Migration er opt-in når
 struktureret analyse-objekt giver mervaerdi.
 
-**Refs:** ADR-003, openspec change `restructure-spc-analysis-architecture`.
+**Refs:** ADR-004, openspec change `restructure-spc-analysis-architecture`.
 
 ---
 
@@ -276,7 +276,7 @@ Følgende er **markeret deprecated**:
 
 ## Reference
 
-- ADR-003: `docs/adr/ADR-003-structured-spc-analysis-architecture.md`
+- ADR-004: `inst/adr/ADR-004-structured-spc-analysis-architecture.md`
 - NEWS.md 0.20.0: full slice-liste + breaking-detaljer
 - Tests:
   - `tests/testthat/test-spc_compose.R` — bfh_analyse-API

--- a/inst/adr/ADR-004-structured-spc-analysis-architecture.md
+++ b/inst/adr/ADR-004-structured-spc-analysis-architecture.md
@@ -1,4 +1,4 @@
-# ADR-003: Structured SPC Analysis Architecture
+# ADR-004: Structured SPC Analysis Architecture
 
 Status: Accepted (per openspec change `restructure-spc-analysis-architecture`, archived 2026-05-18)
 

--- a/tests/testthat/test-summary-anhoej-consistency.R
+++ b/tests/testthat/test-summary-anhoej-consistency.R
@@ -3,7 +3,7 @@
 # ============================================================================
 #
 # Spec: openspec/changes/2026-05-01-verify-anhoej-summary-vs-qic-data-consistency
-# ADR:  docs/adr/ADR-002-anhoej-summary-source.md
+# ADR:  inst/adr/ADR-002-anhoej-summary-source.md
 #
 # Kerne-krav (spec.md):
 #   summary$laengste_loeb[i] == max(qic_data$longest.run[part == i], na.rm = TRUE)


### PR DESCRIPTION
## Summary
- Resolve ADR-numbering-collision discovered during `/end`-skill review (#389 follow-up)
- Delete stale `docs/adr/ADR-002-anhoej-summary-source.md` (was 49-line subset; canonical `inst/adr/ADR-002` contains 2026-05-03 addendum)
- Rename `docs/adr/ADR-003-structured-spc-analysis-architecture.md` → `inst/adr/ADR-004-...` (avoids clash with `inst/adr/ADR-003-warning-blind-clinical-readers`)
- Cross-references updated: `NEWS.md`, `docs/MIGRATION_STRUCTURED_ANALYSIS.md`, `test-summary-anhoej-consistency.R` header
- `CLAUDE.md` gains `/end`-skill R-package override-mapping (NEWS.md = changelog, inst/adr/ = decisions, no phases)

## Why
Two separate ADR-003s existed at same number (`docs/adr/` had "Structured SPC Analysis Architecture", `inst/adr/` had "Warning-Blind Clinical Readers"). Generic `/end`-skill expected web/app conventions (`docs/changelog.md`, `docs/decisions.md`, phase-roadmap) which don't apply to R-package — documented mapping in CLAUDE.md to prevent future confusion.

Canonical ADR-location is now `inst/adr/` (ships with installed package; downstream access via `system.file("adr", ..., package = "BFHcharts")`).

## Test plan
- [x] Pre-push test-suite: 5501 pass, 0 fail, 70 skip
- [x] Verify no broken `docs/adr/` references (grep clean except `openspec/changes/` archive)
- [x] No R-source changes — `R-CMD-check` impact bounded to `inst/` reorganisation
- [ ] CI green (R-CMD-check ubuntu+windows, lint, pdf-smoke, test-coverage)

## Refs
- Follow-up to PR #389 (topology-sync) discovery
- Original `/end`-checklist skipped items investigation