### PR TITLE
chore(deps): bump BFHtheme to >= 0.5.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ BugReports: https://github.com/johanreventlow/BFHcharts/issues
 Depends:
     R (>= 4.1.0)
 Imports:
-    BFHtheme (>= 0.5.0),
+    BFHtheme (>= 0.5.1),
     ggplot2 (>= 3.4.0),
     qicharts2 (>= 0.7.0),
     scales (>= 1.2.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# BFHcharts (development)
+
+## Dependency bumps
+
+* `BFHtheme (>= 0.5.1)` — kraever font-detection-fix hvor
+  `BFHtheme::font_available()` konsulterer baade `system_fonts()` og
+  `registry_fonts()`. Uden bumpet ville downstream konsumenter (fx
+  biSPCharts) der registrerer Mari via `systemfonts::register_font()` i
+  runtime fortsat se "Mari ikke fundet" og fallback til Roboto/sans paa
+  deploy-targets uden OS-installeret Mari (Posit Connect Cloud).
+
 # BFHcharts 0.20.0
 
 ## Nye features


### PR DESCRIPTION
## Summary

Cross-repo lower-bound bump efter BFHtheme v0.5.1 release.

- `DESCRIPTION`: `BFHtheme (>= 0.5.0)` -> `BFHtheme (>= 0.5.1)`
- `NEWS.md`: development-entry under Dependency bumps

## Why

BFHtheme 0.5.1 fixer `font_available()` til at konsultere baade `system_fonts()` og `registry_fonts()`. Uden bumpet ville downstream konsumenter (biSPCharts) der registrerer Mari via `systemfonts::register_font()` i runtime fortsat se "Mari ikke fundet" og fallback til Roboto paa Posit Connect Cloud.

Cross-repo bump-protokol § E (~/.claude/rules/VERSIONING_POLICY.md).

## Refs

- BFHtheme PR #73 (font_available registry-fix)
- BFHtheme tag v0.5.1
- biSPCharts PR #807 (cache-clear + ragg) — downstream der drager fordel af denne bump

## Test plan

- [x] Pre-push hook bestaaet (BFHtheme 0.5.1 verificeret lokalt)
- [ ] CI gron