### PR TITLE
fix(x-axis): step-based label thinning eliminates gap-of-3 bug (#396)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BFHcharts
 Title: SPC Visualization for Healthcare Quality Improvement
-Version: 0.21.0
+Version: 0.22.0
 Authors@R: c(
     person(
       "Johan", "Reventlow",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,37 @@
+# BFHcharts 0.22.0
+
+## Breaking changes
+
+* **`bfh_subsample_label_indices()` returnerer faerre indices for moderate n.**
+  Algoritmen skifter fra `round(seq(1, n, length.out = max_visible))` til
+  deterministisk step-baseret thinning med force-last anchor. Konsekvens:
+
+  | n   | foer (0.21.0)                            | nu (0.22.0)                              |
+  |-----|------------------------------------------|------------------------------------------|
+  |  24 | 12 indices, gap 11->14 (skjulte 12+13)   |  9 indices, konstant step=3              |
+  |  36 | 12 indices                               | 10 indices, konstant step=4              |
+  |  52 | 12 indices                               | 12 indices, konstant step=5              |
+  | 100 | 12 indices                               | 12 indices, konstant step=9              |
+
+  Downstream consumers (biSPCharts) der renderer x-akse-labels via helperen
+  faar sparser men deterministisk label-distribution uden gap-of-3 anti-
+  pattern. API-signatur uaendret.
+
+## Bug fixes
+
+* **(#396) Strukturel gap-bug i `bfh_subsample_label_indices()` for n=24.**
+  `round(seq.int(1L, n, length.out = max_visible))` producerede ikke-heltals
+  positioner som snappede asymmetrisk via R's banker's rounding. For
+  n=24/max=12 gav det indices `1 3 5 7 9 11 14 16 18 20 22 24` -- gap 11->14
+  skjulte to konsekutive labels (12+13) midt i serien. I biSPCharts SPC-
+  eksport ramte dette aarsskifte-labels (dec 25 + jan 26) ved 2-aars
+  maaneds-serier.
+
+  Fix: deterministisk integer step
+  `ceiling((n_labels - 1) / (max_visible - 1))` + force-last anchor
+  garanterer konstant interval i "showing" pattern -- aldrig to konsekutive
+  skjulte labels.
+
 # BFHcharts 0.21.0
 
 ## Nye features

--- a/R/utils_x_axis_formatting.R
+++ b/R/utils_x_axis_formatting.R
@@ -288,21 +288,26 @@ BFH_MAX_X_LABELS_TEXT <- 12L
 
 #' Subsample Text X-Axis Label Indices
 #'
-#' Returns evenly-spaced indices for selecting which categorical x-axis labels
-#' to display on a chart. First and last indices are always included as anchors;
-#' intermediate indices are chosen via `round(seq(1, n, length.out = max_visible))`.
-#' Designed for tekst-x-data (month names, weekdays, observation IDs) where
-#' showing all labels would overlap or require rotation.
+#' Returns deterministic, evenly-spaced indices for selecting which categorical
+#' x-axis labels to display on a chart. First index is always 1; last index is
+#' always `n_labels` (force-last anchor). Intermediate indices follow integer
+#' step `ceiling((n_labels - 1) / (max_visible - 1))`, which guarantees no two
+#' consecutive label positions are skipped in the "showing" pattern. Designed
+#' for tekst-x-data (month names, weekdays, observation IDs) where showing all
+#' labels would overlap or require rotation.
 #'
 #' Algorithm scales smoothly: for n <= max_visible all indices returned;
-#' otherwise progressively thinning preserves a near-constant label-density.
+#' otherwise step-based thinning preserves a near-constant label-density and
+#' avoids the asymmetric-rounding gap-bug that
+#' `round(seq(..., length.out))` produces for moderate n (issue #396).
 #'
 #' @param n_labels Integer. Total number of labels available.
 #' @param max_visible Integer. Maximum number of labels to display.
 #'   Default [BFH_MAX_X_LABELS_TEXT] (currently 12).
 #'
 #' @return Integer vector of indices into the label sequence. Always includes
-#'   1 and `n_labels` (anchors). Length <= `max_visible`.
+#'   1 and `n_labels` (anchors). Length <= `max_visible` (may be lower when
+#'   step-thinning produces fewer evenly-spaced anchors).
 #'
 #' @export
 #'
@@ -311,13 +316,17 @@ BFH_MAX_X_LABELS_TEXT <- 12L
 #' bfh_subsample_label_indices(12)
 #' # [1] 1 2 3 4 5 6 7 8 9 10 11 12
 #'
-#' # 52 weeks thinned to ~12 evenly-spaced
+#' # 24 months: step=3, force-last anchor -> 9 labels (no gap-of-3)
+#' bfh_subsample_label_indices(24)
+#' # [1]  1  4  7 10 13 16 19 22 24
+#'
+#' # 52 weeks thinned to <=12 evenly-spaced
 #' bfh_subsample_label_indices(52)
-#' # [1]  1  5 10 15 20 25 30 36 41 46 51 52
+#' # [1]  1  6 11 16 21 26 31 36 41 46 51 52
 #'
 #' # Custom max
 #' bfh_subsample_label_indices(24, max_visible = 6)
-#' # [1]  1  6 11 15 20 24
+#' # [1]  1  6 11 16 21 24
 bfh_subsample_label_indices <- function(n_labels, max_visible = BFH_MAX_X_LABELS_TEXT) {
   if (!is.numeric(n_labels) || length(n_labels) != 1L || is.na(n_labels) ||
     n_labels < 1) {
@@ -332,5 +341,15 @@ bfh_subsample_label_indices <- function(n_labels, max_visible = BFH_MAX_X_LABELS
   if (n_labels <= max_visible) {
     return(seq_len(n_labels))
   }
-  unique(as.integer(round(seq.int(1L, n_labels, length.out = max_visible))))
+  if (max_visible == 1L) {
+    return(1L)
+  }
+  # Deterministic step: ceiling((n - 1) / (max - 1)) >= 1 keeps idx count
+  # within max_visible slots when force-last anchor is appended.
+  step <- as.integer(ceiling((n_labels - 1L) / (max_visible - 1L)))
+  idx <- seq.int(1L, n_labels, by = step)
+  if (idx[length(idx)] != n_labels) {
+    idx <- c(idx, n_labels)
+  }
+  idx
 }

--- a/man/bfh_subsample_label_indices.Rd
+++ b/man/bfh_subsample_label_indices.Rd
@@ -14,29 +14,38 @@ Default \link{BFH_MAX_X_LABELS_TEXT} (currently 12).}
 }
 \value{
 Integer vector of indices into the label sequence. Always includes
-1 and \code{n_labels} (anchors). Length <= \code{max_visible}.
+1 and \code{n_labels} (anchors). Length <= \code{max_visible} (may be lower when
+step-thinning produces fewer evenly-spaced anchors).
 }
 \description{
-Returns evenly-spaced indices for selecting which categorical x-axis labels
-to display on a chart. First and last indices are always included as anchors;
-intermediate indices are chosen via \code{round(seq(1, n, length.out = max_visible))}.
-Designed for tekst-x-data (month names, weekdays, observation IDs) where
-showing all labels would overlap or require rotation.
+Returns deterministic, evenly-spaced indices for selecting which categorical
+x-axis labels to display on a chart. First index is always 1; last index is
+always \code{n_labels} (force-last anchor). Intermediate indices follow integer
+step \code{ceiling((n_labels - 1) / (max_visible - 1))}, which guarantees no two
+consecutive label positions are skipped in the "showing" pattern. Designed
+for tekst-x-data (month names, weekdays, observation IDs) where showing all
+labels would overlap or require rotation.
 }
 \details{
 Algorithm scales smoothly: for n <= max_visible all indices returned;
-otherwise progressively thinning preserves a near-constant label-density.
+otherwise step-based thinning preserves a near-constant label-density and
+avoids the asymmetric-rounding gap-bug that
+\code{round(seq(..., length.out))} produces for moderate n (issue #396).
 }
 \examples{
 # All 12 months visible when n <= max
 bfh_subsample_label_indices(12)
 # [1] 1 2 3 4 5 6 7 8 9 10 11 12
 
-# 52 weeks thinned to ~12 evenly-spaced
+# 24 months: step=3, force-last anchor -> 9 labels (no gap-of-3)
+bfh_subsample_label_indices(24)
+# [1]  1  4  7 10 13 16 19 22 24
+
+# 52 weeks thinned to <=12 evenly-spaced
 bfh_subsample_label_indices(52)
-# [1]  1  5 10 15 20 25 30 36 41 46 51 52
+# [1]  1  6 11 16 21 26 31 36 41 46 51 52
 
 # Custom max
 bfh_subsample_label_indices(24, max_visible = 6)
-# [1]  1  6 11 15 20 24
+# [1]  1  6 11 16 21 24
 }

--- a/tests/testthat/test-generate_details.R
+++ b/tests/testthat/test-generate_details.R
@@ -351,12 +351,76 @@ test_that("bfh_subsample_label_indices: custom max_visible respekteres", {
   expect_equal(res[length(res)], 24L)
 })
 
-test_that("bfh_subsample_label_indices: progressive thinning bevarer near-konstant density", {
-  # Density-test: foerste 12 indices skal danne en jaevn fordeling
+test_that("bfh_subsample_label_indices: step-based thinning er konstant intervallet (n=100)", {
+  # n=100, max=12 -> step=9, alle diffs = 9 (force-last anchor 91 -> 100 ogsaa 9)
   res_100 <- bfh_subsample_label_indices(100)
   diffs <- diff(res_100)
-  # Skal vaere approx jaevn (max diff - min diff <= 1 ved round-jitter)
-  expect_lte(max(diffs) - min(diffs), 1L)
+  expect_equal(max(diffs) - min(diffs), 0L)
+  expect_true(all(diffs >= 1L))
+})
+
+test_that("bfh_subsample_label_indices: exact indices for n=24 fjerner gap-of-3 (#396)", {
+  # Bug-repro: round(seq(1, 24, length.out=12)) producerede gap 11->14 (skjulte
+  # 12+13). Step-baseret approach giver konstant step=3 + force-last anchor.
+  res <- bfh_subsample_label_indices(24)
+  expect_equal(res, c(1L, 4L, 7L, 10L, 13L, 16L, 19L, 22L, 24L))
+})
+
+test_that("bfh_subsample_label_indices: exact indices for n=36/52/100 (regression)", {
+  expect_equal(
+    bfh_subsample_label_indices(36),
+    c(1L, 5L, 9L, 13L, 17L, 21L, 25L, 29L, 33L, 36L)
+  )
+  expect_equal(
+    bfh_subsample_label_indices(52),
+    c(1L, 6L, 11L, 16L, 21L, 26L, 31L, 36L, 41L, 46L, 51L, 52L)
+  )
+  expect_equal(
+    bfh_subsample_label_indices(100),
+    c(1L, 10L, 19L, 28L, 37L, 46L, 55L, 64L, 73L, 82L, 91L, 100L)
+  )
+})
+
+test_that("bfh_subsample_label_indices: ingen 2-konsekutive-skjulte i 'showing' pattern", {
+  # Invariant for issue #396: maks gap mellem on-hinanden foelgende synlige
+  # indices <= step+1 (force-last anchor kan tilfoeje en kortere gap, aldrig
+  # laengere). Det udelukker scenariet hvor to nabo-labels begge skjules midt
+  # i serien.
+  for (n in c(13L, 15L, 20L, 24L, 30L, 36L, 48L, 52L, 75L, 100L, 250L)) {
+    res <- bfh_subsample_label_indices(n)
+    diffs <- diff(res)
+    step <- as.integer(ceiling((n - 1L) / 11L))
+    expect_lte(max(diffs), step,
+      label = paste0("max gap for n=", n)
+    )
+  }
+})
+
+test_that("bfh_subsample_label_indices: max_visible=1 returnerer kun foerste anchor", {
+  expect_equal(bfh_subsample_label_indices(10, max_visible = 1L), 1L)
+  expect_equal(bfh_subsample_label_indices(100, max_visible = 1L), 1L)
+})
+
+test_that("bfh_subsample_label_indices: max_visible=2 returnerer kun anchors", {
+  expect_equal(bfh_subsample_label_indices(24, max_visible = 2L), c(1L, 24L))
+  expect_equal(bfh_subsample_label_indices(100, max_visible = 2L), c(1L, 100L))
+})
+
+test_that("bfh_subsample_label_indices: custom max_visible=6 for n=24", {
+  expect_equal(
+    bfh_subsample_label_indices(24, max_visible = 6L),
+    c(1L, 6L, 11L, 16L, 21L, 24L)
+  )
+})
+
+test_that("bfh_subsample_label_indices: length aldrig overstiger max_visible", {
+  # Force-last anchor maa ej overskride cap. Verificer for raekke n-vaerdier.
+  for (n in c(13L, 24L, 36L, 52L, 100L, 200L, 365L)) {
+    res <- bfh_subsample_label_indices(n)
+    expect_lte(length(res), 12L,
+      label = paste0("length cap for n=", n)
+    )
+  }
 })
 
 test_that("bfh_subsample_label_indices: invalid input kaster fejl", {


### PR DESCRIPTION
## Summary

- Fixer strukturel gap-bug i `bfh_subsample_label_indices()` der skjulte to konsekutive labels midt i serien for n=24 (issue #396).
- Erstatter `round(seq.int(..., length.out = max_visible))` med deterministisk integer step `ceiling((n - 1) / (max_visible - 1))` + force-last anchor.
- Bumper version til 0.22.0 (pre-1.0 MINOR med eksplicit `Breaking changes`-sektion pga. behavior-change).

## Root cause

For n=24/max=12 producerede `round(seq(1, 24, length.out = 12))` indices

```
seq(1, 24, length.out = 12) = 1.00, 3.09, 5.18, 7.27, 9.36, 11.45, 13.55, 15.64, 17.73, 19.82, 21.91, 24.00
round()                     =   1     3     5     7     9    11    14    16    18    20    22    24
                                                              ^^^ gap = 3
```

Banker's rounding ved .45/.55 grænsen snapper asymmetrisk → labels 12+13 skjules begge midt i serien. I biSPCharts SPC-eksport med 24-måneders-serier ramte dette årsskifte-labels (dec 25 + jan 26).

## Fix

```r
step <- as.integer(ceiling((n_labels - 1L) / (max_visible - 1L)))
idx  <- seq.int(1L, n_labels, by = step)
if (idx[length(idx)] != n_labels) idx <- c(idx, n_labels)
```

Garanterer konstant interval i "showing" pattern — aldrig 2 konsekutive skjulte mid-series. Length-cap matematisk preserved: `floor((n-1)/step) + force-last <= max_visible`.

## Behavior change

| n   | før (0.21.0)                            | nu (0.22.0)                              |
|-----|-----------------------------------------|------------------------------------------|
|  24 | 12 indices, gap 11→14                   |  9 indices, konstant step=3              |
|  36 | 12 indices                              | 10 indices, konstant step=4              |
|  52 | 12 indices                              | 12 indices, konstant step=5              |
| 100 | 12 indices                              | 12 indices, konstant step=9              |

API-signatur uændret.

## Cross-repo

biSPCharts (PR #819 develop) kalder helperen. **Efter merge til main + tag v0.22.0** opretter separat `chore(deps): bump BFHcharts to 0.22.0`-PR i biSPCharts med `Imports: BFHcharts (>= 0.22.0)`.

## Test plan

- [x] `tests/testthat/test-generate_details.R` udvidet med:
  - Exact-indices regression for n=24/36/52/100
  - Gap-invariant: maks gap <= step for n ∈ {13, 15, 20, 24, 30, 36, 48, 52, 75, 100, 250}
  - Length-cap invariant for n op til 365
  - Edge cases max_visible ∈ {1, 2, 6}
- [x] `devtools::test()` → 5558 pass, 0 fail, 70 skip (pre-existing)
- [x] Pre-push hook (test:full, 251s) grøn
- [x] `devtools::document()` regen af `.Rd`
- [ ] **[MANUELT]** Visuel verifikation i biSPCharts SPC-eksport (n=24 måneds-serie) efter cross-repo bump

closes #396