### PR TITLE
fix(x-axis): step-based label-thinning fjerner round() gap-artefakt (#396)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BFHcharts
 Title: SPC Visualization for Healthcare Quality Improvement
-Version: 0.21.0
+Version: 0.22.0
 Authors@R: c(
     person(
       "Johan", "Reventlow",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,22 @@
+# BFHcharts 0.22.0
+
+## Breaking changes
+
+* **`bfh_subsample_label_indices()` skifter til deterministisk step-baseret
+  algoritme** (#396). Erstatter tidligere
+  `round(seq.int(1L, n_labels, length.out = max_visible))` med
+  `seq.int(1L, n_labels, by = step)` hvor `step = ceiling((n - 1) / (max_visible - 1))`.
+  Eliminerer asymmetrisk round()-artefakt der gav konsekutive skjulte labels
+  midt i serien (eksempel: n=24 gav gap mellem index 11 og 14, dvs.
+  index 12+13 begge skjult). Density-target for n=24 ændres fra 12 til 9
+  visible labels (\"vis 1, skjul 2\"-rytme). Eksisterende `max_visible`-kontrakt
+  løsnes fra hard cap til soft cap (result-length kan overstige `max_visible`
+  med 1 når last-anchor falder af step-grid).
+
+  Migration: callers der hardcodede forventning om nøjagtigt `max_visible`
+  indices skal forvente ±1. Visual layout bliver glattere; ingen mid-series
+  gap-of-`step+1`.
+
 # BFHcharts 0.21.0
 
 ## Nye features

--- a/R/utils_x_axis_formatting.R
+++ b/R/utils_x_axis_formatting.R
@@ -290,19 +290,27 @@ BFH_MAX_X_LABELS_TEXT <- 12L
 #'
 #' Returns evenly-spaced indices for selecting which categorical x-axis labels
 #' to display on a chart. First and last indices are always included as anchors;
-#' intermediate indices are chosen via `round(seq(1, n, length.out = max_visible))`.
-#' Designed for tekst-x-data (month names, weekdays, observation IDs) where
-#' showing all labels would overlap or require rotation.
+#' intermediate indices follow a deterministic integer step computed as
+#' `ceiling((n_labels - 1) / (max_visible - 1))`. Designed for tekst-x-data
+#' (month names, weekdays, observation IDs) where showing all labels would
+#' overlap or require rotation.
 #'
-#' Algorithm scales smoothly: for n <= max_visible all indices returned;
-#' otherwise progressively thinning preserves a near-constant label-density.
+#' Algorithm:
+#' - `n_labels <= max_visible`: all indices returned.
+#' - `n_labels > max_visible`: step = ceil((n - 1) / (max_visible - 1));
+#'   indices = seq(1, n, by = step); last index force-appended if not present.
+#'
+#' Step ceiling guarantees no two consecutive indices missing in the same
+#' visible/hidden cycle (previous `round(seq.int)` implementation produced
+#' asymmetric rounding artefacts; see issue #396).
 #'
 #' @param n_labels Integer. Total number of labels available.
-#' @param max_visible Integer. Maximum number of labels to display.
-#'   Default [BFH_MAX_X_LABELS_TEXT] (currently 12).
+#' @param max_visible Integer. Soft cap on number of labels to display.
+#'   Default [BFH_MAX_X_LABELS_TEXT] (currently 12). Result length may exceed
+#'   `max_visible` by 1 when the last anchor falls off the step-grid.
 #'
 #' @return Integer vector of indices into the label sequence. Always includes
-#'   1 and `n_labels` (anchors). Length <= `max_visible`.
+#'   1 and `n_labels` (anchors).
 #'
 #' @export
 #'
@@ -311,13 +319,17 @@ BFH_MAX_X_LABELS_TEXT <- 12L
 #' bfh_subsample_label_indices(12)
 #' # [1] 1 2 3 4 5 6 7 8 9 10 11 12
 #'
-#' # 52 weeks thinned to ~12 evenly-spaced
+#' # 24 months thinned with step=3 (vis 1, skjul 2-rytme)
+#' bfh_subsample_label_indices(24)
+#' # [1]  1  4  7 10 13 16 19 22 24
+#'
+#' # 52 weeks thinned with step=5
 #' bfh_subsample_label_indices(52)
-#' # [1]  1  5 10 15 20 25 30 36 41 46 51 52
+#' # [1]  1  6 11 16 21 26 31 36 41 46 51 52
 #'
 #' # Custom max
 #' bfh_subsample_label_indices(24, max_visible = 6)
-#' # [1]  1  6 11 15 20 24
+#' # [1]  1  6 11 16 21 24
 bfh_subsample_label_indices <- function(n_labels, max_visible = BFH_MAX_X_LABELS_TEXT) {
   if (!is.numeric(n_labels) || length(n_labels) != 1L || is.na(n_labels) ||
     n_labels < 1) {
@@ -332,5 +344,12 @@ bfh_subsample_label_indices <- function(n_labels, max_visible = BFH_MAX_X_LABELS
   if (n_labels <= max_visible) {
     return(seq_len(n_labels))
   }
-  unique(as.integer(round(seq.int(1L, n_labels, length.out = max_visible))))
+  # Deterministisk step via ceil() forhindrer round(seq.int) asymmetri-artefakt
+  # hvor consecutive labels midt i serien skjules samtidig (issue #396).
+  step <- max(1L, as.integer(ceiling((n_labels - 1L) / (max_visible - 1L))))
+  idx <- seq.int(1L, n_labels, by = step)
+  if (idx[length(idx)] != n_labels) {
+    idx <- c(idx, n_labels)
+  }
+  as.integer(idx)
 }

--- a/man/bfh_subsample_label_indices.Rd
+++ b/man/bfh_subsample_label_indices.Rd
@@ -9,34 +9,48 @@ bfh_subsample_label_indices(n_labels, max_visible = BFH_MAX_X_LABELS_TEXT)
 \arguments{
 \item{n_labels}{Integer. Total number of labels available.}
 
-\item{max_visible}{Integer. Maximum number of labels to display.
-Default \link{BFH_MAX_X_LABELS_TEXT} (currently 12).}
+\item{max_visible}{Integer. Soft cap on number of labels to display.
+Default \link{BFH_MAX_X_LABELS_TEXT} (currently 12). Result length may exceed
+\code{max_visible} by 1 when the last anchor falls off the step-grid.}
 }
 \value{
 Integer vector of indices into the label sequence. Always includes
-1 and \code{n_labels} (anchors). Length <= \code{max_visible}.
+1 and \code{n_labels} (anchors).
 }
 \description{
 Returns evenly-spaced indices for selecting which categorical x-axis labels
 to display on a chart. First and last indices are always included as anchors;
-intermediate indices are chosen via \code{round(seq(1, n, length.out = max_visible))}.
-Designed for tekst-x-data (month names, weekdays, observation IDs) where
-showing all labels would overlap or require rotation.
+intermediate indices follow a deterministic integer step computed as
+\code{ceiling((n_labels - 1) / (max_visible - 1))}. Designed for tekst-x-data
+(month names, weekdays, observation IDs) where showing all labels would
+overlap or require rotation.
 }
 \details{
-Algorithm scales smoothly: for n <= max_visible all indices returned;
-otherwise progressively thinning preserves a near-constant label-density.
+Algorithm:
+\itemize{
+\item \code{n_labels <= max_visible}: all indices returned.
+\item \code{n_labels > max_visible}: step = ceil((n - 1) / (max_visible - 1));
+indices = seq(1, n, by = step); last index force-appended if not present.
+}
+
+Step ceiling guarantees no two consecutive indices missing in the same
+visible/hidden cycle (previous \code{round(seq.int)} implementation produced
+asymmetric rounding artefacts; see issue #396).
 }
 \examples{
 # All 12 months visible when n <= max
 bfh_subsample_label_indices(12)
 # [1] 1 2 3 4 5 6 7 8 9 10 11 12
 
-# 52 weeks thinned to ~12 evenly-spaced
+# 24 months thinned with step=3 (vis 1, skjul 2-rytme)
+bfh_subsample_label_indices(24)
+# [1]  1  4  7 10 13 16 19 22 24
+
+# 52 weeks thinned with step=5
 bfh_subsample_label_indices(52)
-# [1]  1  5 10 15 20 25 30 36 41 46 51 52
+# [1]  1  6 11 16 21 26 31 36 41 46 51 52
 
 # Custom max
 bfh_subsample_label_indices(24, max_visible = 6)
-# [1]  1  6 11 15 20 24
+# [1]  1  6 11 16 21 24
 }

--- a/tests/testthat/test-generate_details.R
+++ b/tests/testthat/test-generate_details.R
@@ -355,8 +355,47 @@ test_that("bfh_subsample_label_indices: progressive thinning bevarer near-konsta
   # Density-test: foerste 12 indices skal danne en jaevn fordeling
   res_100 <- bfh_subsample_label_indices(100)
   diffs <- diff(res_100)
-  # Skal vaere approx jaevn (max diff - min diff <= 1 ved round-jitter)
+  # Skal vaere approx jaevn (max diff - min diff <= 1 ved last-anchor justering)
   expect_lte(max(diffs) - min(diffs), 1L)
+})
+
+test_that("bfh_subsample_label_indices: ingen konsekutive skjulte midt i serien (issue #396)", {
+  # Regression-test: round(seq.int)-implementation gav gap-of-3 ved n=24
+  # mellem indices 11 og 14 (positions 11.45 + 13.55 rundede asymmetrisk).
+  # Step-based implementation skal have ensartet step gennem hele serien
+  # eller alene tail-justering ved last-anchor.
+  res_24 <- bfh_subsample_label_indices(24)
+  diffs <- diff(res_24)
+
+  # Alle mid-series diffs skal vaere identiske (tail kan vaere mindre pga.
+  # last-anchor force-append).
+  mid_diffs <- diffs[-length(diffs)]
+  expect_true(length(unique(mid_diffs)) == 1L,
+    info = paste("mid-series diffs:", paste(mid_diffs, collapse = ", "))
+  )
+
+  # Step skal vaere >= 2 for n > max_visible (ellers ingen thinning).
+  expect_gte(mid_diffs[1L], 2L)
+
+  # Tail-diff <= mid-diff (last-anchor closer to penultimate).
+  expect_lte(diffs[length(diffs)], mid_diffs[1L])
+})
+
+test_that("bfh_subsample_label_indices: step-3 for n=24 matcher spec", {
+  # Issue #396 acceptance criteria: n=24, max=12 => step=3 (vis 1, skjul 2-rytme)
+  expect_equal(
+    bfh_subsample_label_indices(24L, max_visible = 12L),
+    c(1L, 4L, 7L, 10L, 13L, 16L, 19L, 22L, 24L)
+  )
+})
+
+test_that("bfh_subsample_label_indices: foerste + sidste altid inkluderet", {
+  # Anchor-invariant: foerste og sidste index skal ALTID med, uanset step
+  for (n in c(13L, 24L, 25L, 36L, 47L, 52L, 100L)) {
+    res <- bfh_subsample_label_indices(n)
+    expect_equal(res[1L], 1L, info = paste("n =", n))
+    expect_equal(res[length(res)], n, info = paste("n =", n))
+  }
 })
 
 test_that("bfh_subsample_label_indices: invalid input kaster fejl", {


### PR DESCRIPTION
## Summary

- Erstatter `round(seq.int(1L, n_labels, length.out = max_visible))` med deterministisk step-baseret algoritme i `bfh_subsample_label_indices()`.
- Eliminerer asymmetrisk round()-artefakt der gav konsekutive skjulte labels midt i serien (n=24: dec25 + jan26 begge skjult).
- Density-target for n=24 ændres fra 12 labels (50%) til 9 labels (33%, "vis 1, skjul 2"-rytme).
- MINOR-bump 0.21.0 → 0.22.0 pga. observable behavior-change.

## Trigger

Bruger-eksport via biSPCharts (PR #819) viste SPC-chart med 24 mdr labels hvor dec 25 og jan 26 begge var skjult midt i serien, mens rytmen ellers var "hver 2.". Root cause: `seq(1, 24, length.out = 12)` giver positions 11.45 + 13.55 som `round()` snapper asymmetrisk → gap-of-3 mellem index 11 og 14.

## Algorithm

```r
step <- max(1L, as.integer(ceiling((n_labels - 1L) / (max_visible - 1L))))
idx  <- seq.int(1L, n_labels, by = step)
if (idx[length(idx)] != n_labels) idx <- c(idx, n_labels)
```

| n   | step | indices                                       | count |
|-----|------|-----------------------------------------------|-------|
| 24  | 3    | 1, 4, 7, 10, 13, 16, 19, 22, 24               | 9     |
| 36  | 4    | 1, 5, 9, 13, 17, 21, 25, 29, 33, 36           | 10    |
| 52  | 5    | 1, 6, 11, 16, 21, 26, 31, 36, 41, 46, 51, 52  | 12    |
| 100 | 9    | 1, 10, 19, 28, 37, 46, 55, 64, 73, 82, 91, 100| 12    |

## Behavior change

- `n <= max_visible`: uændret
- `n > max_visible`: færre visible labels (sparser layout, eliminerer mid-series gap)
- API-signature uændret
- `max_visible`-kontrakt løsnes fra hard cap til soft cap (result-length kan overstige med 1 ved last-anchor)

## Cross-repo follow-up

Efter release BFHcharts 0.22.0: bump biSPCharts `Imports: BFHcharts (>= 0.22.0)` i separat `chore(deps):`-PR. Visual layout for tekst-x-SPC-eksport ændres synligt.

## Test plan

- [x] Eksisterende `bfh_subsample_label_indices()` tests passer (max-cap, anchor, density)
- [x] Ny regression-test: n=24 returnerer `c(1, 4, 7, 10, 13, 16, 19, 22, 24)` (eksakt spec-match)
- [x] Ny regression-test: ingen konsekutive skjulte midt i serien (#396 root cause)
- [x] Ny anchor-invariant test for n ∈ {13, 24, 25, 36, 47, 52, 100}
- [x] `devtools::test()`: 5548 PASS, 0 FAIL
- [x] `devtools::check()`: 0 errors, 1 pre-existing warning (`bfh_generate_details.Rd:16` `\u`-macro — ikke relateret til denne PR)
- [ ] Manuel verifikation i biSPCharts efter version-bump: SPC-eksport med 24 mdr data viser jævn 1-of-3 label-rytme

## References

Closes #396