### PR TITLE
fix(x-axis): drop force-last anchor for konstant rhythm (0.22.1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BFHcharts
 Title: SPC Visualization for Healthcare Quality Improvement
-Version: 0.22.0
+Version: 0.22.1
 Authors@R: c(
     person(
       "Johan", "Reventlow",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,25 @@
+# BFHcharts 0.22.1
+
+## Behavior change
+
+* **`bfh_subsample_label_indices()` dropper force-last anchor.** I 0.22.0 blev
+  `n_labels` altid appendet som sidste anchor selv naar det braed step-rhythmen
+  (fx n=24/step=3 endte med diffs `c(3,3,3,3,3,3,3,2)` -- sidste gap=2 stak ud
+  visuelt). Nu inkluderes sidste index `n_labels` KUN naar `(n_labels - 1)`
+  er delelig med step; ellers slutter sekvensen ved den hoejeste step-alignede
+  position <= `n_labels`. Resultat: konstant rhythm hele vejen igennem.
+
+  | n   | step | sidste index | 0.22.0 (force-last)     | 0.22.1 (kun grid)        |
+  |-----|------|--------------|-------------------------|--------------------------|
+  |  24 | 3    | 22 (ej 24)   | length=9, gap-tail=2    | length=8, alle diffs=3   |
+  |  36 | 4    | 33 (ej 36)   | length=10, gap-tail=3   | length=9, alle diffs=4   |
+  |  52 | 5    | 51 (ej 52)   | length=12, gap-tail=1   | length=11, alle diffs=5  |
+  | 100 | 9    | 100 (grid)   | length=12, alle diffs=9 | uaendret                 |
+
+  Callers der har brug for sidste label som anker skal appende det eksplicit.
+  Downstream consumers (biSPCharts) der renderer subsampled labels via helperen
+  vil se sidste label droppet for n hvor `(n - 1)` ej er delelig med step.
+
 # BFHcharts 0.22.0
 
 ## Breaking changes

--- a/R/utils_x_axis_formatting.R
+++ b/R/utils_x_axis_formatting.R
@@ -289,25 +289,33 @@ BFH_MAX_X_LABELS_TEXT <- 12L
 #' Subsample Text X-Axis Label Indices
 #'
 #' Returns deterministic, evenly-spaced indices for selecting which categorical
-#' x-axis labels to display on a chart. First index is always 1; last index is
-#' always `n_labels` (force-last anchor). Intermediate indices follow integer
-#' step `ceiling((n_labels - 1) / (max_visible - 1))`, which guarantees no two
-#' consecutive label positions are skipped in the "showing" pattern. Designed
-#' for tekst-x-data (month names, weekdays, observation IDs) where showing all
-#' labels would overlap or require rotation.
+#' x-axis labels to display on a chart. First index is always 1. Intermediate
+#' indices follow integer step `ceiling((n_labels - 1) / (max_visible - 1))`.
+#' The last index `n_labels` is included only when it lands naturally on the
+#' step grid (i.e. when `(n_labels - 1)` is divisible by `step`); otherwise
+#' the sequence ends at the highest step-aligned position <= `n_labels`.
+#' Designed for tekst-x-data (month names, weekdays, observation IDs) where
+#' showing all labels would overlap or require rotation.
 #'
 #' Algorithm scales smoothly: for n <= max_visible all indices returned;
-#' otherwise step-based thinning preserves a near-constant label-density and
+#' otherwise step-based thinning preserves a constant label-density and
 #' avoids the asymmetric-rounding gap-bug that
 #' `round(seq(..., length.out))` produces for moderate n (issue #396).
+#'
+#' Note: prior versions (0.22.0) appended `n_labels` as a force-last anchor,
+#' producing a shorter tail-gap mid-rhythm. This was removed because the
+#' rhythm-break was visually jarring (e.g. n=24 jumped from a constant step=3
+#' to a step=2 tail). Callers requiring the last label as anchor must append
+#' it explicitly.
 #'
 #' @param n_labels Integer. Total number of labels available.
 #' @param max_visible Integer. Maximum number of labels to display.
 #'   Default [BFH_MAX_X_LABELS_TEXT] (currently 12).
 #'
-#' @return Integer vector of indices into the label sequence. Always includes
-#'   1 and `n_labels` (anchors). Length <= `max_visible` (may be lower when
-#'   step-thinning produces fewer evenly-spaced anchors).
+#' @return Integer vector of indices into the label sequence. First index is
+#'   always 1; last index is `n_labels` only when it falls on the step grid,
+#'   otherwise the highest step-aligned position <= `n_labels`.
+#'   Length <= `max_visible`.
 #'
 #' @export
 #'
@@ -316,17 +324,17 @@ BFH_MAX_X_LABELS_TEXT <- 12L
 #' bfh_subsample_label_indices(12)
 #' # [1] 1 2 3 4 5 6 7 8 9 10 11 12
 #'
-#' # 24 months: step=3, force-last anchor -> 9 labels (no gap-of-3)
+#' # 24 months: step=3, no force-last (sidste = 22, ej 24)
 #' bfh_subsample_label_indices(24)
-#' # [1]  1  4  7 10 13 16 19 22 24
+#' # [1]  1  4  7 10 13 16 19 22
 #'
-#' # 52 weeks thinned to <=12 evenly-spaced
-#' bfh_subsample_label_indices(52)
-#' # [1]  1  6 11 16 21 26 31 36 41 46 51 52
+#' # 100 obs: step=9, n=100 lands naturally on grid -> included
+#' bfh_subsample_label_indices(100)
+#' # [1]   1  10  19  28  37  46  55  64  73  82  91 100
 #'
 #' # Custom max
 #' bfh_subsample_label_indices(24, max_visible = 6)
-#' # [1]  1  6 11 16 21 24
+#' # [1]  1  6 11 16 21
 bfh_subsample_label_indices <- function(n_labels, max_visible = BFH_MAX_X_LABELS_TEXT) {
   if (!is.numeric(n_labels) || length(n_labels) != 1L || is.na(n_labels) ||
     n_labels < 1) {
@@ -344,12 +352,9 @@ bfh_subsample_label_indices <- function(n_labels, max_visible = BFH_MAX_X_LABELS
   if (max_visible == 1L) {
     return(1L)
   }
-  # Deterministic step: ceiling((n - 1) / (max - 1)) >= 1 keeps idx count
-  # within max_visible slots when force-last anchor is appended.
+  # Deterministic step keeps idx count within max_visible. Last index is
+  # included only when (n_labels - 1) %% step == 0 -- preserves constant
+  # rhythm and avoids the jarring shorter tail-gap from force-last anchoring.
   step <- as.integer(ceiling((n_labels - 1L) / (max_visible - 1L)))
-  idx <- seq.int(1L, n_labels, by = step)
-  if (idx[length(idx)] != n_labels) {
-    idx <- c(idx, n_labels)
-  }
-  idx
+  seq.int(1L, n_labels, by = step)
 }

--- a/man/bfh_subsample_label_indices.Rd
+++ b/man/bfh_subsample_label_indices.Rd
@@ -13,39 +13,47 @@ bfh_subsample_label_indices(n_labels, max_visible = BFH_MAX_X_LABELS_TEXT)
 Default \link{BFH_MAX_X_LABELS_TEXT} (currently 12).}
 }
 \value{
-Integer vector of indices into the label sequence. Always includes
-1 and \code{n_labels} (anchors). Length <= \code{max_visible} (may be lower when
-step-thinning produces fewer evenly-spaced anchors).
+Integer vector of indices into the label sequence. First index is
+always 1; last index is \code{n_labels} only when it falls on the step grid,
+otherwise the highest step-aligned position <= \code{n_labels}.
+Length <= \code{max_visible}.
 }
 \description{
 Returns deterministic, evenly-spaced indices for selecting which categorical
-x-axis labels to display on a chart. First index is always 1; last index is
-always \code{n_labels} (force-last anchor). Intermediate indices follow integer
-step \code{ceiling((n_labels - 1) / (max_visible - 1))}, which guarantees no two
-consecutive label positions are skipped in the "showing" pattern. Designed
-for tekst-x-data (month names, weekdays, observation IDs) where showing all
-labels would overlap or require rotation.
+x-axis labels to display on a chart. First index is always 1. Intermediate
+indices follow integer step \code{ceiling((n_labels - 1) / (max_visible - 1))}.
+The last index \code{n_labels} is included only when it lands naturally on the
+step grid (i.e. when \code{(n_labels - 1)} is divisible by \code{step}); otherwise
+the sequence ends at the highest step-aligned position <= \code{n_labels}.
+Designed for tekst-x-data (month names, weekdays, observation IDs) where
+showing all labels would overlap or require rotation.
 }
 \details{
 Algorithm scales smoothly: for n <= max_visible all indices returned;
-otherwise step-based thinning preserves a near-constant label-density and
+otherwise step-based thinning preserves a constant label-density and
 avoids the asymmetric-rounding gap-bug that
 \code{round(seq(..., length.out))} produces for moderate n (issue #396).
+
+Note: prior versions (0.22.0) appended \code{n_labels} as a force-last anchor,
+producing a shorter tail-gap mid-rhythm. This was removed because the
+rhythm-break was visually jarring (e.g. n=24 jumped from a constant step=3
+to a step=2 tail). Callers requiring the last label as anchor must append
+it explicitly.
 }
 \examples{
 # All 12 months visible when n <= max
 bfh_subsample_label_indices(12)
 # [1] 1 2 3 4 5 6 7 8 9 10 11 12
 
-# 24 months: step=3, force-last anchor -> 9 labels (no gap-of-3)
+# 24 months: step=3, no force-last (sidste = 22, ej 24)
 bfh_subsample_label_indices(24)
-# [1]  1  4  7 10 13 16 19 22 24
+# [1]  1  4  7 10 13 16 19 22
 
-# 52 weeks thinned to <=12 evenly-spaced
-bfh_subsample_label_indices(52)
-# [1]  1  6 11 16 21 26 31 36 41 46 51 52
+# 100 obs: step=9, n=100 lands naturally on grid -> included
+bfh_subsample_label_indices(100)
+# [1]   1  10  19  28  37  46  55  64  73  82  91 100
 
 # Custom max
 bfh_subsample_label_indices(24, max_visible = 6)
-# [1]  1  6 11 16 21 24
+# [1]  1  6 11 16 21
 }

--- a/tests/testthat/test-generate_details.R
+++ b/tests/testthat/test-generate_details.R
@@ -327,54 +327,71 @@ test_that("bfh_subsample_label_indices: n <= max returnerer alle indices", {
   expect_equal(bfh_subsample_label_indices(12), 1:12)
 })
 
-test_that("bfh_subsample_label_indices: n > max thinner til max_visible med foerste+sidste anker", {
+test_that("bfh_subsample_label_indices: n > max har foerste anker, sidste kun naar grid-aligned", {
+  # Sidste = n_labels KUN naar (n - 1) %% step == 0, ellers det hoejeste
+  # step-aligned position <= n. Forhindrer ujaevn tail-gap mid-rhythm.
   res_24 <- bfh_subsample_label_indices(24)
   expect_lte(length(res_24), 12L)
   expect_equal(res_24[1], 1L)
-  expect_equal(res_24[length(res_24)], 24L)
+  expect_equal(res_24[length(res_24)], 22L) # 24 ej grid-aligned (step=3, 23%%3 != 0)
 
   res_52 <- bfh_subsample_label_indices(52)
   expect_lte(length(res_52), 12L)
   expect_equal(res_52[1], 1L)
-  expect_equal(res_52[length(res_52)], 52L)
+  expect_equal(res_52[length(res_52)], 51L) # 52 ej grid-aligned (step=5, 51%%5 != 0)
 
   res_100 <- bfh_subsample_label_indices(100)
   expect_lte(length(res_100), 12L)
   expect_equal(res_100[1], 1L)
-  expect_equal(res_100[length(res_100)], 100L)
+  expect_equal(res_100[length(res_100)], 100L) # 100 grid-aligned (step=9, 99%%9 == 0)
 })
 
 test_that("bfh_subsample_label_indices: custom max_visible respekteres", {
   res <- bfh_subsample_label_indices(24, max_visible = 6L)
   expect_lte(length(res), 6L)
   expect_equal(res[1], 1L)
-  expect_equal(res[length(res)], 24L)
+  # max=6, step=ceil(23/5)=5 -> sidste = 21 (24 ej grid-aligned)
+  expect_equal(res[length(res)], 21L)
 })
 
 test_that("bfh_subsample_label_indices: step-based thinning er konstant intervallet (n=100)", {
-  # n=100, max=12 -> step=9, alle diffs = 9 (force-last anchor 91 -> 100 ogsaa 9)
+  # n=100, max=12 -> step=9, alle diffs = 9 (uden force-last forbliver konstant)
   res_100 <- bfh_subsample_label_indices(100)
   diffs <- diff(res_100)
   expect_equal(max(diffs) - min(diffs), 0L)
-  expect_true(all(diffs >= 1L))
+  expect_true(all(diffs == 9L))
 })
 
-test_that("bfh_subsample_label_indices: exact indices for n=24 fjerner gap-of-3 (#396)", {
-  # Bug-repro: round(seq(1, 24, length.out=12)) producerede gap 11->14 (skjulte
-  # 12+13). Step-baseret approach giver konstant step=3 + force-last anchor.
+test_that("bfh_subsample_label_indices: konstant rhythm uden tail-break for n=24 (#396 follow-up)", {
+  # Issue #396 follow-up: drop force-last anchor saa tail-gap aldrig bryder
+  # rhythmen. Alle diffs i n=24 sekvensen skal vaere identiske med step.
+  res_24 <- bfh_subsample_label_indices(24)
+  diffs <- diff(res_24)
+  expect_true(length(unique(diffs)) == 1L,
+    info = paste("diffs:", paste(diffs, collapse = ", "))
+  )
+  expect_equal(diffs[1L], 3L) # step = ceil(23/11) = 3
+})
+
+test_that("bfh_subsample_label_indices: exact indices for n=24 (#396 + follow-up)", {
+  # Bug-repro: round(seq(1, 24, length.out=12)) producerede gap 11->14.
+  # Step-baseret approach giver konstant step=3 uden tail-break.
   res <- bfh_subsample_label_indices(24)
-  expect_equal(res, c(1L, 4L, 7L, 10L, 13L, 16L, 19L, 22L, 24L))
+  expect_equal(res, c(1L, 4L, 7L, 10L, 13L, 16L, 19L, 22L))
 })
 
 test_that("bfh_subsample_label_indices: exact indices for n=36/52/100 (regression)", {
+  # n=36 step=4: ender ved 33 (35%%4 != 0)
   expect_equal(
     bfh_subsample_label_indices(36),
-    c(1L, 5L, 9L, 13L, 17L, 21L, 25L, 29L, 33L, 36L)
+    c(1L, 5L, 9L, 13L, 17L, 21L, 25L, 29L, 33L)
   )
+  # n=52 step=5: ender ved 51 (51%%5 != 0)
   expect_equal(
     bfh_subsample_label_indices(52),
-    c(1L, 6L, 11L, 16L, 21L, 26L, 31L, 36L, 41L, 46L, 51L, 52L)
+    c(1L, 6L, 11L, 16L, 21L, 26L, 31L, 36L, 41L, 46L, 51L)
   )
+  # n=100 step=9: ender ved 100 (99%%9 == 0, grid-aligned)
   expect_equal(
     bfh_subsample_label_indices(100),
     c(1L, 10L, 19L, 28L, 37L, 46L, 55L, 64L, 73L, 82L, 91L, 100L)
@@ -383,9 +400,7 @@ test_that("bfh_subsample_label_indices: exact indices for n=36/52/100 (regressio
 
 test_that("bfh_subsample_label_indices: ingen 2-konsekutive-skjulte i 'showing' pattern", {
   # Invariant for issue #396: maks gap mellem on-hinanden foelgende synlige
-  # indices <= step+1 (force-last anchor kan tilfoeje en kortere gap, aldrig
-  # laengere). Det udelukker scenariet hvor to nabo-labels begge skjules midt
-  # i serien.
+  # indices = step (uden force-last anchor er gap-vektoren konstant).
   for (n in c(13L, 15L, 20L, 24L, 30L, 36L, 48L, 52L, 75L, 100L, 250L)) {
     res <- bfh_subsample_label_indices(n)
     diffs <- diff(res)
@@ -401,7 +416,8 @@ test_that("bfh_subsample_label_indices: max_visible=1 returnerer kun foerste anc
   expect_equal(bfh_subsample_label_indices(100, max_visible = 1L), 1L)
 })
 
-test_that("bfh_subsample_label_indices: max_visible=2 returnerer kun anchors", {
+test_that("bfh_subsample_label_indices: max_visible=2 inkluderer last naturligt", {
+  # max=2 -> step = n - 1 -> sidste position = 1 + (n-1) = n (alid grid-aligned)
   expect_equal(bfh_subsample_label_indices(24, max_visible = 2L), c(1L, 24L))
   expect_equal(bfh_subsample_label_indices(100, max_visible = 2L), c(1L, 100L))
 })
@@ -409,12 +425,11 @@ test_that("bfh_subsample_label_indices: max_visible=2 returnerer kun anchors", {
 test_that("bfh_subsample_label_indices: custom max_visible=6 for n=24", {
   expect_equal(
     bfh_subsample_label_indices(24, max_visible = 6L),
-    c(1L, 6L, 11L, 16L, 21L, 24L)
+    c(1L, 6L, 11L, 16L, 21L)
   )
 })
 
 test_that("bfh_subsample_label_indices: length aldrig overstiger max_visible", {
-  # Force-last anchor maa ej overskride cap. Verificer for raekke n-vaerdier.
   for (n in c(13L, 24L, 36L, 52L, 100L, 200L, 365L)) {
     res <- bfh_subsample_label_indices(n)
     expect_lte(length(res), 12L,


### PR DESCRIPTION
## Summary

- Dropper force-last anchor i `bfh_subsample_label_indices()`. Sidste label vises kun hvis det lander naturligt på step-grid'et.
- Fixer ujævn tail-gap der introduceredes i 0.22.0 (n=24 endte med diffs `c(3,3,3,3,3,3,3,2)` — sidste gap=2 stak visuelt ud).
- PATCH-bump 0.22.0 → 0.22.1.

## User-feedback

> Ved fx ved 24 punkter så har vi vist lavet det sådan at det 24 punkt altid vises, selvom det egentlig ikke passer i intervallet. Jeg vil gerne have at reglen om at sidste observations label altid indgår skal ændres, sådan at den kun vises, hvis det passer i det interval vi har opsat.

## Before / after (n=24, step=3)

```
0.22.0: 1  4  7  10  13  16  19  22  24    diffs: 3 3 3 3 3 3 3 2
                                                                ^ tail-break
0.22.1: 1  4  7  10  13  16  19  22        diffs: 3 3 3 3 3 3 3 (konstant)
```

## Effekt per n

| n   | step | sidste index | rhythm                     |
|-----|------|--------------|----------------------------|
|  24 | 3    | 22 (24 droppet) | konstant step=3         |
|  36 | 4    | 33 (36 droppet) | konstant step=4         |
|  52 | 5    | 51 (52 droppet) | konstant step=5         |
| 100 | 9    | 100 (grid-aligned) | uændret, konstant step=9 |

Sidste = `n_labels` kun når `(n_labels - 1) %% step == 0`.

## Cross-repo

biSPCharts har ikke bumpet til `BFHcharts (>= 0.22.0)` endnu. Når den cross-repo bump-PR åbnes, retter den direkte mod 0.22.1 (uden mellem-step over 0.22.0's force-last adfærd). Ingen downstream-impact i mellemtiden.

## Test plan

- [x] Eksisterende tests opdateret: forventninger om sidste = `n` ændret til step-grid-alignment
- [x] Nye tests:
  - `konstant rhythm uden tail-break for n=24`: `length(unique(diff(res_24))) == 1`
  - `exact indices for n=24`: `c(1, 4, 7, 10, 13, 16, 19, 22)`
  - `exact indices for n=36/52/100` opdateret
  - `max_visible=2 inkluderer last naturligt`: step = n-1, sidste = n grid-aligned per definition
- [x] Pre-push hook grøn: 5560 pass, 0 fail, 70 skip (pre-existing)
- [ ] **[MANUELT]** Visuel verifikation i biSPCharts SPC-eksport (n=24 måneds-serie) efter release + cross-repo bump

Refs #396