### PR TITLE
feat(ylim): ylim-aware target/CL-label placering + docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BFHcharts
 Title: SPC Visualization for Healthcare Quality Improvement
-Version: 0.22.1
+Version: 0.23.0
 Authors@R: c(
     person(
       "Johan", "Reventlow",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,19 @@
+# BFHcharts 0.23.0
+
+## Nye features
+
+* **`bfh_qic(ylim = ...)` -- y-akse-visningsgrænser.** Ny valgfri parameter
+  `ylim = c(min, max)` der zoomer y-aksen analogt med
+  `ggplot2::coord_cartesian(ylim = ...)`. Værdier er i plottets data-skala
+  (proportion-charts `p`/`pp` bruger 0-1-skalaen, fx `c(0, 1)` viser 0%-100%;
+  øvrige charts bruger absolut skala). `NA` per ende giver fri grænse
+  (`c(0, NA)` = fast bund, datadrevet top). Grænsen sættes på det eksisterende
+  `lemon::coord_capped_cart`, så BFH-akse-caps bevares. Da coord *zoomer* og
+  ikke *clipper*, droppes datapunkter og kontrolgrænse-segmenter uden for
+  range IKKE (modsat `scale_y`-limits) -- charten zoomer blot til vinduet.
+  Ugyldig `min >= max` ignoreres med en advarsel. Default `NULL` bevarer
+  uændret, datadrevet adfærd.
+
 # BFHcharts 0.22.1
 
 ## Behavior change

--- a/R/bfh_qic.R
+++ b/R/bfh_qic.R
@@ -46,6 +46,16 @@ NULL
 #'   `bfh_export_pdf()` PDF surfaces a caveat note below the SPC table when
 #'   this flag is set. See `bfh_extract_spc_stats()` for the discoverable
 #'   surface.
+#' @param ylim Y-axis display limits as a numeric vector of length 2,
+#'   `c(min, max)`, applied via [ggplot2::coord_cartesian()] (default: NULL =
+#'   data-driven). Values are in the plot's data scale: proportion charts
+#'   (`p`, `pp`) use the 0-1 proportion scale (e.g. `c(0, 1)` shows 0%-100%),
+#'   all other charts use the absolute data scale. Use `NA` for a free end:
+#'   `c(0, NA)` fixes the bottom at 0 with a data-driven top. Because
+#'   `coord_cartesian` zooms rather than clips, data points and control-limit
+#'   segments outside the range are NOT dropped (unlike `scale_y` limits) -- the
+#'   chart simply zooms to the requested window. If `min >= max` (both
+#'   non-`NA`) the limit is ignored with a warning.
 #' @param multiply Numeric multiplier for y-axis values, e.g. 100 to convert proportions to percentages (default: 1)
 #' @param agg.fun Aggregation function for run/I charts with multiple observations per subgroup: "mean" (default), "median", "sum", "sd"
 #' @param base_size Base font size in points (default: auto-calculated from width/height if provided, otherwise 14)
@@ -609,6 +619,7 @@ bfh_qic <- function(data,
                     freeze = NULL,
                     exclude = NULL,
                     cl = NULL,
+                    ylim = NULL,
                     multiply = 1,
                     agg.fun = c("mean", "median", "sum", "sd"),
                     base_size = 14,
@@ -640,6 +651,8 @@ bfh_qic <- function(data,
 
   # ---- Valider alle inputs (inkl. language) ----
   validate_language(language)
+  # ylim normaliseres til enten NULL (no-op) eller gyldig c(min, max) m. NA.
+  ylim <- validate_ylim(ylim)
   agg.fun <- validate_bfh_qic_inputs(
     data = data,
     chart_type = chart_type,
@@ -758,6 +771,7 @@ bfh_qic <- function(data,
     caption = caption,
     base_size = vp$base_size,
     plot_margin = plot_margin,
+    ylim = ylim,
     language = language
   )
 

--- a/R/config_objects.R
+++ b/R/config_objects.R
@@ -75,6 +75,12 @@ assert_positive_scalar <- function(x, name) {
 #' @param caption Plot caption text (optional)
 #' @param ylim Y-axis display limits `c(min, max)` for coord_cartesian, NA
 #'   allowed per end (optional). Pre-validated by `validate_ylim()` upstream.
+#'   Zoomer det synlige vindue uden at droppe datapunkter. Target-/CL-labels
+#'   er ylim-aware: de placeres relativt til det zoomede vindue (inkl.
+#'   gen-anvendt scale-expansion/headroom), saa de foelger korrekt med ved
+#'   aendret ylim -- ogsaa ved ekstremer (target i top, CL i bund). NB: saetter
+#'   man ylim der udelukker target- eller centerline-vaerdien, falder den linje
+#'   + dens label uden for vinduet og vises ikke (bevidst zoom-adfaerd).
 #'
 #' @return List with class "spc_plot_config"
 #'

--- a/R/config_objects.R
+++ b/R/config_objects.R
@@ -73,6 +73,8 @@ assert_positive_scalar <- function(x, name) {
 #' @param xlab X-axis label (default: "" for blank)
 #' @param subtitle Plot subtitle text (optional)
 #' @param caption Plot caption text (optional)
+#' @param ylim Y-axis display limits `c(min, max)` for coord_cartesian, NA
+#'   allowed per end (optional). Pre-validated by `validate_ylim()` upstream.
 #'
 #' @return List with class "spc_plot_config"
 #'
@@ -109,6 +111,7 @@ spc_plot_config <- function(
   xlab = "",
   subtitle = NULL,
   caption = NULL,
+  ylim = NULL,
   language = "da"
 ) {
   # Validation
@@ -155,6 +158,7 @@ spc_plot_config <- function(
       xlab = xlab,
       subtitle = subtitle,
       caption = caption,
+      ylim = ylim,
       language = language
     ),
     class = "spc_plot_config"

--- a/R/fct_add_spc_labels.R
+++ b/R/fct_add_spc_labels.R
@@ -259,6 +259,18 @@ add_spc_labels <- function(
   }
 
   # Build plot og mapper en gang - genbrug til arrow-placering + labels
+  #
+  # ylim-awareness: add_spc_labels() kaldes EFTER coord_capped_cart(ylim)
+  # er sat paa plottet (se bfh_qic.R: render_bfh_plot foer
+  # apply_spc_labels_to_export). Derfor afspejler ggplot_build()'s
+  # panel-range (pp$y.range, brugt af npc_mapper_from_built) det zoomede
+  # ylim-vindue -- og ggplot2 gen-anvender scale-expansion oven paa
+  # coord-ylim, saa der er proportional headroom i baade top og bund.
+  # Konsekvens: target-/CL-labels placeres relativt til det SYNLIGE
+  # vindue (inkl. headroom), ikke raa data-range. En aendring i ylim
+  # flytter saaledes labels korrekt med. (Edge case: saetter man ylim
+  # der UDELUKKER target/CL-vaerdien, forsvinder den linje + dens label
+  # fra vinduet -- bevidst zoom-adfaerd, ikke en placeringsfejl.)
   built_plot <- ggplot2::ggplot_build(plot)
   shared_mapper <- npc_mapper_from_built(built_plot, original_plot = plot)
 

--- a/R/plot_core.R
+++ b/R/plot_core.R
@@ -292,7 +292,10 @@ bfh_spc_plot <- function(qic_data,
     target_linewidth = target_linewidth,
     comment_size = comment_size,
     suppress_targetline = suppress_targetline,
-    line_positions = line_positions
+    line_positions = line_positions,
+    # ylim videreføres så kommentar-placering scorer mod det synlige
+    # (zoomede) y-vindue i stedet for den fulde data-range.
+    ylim = plot_config$ylim
   )
 
   # Apply theme ----

--- a/R/plot_core.R
+++ b/R/plot_core.R
@@ -293,13 +293,13 @@ bfh_spc_plot <- function(qic_data,
     comment_size = comment_size,
     suppress_targetline = suppress_targetline,
     line_positions = line_positions,
-    # ylim videreføres så kommentar-placering scorer mod det synlige
+    # ylim viderefoeres saa kommentar-placering scorer mod det synlige
     # (zoomede) y-vindue i stedet for den fulde data-range.
     ylim = plot_config$ylim
   )
 
   # Apply theme ----
-  # ylim videreføres til apply_spc_theme, som sætter den PÅ det eksisterende
+  # ylim viderefoeres til apply_spc_theme, som saetter den PAA det eksisterende
   # lemon::coord_capped_cart (ikke en separat coord_cartesian -- ellers
   # erstattes BFH-akse-caps). coord zoomer (dropper IKKE data, modsat scale_y).
   plot <- apply_spc_theme(plot, viewport$base_size, plot_margin,

--- a/R/plot_core.R
+++ b/R/plot_core.R
@@ -296,7 +296,12 @@ bfh_spc_plot <- function(qic_data,
   )
 
   # Apply theme ----
-  plot <- apply_spc_theme(plot, viewport$base_size, plot_margin)
+  # ylim videreføres til apply_spc_theme, som sætter den PÅ det eksisterende
+  # lemon::coord_capped_cart (ikke en separat coord_cartesian -- ellers
+  # erstattes BFH-akse-caps). coord zoomer (dropper IKKE data, modsat scale_y).
+  plot <- apply_spc_theme(plot, viewport$base_size, plot_margin,
+    ylim = plot_config$ylim
+  )
 
   return(plot)
 }

--- a/R/plot_enhancements.R
+++ b/R/plot_enhancements.R
@@ -34,7 +34,8 @@ add_plot_enhancements <- function(plot,
                                   target_linewidth = 1,
                                   comment_size = 6,
                                   suppress_targetline = FALSE,
-                                  line_positions = NULL) {
+                                  line_positions = NULL,
+                                  ylim = NULL) {
   .ensure_bfhtheme()
   # Cache BFHtheme farver (undgaar gentagne opslag)
   color_keys <- c("hospital_blue", "regionh_grey", "regionh_dark")
@@ -154,6 +155,17 @@ add_plot_enhancements <- function(plot,
     y_data_range <- range(all_y)
     y_expand <- diff(y_data_range) * Y_AXIS_EXPANSION_MULT
     y_range <- c(y_data_range[1] - y_expand, y_data_range[2] + y_expand)
+
+    # Naar brugeren har sat ylim (coord_cartesian-zoom), skal kommentar-
+    # placeringen score mod det SYNLIGE vindue, ikke den fulde data-range.
+    # Ellers maser labels sig sammen i en del af aksen (eller havner uden for
+    # zoom). NA per ende = behold data-afledt graense. CL/target-labels er
+    # allerede zoom-aware via NPC-mapper (add_spc_labels), saa kun kommentarer
+    # behoever denne korrektion.
+    if (!is.null(ylim)) {
+      if (length(ylim) >= 1 && !is.na(ylim[1])) y_range[1] <- ylim[1]
+      if (length(ylim) >= 2 && !is.na(ylim[2])) y_range[2] <- ylim[2]
+    }
 
     x_range <- range(qic_data$x, na.rm = TRUE)
 

--- a/R/themes.R
+++ b/R/themes.R
@@ -27,17 +27,23 @@ NULL
 #' @param base_size Base font size
 #' @param plot_margin Numeric vector of length 4 (top, right, bottom, left) in mm,
 #'   or a margin object from ggplot2::margin(), or NULL for default (5mm all sides)
+#' @param ylim Y-axis display limits `c(min, max)` (NA allowed per end), eller
+#'   NULL for datadrevet (default). Sættes på coord_capped_cart, som zoomer uden
+#'   at droppe datapunkter -- modsat scale_y limits. Pre-valideret upstream.
 #'
 #' @return Modified ggplot2 object with theme applied
 #'
 #' @keywords internal
 #' @noRd
-apply_spc_theme <- function(plot, base_size = 14, plot_margin = NULL) {
+apply_spc_theme <- function(plot, base_size = 14, plot_margin = NULL, ylim = NULL) {
   .ensure_bfhtheme()
-  # Use BFHtheme's theme_bfh as base
+  # Use BFHtheme's theme_bfh as base.
+  # ylim sættes PÅ coord_capped_cart (lemon arver coord_cartesian) i stedet for
+  # en separat coord_cartesian -- ellers ville BFH-akse-caps blive erstattet.
+  # ylim = NULL er coord_cartesian-default => ingen zoom (uændret adfærd).
   plot <- plot +
     BFHtheme::theme_bfh(base_size = base_size) +
-    lemon::coord_capped_cart(bottom = "right", gap = 0)
+    lemon::coord_capped_cart(bottom = "right", gap = 0, ylim = ylim)
 
   # Apply margins: use custom if provided, otherwise default 5mm
   if (!is.null(plot_margin)) {

--- a/R/themes.R
+++ b/R/themes.R
@@ -28,7 +28,7 @@ NULL
 #' @param plot_margin Numeric vector of length 4 (top, right, bottom, left) in mm,
 #'   or a margin object from ggplot2::margin(), or NULL for default (5mm all sides)
 #' @param ylim Y-axis display limits `c(min, max)` (NA allowed per end), eller
-#'   NULL for datadrevet (default). Sættes på coord_capped_cart, som zoomer uden
+#'   NULL for datadrevet (default). Saettes paa coord_capped_cart, som zoomer uden
 #'   at droppe datapunkter -- modsat scale_y limits. Pre-valideret upstream.
 #'
 #' @return Modified ggplot2 object with theme applied
@@ -38,9 +38,9 @@ NULL
 apply_spc_theme <- function(plot, base_size = 14, plot_margin = NULL, ylim = NULL) {
   .ensure_bfhtheme()
   # Use BFHtheme's theme_bfh as base.
-  # ylim sættes PÅ coord_capped_cart (lemon arver coord_cartesian) i stedet for
+  # ylim saettes PAA coord_capped_cart (lemon arver coord_cartesian) i stedet for
   # en separat coord_cartesian -- ellers ville BFH-akse-caps blive erstattet.
-  # ylim = NULL er coord_cartesian-default => ingen zoom (uændret adfærd).
+  # ylim = NULL er coord_cartesian-default => ingen zoom (uaendret adfaerd).
   plot <- plot +
     BFHtheme::theme_bfh(base_size = base_size) +
     lemon::coord_capped_cart(bottom = "right", gap = 0, ylim = ylim)

--- a/R/utils_bfh_qic_helpers.R
+++ b/R/utils_bfh_qic_helpers.R
@@ -16,6 +16,48 @@
 #   part:    require_sorted = TRUE, require_unique = TRUE, min = 2, max = nrow
 #   freeze:  require_scalar = TRUE, require_unique = TRUE, min = 1, max = nrow-1
 #   exclude: require_unique = TRUE, min = 1, max = nrow
+# Valider + normalisér ylim-input til coord_cartesian.
+# Returnerer NULL (no-op: ingen coord) eller en gyldig c(min, max) hvor NA
+# er tilladt per ende (fri grænse). coord_cartesian zoomer (dropper IKKE data),
+# så vi behøver ikke validere mod data-range.
+#' @keywords internal
+#' @noRd
+validate_ylim <- function(ylim) {
+  if (is.null(ylim)) {
+    return(NULL)
+  }
+  if (length(ylim) != 2L) {
+    stop(
+      "ylim must be NULL or a numeric vector of length 2, c(min, max) ",
+      "(NA allowed per end for a free limit).",
+      call. = FALSE
+    )
+  }
+  # Begge ender fri => ingen grænse at sætte (accepteres uanset type,
+  # fx logical c(NA, NA)).
+  if (all(is.na(ylim))) {
+    return(NULL)
+  }
+  if (!is.numeric(ylim)) {
+    stop(
+      "ylim must be a numeric vector (length 2, c(min, max), ",
+      "NA allowed per end).",
+      call. = FALSE
+    )
+  }
+  if (!is.na(ylim[1]) && !is.na(ylim[2]) && ylim[1] >= ylim[2]) {
+    warning(
+      sprintf(
+        "ylim min (%s) >= max (%s); ignoring ylim.",
+        ylim[1], ylim[2]
+      ),
+      call. = FALSE
+    )
+    return(NULL)
+  }
+  ylim
+}
+
 #' @keywords internal
 #' @noRd
 validate_position_indices <- function(x,
@@ -873,6 +915,7 @@ render_bfh_plot <- function(qic_data,
                             caption,
                             base_size,
                             plot_margin,
+                            ylim = NULL,
                             language = "da") {
   plot_config <- spc_plot_config(
     chart_type = chart_type,
@@ -884,6 +927,7 @@ render_bfh_plot <- function(qic_data,
     xlab = xlab,
     subtitle = subtitle,
     caption = caption,
+    ylim = ylim,
     language = language
   )
 

--- a/R/utils_bfh_qic_helpers.R
+++ b/R/utils_bfh_qic_helpers.R
@@ -16,10 +16,10 @@
 #   part:    require_sorted = TRUE, require_unique = TRUE, min = 2, max = nrow
 #   freeze:  require_scalar = TRUE, require_unique = TRUE, min = 1, max = nrow-1
 #   exclude: require_unique = TRUE, min = 1, max = nrow
-# Valider + normalisér ylim-input til coord_cartesian.
+# Valider + normaliser ylim-input til coord_cartesian.
 # Returnerer NULL (no-op: ingen coord) eller en gyldig c(min, max) hvor NA
-# er tilladt per ende (fri grænse). coord_cartesian zoomer (dropper IKKE data),
-# så vi behøver ikke validere mod data-range.
+# er tilladt per ende (fri graense). coord_cartesian zoomer (dropper IKKE data),
+# saa vi behoever ikke validere mod data-range.
 #' @keywords internal
 #' @noRd
 validate_ylim <- function(ylim) {
@@ -33,7 +33,7 @@ validate_ylim <- function(ylim) {
       call. = FALSE
     )
   }
-  # Begge ender fri => ingen grænse at sætte (accepteres uanset type,
+  # Begge ender fri => ingen graense at saette (accepteres uanset type,
   # fx logical c(NA, NA)).
   if (all(is.na(ylim))) {
     return(NULL)

--- a/man/bfh_qic.Rd
+++ b/man/bfh_qic.Rd
@@ -19,6 +19,7 @@ bfh_qic(
   freeze = NULL,
   exclude = NULL,
   cl = NULL,
+  ylim = NULL,
   multiply = 1,
   agg.fun = c("mean", "median", "sum", "sd"),
   base_size = 14,
@@ -79,6 +80,17 @@ attribute via \code{isTRUE(attr(result$summary, "cl_user_supplied"))}. The
 \code{bfh_export_pdf()} PDF surfaces a caveat note below the SPC table when
 this flag is set. See \code{bfh_extract_spc_stats()} for the discoverable
 surface.}
+
+\item{ylim}{Y-axis display limits as a numeric vector of length 2,
+\code{c(min, max)}, applied via \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}} (default: NULL =
+data-driven). Values are in the plot's data scale: proportion charts
+(\code{p}, \code{pp}) use the 0-1 proportion scale (e.g. \code{c(0, 1)} shows 0\%-100\%),
+all other charts use the absolute data scale. Use \code{NA} for a free end:
+\code{c(0, NA)} fixes the bottom at 0 with a data-driven top. Because
+\code{coord_cartesian} zooms rather than clips, data points and control-limit
+segments outside the range are NOT dropped (unlike \code{scale_y} limits) -- the
+chart simply zooms to the requested window. If \code{min >= max} (both
+non-\code{NA}) the limit is ignored with a warning.}
 
 \item{multiply}{Numeric multiplier for y-axis values, e.g. 100 to convert proportions to percentages (default: 1)}
 

--- a/tests/testthat/test-ylim.R
+++ b/tests/testthat/test-ylim.R
@@ -1,0 +1,147 @@
+# Tests for ylim (y-axis display limits via coord_cartesian)
+# validate_ylim() er ren logik (ingen fonts). Plot-niveau-tests kraever
+# BFHtheme-fonts og gates via skip_if_fonts_unavailable().
+
+# ============================================================================
+# 1. validate_ylim() - ren input-validering (ingen fonts)
+# ============================================================================
+
+test_that("validate_ylim() returns NULL for NULL input", {
+  expect_null(validate_ylim(NULL))
+})
+
+test_that("validate_ylim() passes a valid c(min, max) through", {
+  expect_equal(validate_ylim(c(0, 1)), c(0, 1))
+  expect_equal(validate_ylim(c(-5, 10)), c(-5, 10))
+})
+
+test_that("validate_ylim() allows NA per end (free limit)", {
+  expect_equal(validate_ylim(c(0, NA)), c(0, NA))
+  expect_equal(validate_ylim(c(NA, 100)), c(NA, 100))
+})
+
+test_that("validate_ylim() treats both-NA as no-op (NULL)", {
+  expect_null(validate_ylim(c(NA, NA)))
+  expect_null(validate_ylim(c(NA_real_, NA_real_)))
+})
+
+test_that("validate_ylim() warns and ignores when min >= max", {
+  expect_warning(out <- validate_ylim(c(10, 0)), "min.*>=.*max")
+  expect_null(out)
+  expect_warning(out2 <- validate_ylim(c(5, 5)), "min.*>=.*max")
+  expect_null(out2)
+})
+
+test_that("validate_ylim() rejects wrong length or non-numeric", {
+  expect_error(validate_ylim(c(0, 1, 2)), "length 2")
+  expect_error(validate_ylim(0), "length 2")
+  expect_error(validate_ylim("0-1"), "numeric")
+  expect_error(validate_ylim(list(0, 1)), "numeric")
+})
+
+# ============================================================================
+# 2. spc_plot_config() carries ylim
+# ============================================================================
+
+test_that("spc_plot_config() stores ylim field (default NULL)", {
+  cfg <- spc_plot_config(chart_type = "i", y_axis_unit = "count")
+  expect_null(cfg$ylim)
+
+  cfg2 <- spc_plot_config(chart_type = "i", y_axis_unit = "count", ylim = c(0, 1))
+  expect_equal(cfg2$ylim, c(0, 1))
+})
+
+# ============================================================================
+# 3. bfh_qic() applies coord_cartesian + does NOT drop data (font-gated)
+# ============================================================================
+
+make_ylim_test_data <- function() {
+  data.frame(
+    maaned = seq.Date(as.Date("2023-01-01"), by = "month", length.out = 12),
+    vaerdi = c(10, 12, 11, 13, 10, 14, 11, 12, 10, 13, 11, 50)
+  )
+}
+
+test_that("bfh_qic() with ylim sets coord_cartesian y-limits", {
+  skip_if_fonts_unavailable()
+  df <- make_ylim_test_data()
+
+  res <- bfh_qic(df, x = maaned, y = vaerdi, chart_type = "i", ylim = c(0, 20))
+
+  expect_equal(res$plot$coordinates$limits$y, c(0, 20))
+})
+
+test_that("bfh_qic() with ylim does NOT drop data points (zoom, not clip)", {
+  skip_if_fonts_unavailable()
+  df <- make_ylim_test_data()
+
+  # Punkt #12 (vaerdi = 50) ligger uden for ylim c(0, 20).
+  res_lim <- bfh_qic(df, x = maaned, y = vaerdi, chart_type = "i", ylim = c(0, 20))
+  res_free <- bfh_qic(df, x = maaned, y = vaerdi, chart_type = "i")
+
+  # qic_data + summary uaendret: coord_cartesian zoomer, dropper ikke.
+  expect_equal(nrow(res_lim$qic_data), nrow(res_free$qic_data))
+  expect_equal(res_lim$summary, res_free$summary)
+})
+
+test_that("bfh_qic() supports partial limit c(0, NA)", {
+  skip_if_fonts_unavailable()
+  df <- make_ylim_test_data()
+
+  res <- bfh_qic(df, x = maaned, y = vaerdi, chart_type = "i", ylim = c(0, NA))
+
+  expect_equal(res$plot$coordinates$limits$y, c(0, NA))
+})
+
+test_that("bfh_qic() without ylim leaves y-limits data-driven (NULL)", {
+  skip_if_fonts_unavailable()
+  df <- make_ylim_test_data()
+
+  res <- bfh_qic(df, x = maaned, y = vaerdi, chart_type = "i")
+
+  expect_null(res$plot$coordinates$limits$y)
+})
+
+test_that("percent p-chart plots on 0-1 proportion scale (ylim contract)", {
+  # Coordinate-space-kontrakt: for percent-charts er data på 0-1-skalaen,
+  # så ylim c(0, 1) svarer til 0%-100%. Downstream (biSPCharts) skal sende
+  # proportion-værdier, ikke 0-100. Guarder antagelsen empirisk.
+  set.seed(1)
+  d <- data.frame(
+    m = seq.Date(as.Date("2023-01-01"), by = "month", length.out = 12),
+    events = c(5, 8, 6, 7, 9, 4, 6, 8, 5, 7, 6, 9),
+    total = rep(100, 12)
+  )
+  qd <- bfh_qic(d,
+    x = m, y = events, n = total, chart_type = "p",
+    y_axis_unit = "percent", return.data = TRUE
+  )
+  # Andele 0.04-0.09, ikke 4-9 => 0-1-skala bekræftet.
+  expect_true(all(qd$y <= 1, na.rm = TRUE))
+  expect_true(max(qd$y, na.rm = TRUE) < 1)
+})
+
+test_that("bfh_qic() percent chart accepts ylim c(0, 1) for 0%-100%", {
+  skip_if_fonts_unavailable()
+  d <- data.frame(
+    m = seq.Date(as.Date("2023-01-01"), by = "month", length.out = 12),
+    events = c(5, 8, 6, 7, 9, 4, 6, 8, 5, 7, 6, 9),
+    total = rep(100, 12)
+  )
+  res <- bfh_qic(d,
+    x = m, y = events, n = total, chart_type = "p",
+    y_axis_unit = "percent", ylim = c(0, 1)
+  )
+  expect_equal(res$plot$coordinates$limits$y, c(0, 1))
+})
+
+test_that("bfh_qic() warns and ignores ylim when min >= max", {
+  skip_if_fonts_unavailable()
+  df <- make_ylim_test_data()
+
+  expect_warning(
+    res <- bfh_qic(df, x = maaned, y = vaerdi, chart_type = "i", ylim = c(20, 0)),
+    "min.*>=.*max"
+  )
+  expect_null(res$plot$coordinates$limits$y)
+})

--- a/tests/testthat/test-ylim.R
+++ b/tests/testthat/test-ylim.R
@@ -145,3 +145,30 @@ test_that("bfh_qic() warns and ignores ylim when min >= max", {
   )
   expect_null(res$plot$coordinates$limits$y)
 })
+
+test_that("ylim placerer kommentarer inden for zoom-vinduet (ej fuld data-range)", {
+  skip_if_fonts_unavailable()
+  notes_vec <- rep(NA_character_, 12)
+  notes_vec[3] <- "Intervention"
+  notes_vec[8] <- "Ny protokol"
+  df <- make_ylim_test_data()
+
+  res <- bfh_qic(df,
+    x = maaned, y = vaerdi, chart_type = "i",
+    notes = notes_vec, ylim = c(0, 20)
+  )
+  b <- ggplot2::ggplot_build(res$plot)
+
+  # Find kommentar-tekst-laget og bekraeft at dets y-positioner ligger inden
+  # for zoom-vinduet [0, 20] -- uden ylim-bevidsthed ville placeringen score
+  # mod data-range (~10-18) og kunne havne uden for det synlige vindue.
+  comment_ys <- numeric(0)
+  for (d in b$data) {
+    if (all(c("label", "y") %in% names(d)) && nrow(d) > 0) {
+      hit <- d$label %in% c("Intervention", "Ny protokol")
+      if (any(hit)) comment_ys <- c(comment_ys, d$y[hit])
+    }
+  }
+  expect_true(length(comment_ys) > 0)
+  expect_true(all(comment_ys >= 0 & comment_ys <= 20))
+})


### PR DESCRIPTION
## Summary
- `ylim`-param på `bfh_qic()` zoomer det synlige y-vindue via `coord_capped_cart` (lemon) uden at droppe datapunkter
- Target-/CL-labels er ylim-aware: placeres relativt til det zoomede vindue (inkl. gen-anvendt scale-expansion/headroom) via `ggplot_build()` panel-range
- Kommentar-placering scorer mod det zoomede vindue
- Tilføjer forklarende kommentarer + roxygen om ylim-awareness og edge case (ylim der udelukker target/CL skjuler linje + label — bevidst zoom-adfærd)
- ASCII-fix: translitererede danske tegn i ylim-kommentarer (test-source-ascii + CRAN-clean)

## Test plan
- [x] Fuld testsuite grøn ved pre-push (5589 pass, 0 fail, 70 skip)
- [x] `test-source-ascii` grøn efter translitering
- [x] `test-ylim` grøn