### PR TITLE
chore(ci): add retention-days to coverage-test-failures artifact

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -86,4 +86,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
+          retention-days: 7
           path: ${{ runner.temp }}/package


### PR DESCRIPTION
## Summary
Del af account-wide GitHub Actions-storage-oprydning (konto ramte 90% af included quota).

- `coverage-test-failures` var eneste custom upload-step **uden** `retention-days` (arvede repo-default 90d) → sat til **7d**, konsistent med `render-tests` (14d), `git-archive-render` (7d), `pdf-smoke` (7d).

## Kontekst / ikke dækket
- Dominerende volumen i BFHcharts var r-lib `*-testthat-snapshots` (1692 stk / 220MB, fra `upload-snapshots: true`) + `*-results` (på failure). Disse er **r-lib/actions-interne** og kan ikke få `retention-days` inline.
- Eksisterende gamle artifacts (1793 stk / 433MB) er ryddet manuelt.
- **Reel fælles-løftestang:** repo-default artifact retention 90→7d (Settings → Actions → General). UI-only, ingen REST-API → separat manuelt trin.

## Test plan
- [ ] Et failure-run uploader stadig coverage-test-failures (debugging bevaret)
- [ ] Artifact udløber efter 7 dage