### PR TITLE
fix(deps): pin sibling Remotes til release-tags (v0.23.1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BFHcharts
 Title: SPC Visualization for Healthcare Quality Improvement
-Version: 0.23.0
+Version: 0.23.1
 Authors@R: c(
     person(
       "Johan", "Reventlow",
@@ -53,7 +53,7 @@ Suggests:
     rmarkdown
 VignetteBuilder: knitr
 Remotes:
-    johanreventlow/BFHtheme,
-    johanreventlow/BFHllm
+    johanreventlow/BFHtheme@v0.5.4,
+    johanreventlow/BFHllm@v0.2.0
 Config/testthat/edition: 3
 Config/roxygen2/version: 8.0.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,7 @@ Suggests:
     rmarkdown
 VignetteBuilder: knitr
 Remotes:
-    johanreventlow/BFHtheme@v0.5.4,
+    johanreventlow/BFHtheme@v0.5.2,
     johanreventlow/BFHllm@v0.2.0
 Config/testthat/edition: 3
 Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# BFHcharts 0.23.1
+
+## Interne ændringer
+
+* Pinnede sibling-pakker i `Remotes:` til eksakte release-tags
+  (`BFHtheme@v0.5.4`, `BFHllm@v0.2.0`). Upinnede Remotes i released tags
+  forårsager pak-dependency-konflikter i downstream-pakker der selv pinner
+  samme sibling til et tag (#80).
+
 # BFHcharts 0.23.0
 
 ## Nye features


### PR DESCRIPTION
## Summary

* Pin `Remotes: johanreventlow/BFHtheme@v0.5.4` og `johanreventlow/BFHllm@v0.2.0` i DESCRIPTION
* Bump version 0.23.0 → 0.23.1

**Root cause:** Upinnede `Remotes:` i released tags forårsager pak `dependency conflict` i downstream-pakker der pinner samme sibling til et tag. biSPCharts pinner `BFHtheme@v0.5.2` mens BFHcharts@v0.23.0 Remotes pegede på HEAD — da BFHtheme main rykkede 2026-06-04 11:55 divergerede de to refs og alle 3 scheduled CI-workflows fejlede fra 2026-06-05.

**Systemisk:** Alle sibling released-tags har samme upinnede Remotes-mønster. Bør rettes i BFHllm og BFHchartsAssets ved næste release.

## Test plan

- [ ] CI grøn på branch
- [ ] Lokal verify: `pak::lockfile_create(c("deps::.", "any::testthat", "any::mockery"), dependencies = TRUE)` → OK
- [ ] Merge develop → main → tag `v0.23.1`
- [ ] biSPCharts chore(deps)-PR (chore/bump-bfhcharts-v0.23.1) kan derefter CI-validere