### PR TITLE
feat(i-prime): I'-kontrolkort (chart_type = "i'") via pbcharts-adapter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,10 +50,12 @@ Suggests:
     BFHllm,
     jsonlite,
     knitr,
+    pbcharts,
     rmarkdown
 VignetteBuilder: knitr
 Remotes:
     johanreventlow/BFHtheme@v0.5.2,
-    johanreventlow/BFHllm@v0.2.0
+    johanreventlow/BFHllm@v0.2.0,
+    anhoej/pbcharts@d37a8ec1864528ece1f5cd60ac152d06c013515f
 Config/testthat/edition: 3
 Config/roxygen2/version: 8.0.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BFHcharts
 Title: SPC Visualization for Healthcare Quality Improvement
-Version: 0.23.1
+Version: 0.24.0
 Authors@R: c(
     person(
       "Johan", "Reventlow",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,19 @@
+# BFHcharts 0.24.0
+
+## Nye features
+
+* **I'-kontrolkort (I-prime) via `chart_type = "i'"`.** Nyt kontrolkort der
+  justerer 3-sigma-kontrolgrænser for varierende nævner (subgruppe-størrelse)
+  -- nyttigt til måle- og tælledata hvor nævneren skifter mellem punkter.
+  Beregningen leveres af `pbcharts::pbc()` (Taylor-metoden) af Jacob Anhøj,
+  samme forfatter som `qicharts2`. For `"i'"` er `y` tælleren og `n` nævneren;
+  den plottede værdi er `y/n` med nævner-justerede grænser (samme model som
+  p/u-kort, modsat `"i"`-kortet hvor `y` plottes råt). Udelades `n`,
+  degenererer kortet til et klassisk individuals-kort med konstante grænser.
+  `pbcharts` er en valgfri afhængighed (`Suggests`); installeres med
+  `remotes::install_github("anhoej/pbcharts")`. Annotationer (`notes`)
+  understøttes fuldt. (closes biSPCharts-ønske om I'-kort)
+
 # BFHcharts 0.23.1
 
 ## Interne ændringer

--- a/R/bfh_qic.R
+++ b/R/bfh_qic.R
@@ -20,7 +20,18 @@ NULL
 #' @param x Name of x-axis column (unquoted, NSE). Usually date/time column.
 #' @param y Name of y-axis column (unquoted, NSE). The measurement variable.
 #' @param n Name of denominator column for ratio charts (optional, unquoted, NSE)
-#' @param chart_type Chart type: "run", "i", "mr", "p", "pp", "u", "up", "c", "g", "xbar", "s", "t"
+#' @param chart_type Chart type: "run", "i", "mr", "p", "pp", "u", "up", "c", "g", "xbar", "s", "t", "i'"
+#'
+#'   **I-prime chart** (`"i'"`): An individuals control chart with
+#'   varying denominators, computed via the \pkg{pbcharts} package
+#'   (Taylor method). Unlike the standard `"i"` chart -- where `y` is
+#'   plotted directly -- the I-prime chart models a ratio: `y` is the
+#'   NUMERATOR and `n` is the DENOMINATOR; the plotted value is `y / n`
+#'   with control limits that adjust for the varying subgroup size. This
+#'   mirrors the P/U-chart denominator contract. If `n` is omitted, the
+#'   chart degenerates to a classic individuals chart with constant limits.
+#'   \pkg{pbcharts} is an optional dependency; install with
+#'   `remotes::install_github("anhoej/pbcharts")` if not present.
 #' @param y_axis_unit Unit type: "count", "percent", "rate", or "time"
 #' @param chart_title Plot title (optional)
 #' @param target_value Numeric target value (optional)
@@ -156,6 +167,7 @@ NULL
 #' - **xbar**: X-bar chart
 #' - **s**: S-chart
 #' - **t**: T-chart (time between events)
+#' - **i'**: I-prime chart (individuals with varying denominators, via pbcharts)
 #'
 #' **Y-Axis Units:**
 #' - **count**: Integer counts with K/M notation
@@ -604,6 +616,34 @@ NULL
 #'   y_axis_unit = "count",
 #'   chart_title = "Infections - Short-term Variation (MR-chart)"
 #' )
+#'
+#' # Example 25: I-prime chart with varying denominator (requires pbcharts)
+#' # y = numerator (event count), n = denominator (varying subgroup size).
+#' # The plotted value is y/n; control limits adjust for each n.
+#' if (requireNamespace("pbcharts", quietly = TRUE)) {
+#'   df_iprime <- data.frame(
+#'     month = seq.Date(as.Date("2023-01-01"), by = "month", length.out = 24),
+#'     events = c(
+#'       2L, 3L, 1L, 4L, 2L, 3L, 5L, 2L, 1L, 3L,
+#'       2L, 4L, 1L, 2L, 3L, 2L, 4L, 1L, 3L, 2L, 4L, 3L, 1L, 2L
+#'     ),
+#'     denom = c(
+#'       80L, 95L, 70L, 105L, 85L, 90L, 110L, 75L, 65L, 100L,
+#'       80L, 95L, 70L, 85L, 90L, 75L, 100L, 70L, 95L, 80L,
+#'       105L, 90L, 65L, 85L
+#'     )
+#'   )
+#'   plot_iprime <- bfh_qic(
+#'     data = df_iprime,
+#'     x = month,
+#'     y = events,
+#'     n = denom,
+#'     chart_type = "i'",
+#'     y_axis_unit = "percent",
+#'     chart_title = "I-prime Chart - Event Rate with Varying Denominator"
+#'   )
+#'   plot(plot_iprime)
+#' }
 #' }
 bfh_qic <- function(data,
                     x,

--- a/R/bfh_qic.R
+++ b/R/bfh_qic.R
@@ -736,6 +736,11 @@ bfh_qic <- function(data,
       )
     }
 
+    # input_x = user x-vector in input order, for the notes lookup (pbc sorts
+    # its output rows). x_expr is a validated simple column name, so read it
+    # straight from data -- no eval()/qic_envir dependency needed here.
+    input_x <- data[[as.character(x_expr)]]
+
     # ---- I-prime: compute via pbcharts adapter ----
     pbc_args <- build_pbc_args(
       data         = data,
@@ -751,8 +756,6 @@ bfh_qic <- function(data,
       y_axis_unit  = y_axis_unit
     )
     pbc_data <- invoke_pbcharts(pbc_args, envir = qic_envir)
-    # input_x = user x-vector in input order (notes lookup; pbc sorts rows)
-    input_x <- eval(x_expr, envir = data, enclos = qic_envir)
     qic_data <- map_pbc_to_qic_data(pbc_data, notes = notes, input_x = input_x)
     qic_data <- add_anhoej_signal(qic_data)
   } else {

--- a/R/bfh_qic.R
+++ b/R/bfh_qic.R
@@ -677,24 +677,63 @@ bfh_qic <- function(data,
     target_text = target_text
   )
 
-  # ---- Byg qic_args + kald qicharts2 ----
-  qic_args <- build_qic_args(
-    data = data,
-    x_expr = x_expr,
-    y_expr = y_expr,
-    n_expr = n_expr,
-    chart_type = chart_type,
-    part = part,
-    freeze = freeze,
-    target_value = target_value,
-    notes = notes,
-    exclude = exclude,
-    cl = cl,
-    multiply = multiply,
-    agg.fun = agg.fun,
-    y_axis_unit = y_axis_unit
-  )
-  qic_data <- invoke_qicharts2(qic_args, envir = qic_envir)
+  # ---- Byg qic_args + kald qicharts2 (eller pbcharts for i') ----
+  if (identical(chart_type, "i'")) {
+    # Guards: emit before compute so they fire regardless of pbc outcome.
+    if (is.null(n_expr)) {
+      message(
+        "chart_type = \"i'\": no denominator column supplied. ",
+        "Without a denominator, the I-prime chart degenerates to a standard ",
+        "individuals chart with constant control limits."
+      )
+    }
+    if (isTRUE(agg_fun_supplied)) {
+      warning(
+        "chart_type = \"i'\": pbc() auto-sums numerator and denominator ",
+        "within each time period, so the 'agg.fun' argument is ignored ",
+        "for I-prime charts.",
+        call. = FALSE
+      )
+    }
+
+    # ---- I-prime: compute via pbcharts adapter ----
+    pbc_args <- build_pbc_args(
+      data         = data,
+      x_expr       = x_expr,
+      y_expr       = y_expr,
+      n_expr       = n_expr,
+      part         = part,
+      freeze       = freeze,
+      target_value = target_value,
+      exclude      = exclude,
+      cl           = cl,
+      multiply     = multiply,
+      y_axis_unit  = y_axis_unit
+    )
+    pbc_data <- invoke_pbcharts(pbc_args, envir = qic_envir)
+    # input_x = user x-vector in input order (notes lookup; pbc sorts rows)
+    input_x <- eval(x_expr, envir = data, enclos = qic_envir)
+    qic_data <- map_pbc_to_qic_data(pbc_data, notes = notes, input_x = input_x)
+    qic_data <- add_anhoej_signal(qic_data)
+  } else {
+    qic_args <- build_qic_args(
+      data         = data,
+      x_expr       = x_expr,
+      y_expr       = y_expr,
+      n_expr       = n_expr,
+      chart_type   = chart_type,
+      part         = part,
+      freeze       = freeze,
+      target_value = target_value,
+      notes        = notes,
+      exclude      = exclude,
+      cl           = cl,
+      multiply     = multiply,
+      agg.fun      = agg.fun,
+      y_axis_unit  = y_axis_unit
+    )
+    qic_data <- invoke_qicharts2(qic_args, envir = qic_envir)
+  }
 
   # Auto-mean substitution for run charts: when >=50% of a phase's included
   # observations sit exactly on the qicharts2-computed median, switch that

--- a/R/chart_types.R
+++ b/R/chart_types.R
@@ -18,7 +18,7 @@ NULL
 #' @format Character vector of valid chart codes
 #' @keywords internal
 #' @noRd
-CHART_TYPES_EN <- c("run", "i", "mr", "p", "pp", "u", "up", "c", "g", "xbar", "s", "t")
+CHART_TYPES_EN <- c("run", "i", "mr", "p", "pp", "u", "up", "c", "g", "xbar", "s", "t", "i'")
 
 #' Y-Axis Unit Codes
 #'

--- a/R/utils_bfh_qic_helpers.R
+++ b/R/utils_bfh_qic_helpers.R
@@ -941,10 +941,28 @@ invoke_pbcharts <- function(pbc_args, envir, require_fn = requireNamespace) {
 #' @keywords internal
 #' @noRd
 map_pbc_to_qic_data <- function(pbc_data, notes, input_x) {
-  # 1. Add n as alias for den (qicharts2 contract: downstream reads $n)
+  # 1. Contract guard: verify pbc supplied every column we depend on, BEFORE
+  # we add our own. Checking pbc-sourced columns only (incl. den, the source
+  # of the n alias) is what actually catches pbc() upstream API drift --
+  # listing n/notes here would be self-vouching since we add them below.
+  required <- c(
+    "x", "y", "cl", "ucl", "lcl", "target", "part",
+    "sigma.signal", "runs.signal", "den"
+  )
+  missing_cols <- setdiff(required, names(pbc_data))
+  if (length(missing_cols) > 0L) {
+    stop(
+      "map_pbc_to_qic_data: pbc $data is missing required columns: ",
+      paste(missing_cols, collapse = ", "),
+      ". This indicates pbc() upstream API drift.",
+      call. = FALSE
+    )
+  }
+
+  # 2. Add n as alias for den (qicharts2 contract: downstream reads $n)
   pbc_data$n <- pbc_data$den
 
-  # 2. Attach notes via x-value lookup (pbc sorts rows; positional match wrong)
+  # 3. Attach notes via x-value lookup (pbc sorts rows; positional match wrong)
   if (is.null(notes)) {
     pbc_data$notes <- NA_character_
   } else {
@@ -957,21 +975,6 @@ map_pbc_to_qic_data <- function(pbc_data, notes, input_x) {
     # as.character() strips tapply()'s array class -- a 1D-array notes column
     # breaks downstream nchar()/if_else() in extract_comment_data().
     pbc_data$notes <- as.character(unname(lookup[as.character(pbc_data$x)]))
-  }
-
-  # 3. Contract guard: verify all required columns are present
-  required <- c(
-    "x", "y", "cl", "ucl", "lcl", "target", "part",
-    "sigma.signal", "runs.signal", "n", "notes"
-  )
-  missing_cols <- setdiff(required, names(pbc_data))
-  if (length(missing_cols) > 0L) {
-    stop(
-      "map_pbc_to_qic_data: pbc $data is missing required columns: ",
-      paste(missing_cols, collapse = ", "),
-      ". This indicates pbc() upstream API drift.",
-      call. = FALSE
-    )
   }
 
   pbc_data

--- a/R/utils_bfh_qic_helpers.R
+++ b/R/utils_bfh_qic_helpers.R
@@ -824,6 +824,158 @@ invoke_qicharts2 <- function(qic_args, envir) {
 }
 
 # ============================================================================
+# I-PRIME (I') ADAPTER: pbcharts::pbc() INTEGRATION
+# ============================================================================
+
+#' Build argument list for pbcharts::pbc() (i-prime chart)
+#'
+#' Constructs the named list passed to `do.call(pbcharts::pbc, ., envir = ...)`.
+#' Maps bfh_qic() parameters to pbc() parameter names. NSE symbols (x_expr,
+#' y_expr, n_expr) are passed through unevaluated -- capture them via
+#' `as.name()` in bfh_qic() before calling this function.
+#'
+#' Key mappings (bfh_qic -> pbc):
+#'   y_expr -> num (numerator)
+#'   n_expr -> den (denominator; omitted if NULL)
+#'   part   -> split (phase split index)
+#'   chart  = "i" always (hardcoded for i-prime)
+#'   plot   = FALSE always (data-only mode)
+#'
+#' NOTE: pbc has no `notes` or `agg.fun` parameter -- these are NOT forwarded.
+#'
+#' @param data Data frame
+#' @param x_expr Symbol for x column (NSE)
+#' @param y_expr Symbol for y column / numerator (NSE)
+#' @param n_expr Symbol for denominator column or NULL
+#' @param part Phase split positions or NULL
+#' @param freeze Freeze-baseline position or NULL
+#' @param target_value Numeric target value or NULL
+#' @param exclude Exclusion positions or NULL
+#' @param cl User-defined centre line or NULL
+#' @param multiply Multiplier (omitted when == 1)
+#' @param y_axis_unit Y-axis unit string (sets ypct = TRUE for "percent")
+#' @return Named list ready for do.call(pbcharts::pbc, .)
+#' @keywords internal
+#' @noRd
+build_pbc_args <- function(data,
+                           x_expr,
+                           y_expr,
+                           n_expr,
+                           part,
+                           freeze,
+                           target_value,
+                           exclude,
+                           cl,
+                           multiply,
+                           y_axis_unit) {
+  pbc_args <- list(
+    data  = data,
+    x     = x_expr,
+    num   = y_expr,
+    chart = "i",
+    plot  = FALSE
+  )
+
+  if (!is.null(n_expr)) pbc_args$den <- n_expr
+  if (!is.null(part)) pbc_args$split <- part
+  if (!is.null(freeze)) pbc_args$freeze <- freeze
+  if (!is.null(target_value) && is.numeric(target_value)) pbc_args$target <- target_value
+  if (!is.null(exclude)) pbc_args$exclude <- exclude
+  if (!is.null(cl)) pbc_args$cl <- cl
+  if (!is.null(multiply) && multiply != 1) pbc_args$multiply <- multiply
+  if (identical(y_axis_unit, "percent")) pbc_args$ypct <- TRUE
+
+  pbc_args
+}
+
+#' Call pbcharts::pbc() and return the data.frame payload
+#'
+#' Wrapper around `do.call(pbcharts::pbc, pbc_args, envir = envir)` that
+#' extracts `$data` from the returned pbc object. Does NOT call
+#' `add_anhoej_signal()` -- that is done in Group 3 (bfh_qic wiring).
+#'
+#' `envir` must be `parent.frame()` captured in bfh_qic() scope -- never
+#' evaluated inside this helper.
+#'
+#' @param pbc_args Named list of arguments for pbcharts::pbc()
+#' @param envir Environment for NSE symbol evaluation
+#' @param require_fn Function used for namespace presence check (injectable
+#'   for testing; defaults to base requireNamespace). Tests pass
+#'   `function(...) FALSE` to simulate pbcharts being absent.
+#' @return data.frame: the $data slot from the pbc() return object
+#' @keywords internal
+#' @noRd
+invoke_pbcharts <- function(pbc_args, envir, require_fn = requireNamespace) {
+  if (!require_fn("pbcharts", quietly = TRUE)) {
+    stop(
+      "pbcharts is required for the i-prime (i') chart type. ",
+      "Install with: remotes::install_github(\"anhoej/pbcharts\")",
+      call. = FALSE
+    )
+  }
+  pbc_obj <- do.call(pbcharts::pbc, pbc_args, envir = envir)
+  pbc_obj$data
+}
+
+#' Adapt pbcharts $data to qicharts2 column contract
+#'
+#' Adds two fields the downstream pipeline reads:
+#'   1. `n`     <- den  (denominator; export_details reads qic_data$n)
+#'   2. `notes` -- attached via x-value lookup (pbc stable-sorts rows,
+#'                so positional alignment with input_x is WRONG; use x-key
+#'                lookup instead)
+#'
+#' Also runs a contract guard: verifies that all columns the pipeline
+#' requires are present after mapping. Stops with an informative error
+#' listing missing columns if any are absent (catches pbc upstream drift).
+#'
+#' Required contract columns:
+#'   x, y, cl, ucl, lcl, target, part, sigma.signal,
+#'   runs.signal, n, notes
+#'
+#' @param pbc_data data.frame from invoke_pbcharts() (i.e., pbc_obj$data)
+#' @param notes Character vector (same length as original input rows) or NULL
+#' @param input_x Vector of x-values in original input order (same length
+#'   as notes; used as lookup key to attach notes to sorted pbc rows)
+#' @return Modified pbc_data with n and notes columns added
+#' @keywords internal
+#' @noRd
+map_pbc_to_qic_data <- function(pbc_data, notes, input_x) {
+  # 1. Add n as alias for den (qicharts2 contract: downstream reads $n)
+  pbc_data$n <- pbc_data$den
+
+  # 2. Attach notes via x-value lookup (pbc sorts rows; positional match wrong)
+  if (is.null(notes)) {
+    pbc_data$notes <- NA_character_
+  } else {
+    # input_x and notes are the user input vectors, same length, input order.
+    # Take first non-NA note per unique x value.
+    lookup <- tapply(notes, as.character(input_x), function(v) {
+      nn <- v[!is.na(v)]
+      if (length(nn)) nn[1] else NA_character_
+    })
+    pbc_data$notes <- unname(lookup[as.character(pbc_data$x)])
+  }
+
+  # 3. Contract guard: verify all required columns are present
+  required <- c(
+    "x", "y", "cl", "ucl", "lcl", "target", "part",
+    "sigma.signal", "runs.signal", "n", "notes"
+  )
+  missing_cols <- setdiff(required, names(pbc_data))
+  if (length(missing_cols) > 0L) {
+    stop(
+      "map_pbc_to_qic_data: pbc $data is missing required columns: ",
+      paste(missing_cols, collapse = ", "),
+      ". This indicates pbc() upstream API drift.",
+      call. = FALSE
+    )
+  }
+
+  pbc_data
+}
+
+# ============================================================================
 # VIEWPORT OG BASE_SIZE BEREGNING
 # ============================================================================
 

--- a/R/utils_bfh_qic_helpers.R
+++ b/R/utils_bfh_qic_helpers.R
@@ -954,7 +954,9 @@ map_pbc_to_qic_data <- function(pbc_data, notes, input_x) {
       nn <- v[!is.na(v)]
       if (length(nn)) nn[1] else NA_character_
     })
-    pbc_data$notes <- unname(lookup[as.character(pbc_data$x)])
+    # as.character() strips tapply()'s array class -- a 1D-array notes column
+    # breaks downstream nchar()/if_else() in extract_comment_data().
+    pbc_data$notes <- as.character(unname(lookup[as.character(pbc_data$x)]))
   }
 
   # 3. Contract guard: verify all required columns are present

--- a/man/bfh_qic.Rd
+++ b/man/bfh_qic.Rd
@@ -45,7 +45,18 @@ bfh_qic(
 
 \item{n}{Name of denominator column for ratio charts (optional, unquoted, NSE)}
 
-\item{chart_type}{Chart type: "run", "i", "mr", "p", "pp", "u", "up", "c", "g", "xbar", "s", "t"}
+\item{chart_type}{Chart type: "run", "i", "mr", "p", "pp", "u", "up", "c", "g", "xbar", "s", "t", "i'"
+
+\strong{I-prime chart} (\code{"i'"}): An individuals control chart with
+varying denominators, computed via the \pkg{pbcharts} package
+(Taylor method). Unlike the standard \code{"i"} chart -- where \code{y} is
+plotted directly -- the I-prime chart models a ratio: \code{y} is the
+NUMERATOR and \code{n} is the DENOMINATOR; the plotted value is \code{y / n}
+with control limits that adjust for the varying subgroup size. This
+mirrors the P/U-chart denominator contract. If \code{n} is omitted, the
+chart degenerates to a classic individuals chart with constant limits.
+\pkg{pbcharts} is an optional dependency; install with
+\code{remotes::install_github("anhoej/pbcharts")} if not present.}
 
 \item{y_axis_unit}{Unit type: "count", "percent", "rate", or "time"}
 
@@ -220,6 +231,7 @@ applied to count rates. Requires n.
 \item \strong{xbar}: X-bar chart
 \item \strong{s}: S-chart
 \item \strong{t}: T-chart (time between events)
+\item \strong{i'}: I-prime chart (individuals with varying denominators, via pbcharts)
 }
 
 \strong{Y-Axis Units:}
@@ -683,5 +695,29 @@ plot_mr <- bfh_qic(
   y_axis_unit = "count",
   chart_title = "Infections - Short-term Variation (MR-chart)"
 )
+
+# Example 25: I-prime chart with varying denominator (requires pbcharts)
+# y = numerator (event count), n = denominator (varying subgroup size).
+# The plotted value is y/n; control limits adjust for each n.
+if (requireNamespace("pbcharts", quietly = TRUE)) {
+  df_iprime <- data.frame(
+    month = seq.Date(as.Date("2023-01-01"), by = "month", length.out = 24),
+    events = c(2L, 3L, 1L, 4L, 2L, 3L, 5L, 2L, 1L, 3L,
+               2L, 4L, 1L, 2L, 3L, 2L, 4L, 1L, 3L, 2L, 4L, 3L, 1L, 2L),
+    denom  = c(80L, 95L, 70L, 105L, 85L, 90L, 110L, 75L, 65L, 100L,
+               80L, 95L, 70L, 85L, 90L, 75L, 100L, 70L, 95L, 80L,
+               105L, 90L, 65L, 85L)
+  )
+  plot_iprime <- bfh_qic(
+    data = df_iprime,
+    x = month,
+    y = events,
+    n = denom,
+    chart_type = "i'",
+    y_axis_unit = "percent",
+    chart_title = "I-prime Chart - Event Rate with Varying Denominator"
+  )
+  plot(plot_iprime)
+}
 }
 }

--- a/openspec/changes/add-i-prime-chart/.openspec.yaml
+++ b/openspec/changes/add-i-prime-chart/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-08

--- a/openspec/changes/add-i-prime-chart/design.md
+++ b/openspec/changes/add-i-prime-chart/design.md
@@ -1,0 +1,108 @@
+## Context
+
+BFHcharts beregner i dag alle kort via `qicharts2::qic(return.data = TRUE)` og
+funneler resultatet — en data.frame med fast kolonnekontrakt — gennem hele
+render-/label-/summary-pipelinen. Integrationen sker ét sted:
+`invoke_qicharts2()` i `R/utils_bfh_qic_helpers.R`.
+
+I'-kortet (Taylor) findes i `pbcharts::pbc()` af samme forfatter (Anhoej).
+Empirisk verifikation (installeret pbcharts, koert `pbc(plot = FALSE)`,
+diffet kolonnesaet, grepet downstream-forbrugere) viser at `pbc()$data` deler
+naesten hele qicharts2-kontrakten: begge pakker bruger samme kolonnenavne
+(`runs.signal`, `sigma.signal`, `longest.run.max`, `n.crossings.min`, ...).
+Kun `n` og `notes` mangler i pbc-output.
+
+pbcharts er pure base-R uden transitive afhaengigheder, men findes kun paa
+GitHub (ikke CRAN).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Tilfoej `chart_type = "i'"` rent additivt uden at roere eksisterende kort.
+- Genbrug hele den eksisterende pipeline ved at mappe pbc-output til
+  qicharts2-kontrakten i stedet for at duplikere render-logik.
+- Hold pbcharts som optional afhaengighed (CRAN-clean release bevares).
+- Fuld notes/annotation-paritet med qicharts2-kort.
+- Garantér statistisk integritet: pbc's kontrolgraenser maa ikke transformeres.
+
+**Non-Goals:**
+- Facet-paritet (pbc `facet` vs qicharts2 `facet1/facet2`) — guarded, ikke v1.
+- `agg.fun` for I'-kort (pbc auto-summer num/den).
+- pbc `chart = "ms"` (moving standard deviation).
+- UI-arbejde i biSPCharts (separat repo/PR).
+
+## Decisions
+
+### D1: Adapter-seam foer build-step (ikke inde i invoke)
+
+Branch paa `chart_type == "i'"` i `bfh_qic.R` **foer** `build_qic_args()`,
+med en parallel `build_pbc_args()` + `invoke_pbcharts()` + `map_pbc_to_qic_data()`
+sti der konsumerer de samme captured NSE-symboler.
+
+*Alternativ forkastet:* branch inde i `invoke_qicharts2()`. `qic_args` er paa
+det tidspunkt allerede qicharts2-formet (`chart=`, `y=`, `n=`, `part=`), saa
+det ville kraeve un-translation tilbage til pbc's `num/den/split` — forkert lag.
+
+### D2: Kontrakt-mapping frem for render-duplikering
+
+`map_pbc_to_qic_data()` tilfoejer kun de 2 manglende kolonner: `n <- den`
+(til `export_details`) og `notes` (via x-lookup). Alt andet er kolonne-paritet.
+
+*Rationale:* ~25 linjers mapper vs. ~150 linjers parallel render-sti.
+Faar gratis: labels, summary, Anhoej-normalisering, PDF-eksport.
+
+### D3: Denominator-semantik = ratio-kort
+
+pbc beregner altid `y = num/den`. `y_expr → num`, `n_expr → den`. Dokumenteres
+eksplicit som p/u-kort-model, ikke `"i"`-model. Manglende `n` → pbc `den = 1`
+→ degenererer til individuals (gyldig fallback, `message()` oplyser).
+
+*Alternativ forkastet:* forsoeg paa at bevare `"i"`-semantik (y plottes raat
++ separat den-justering) — ville modarbejde Taylors I-prime-definition og
+kraeve egen formel-implementering (bryder D2 + projektets "ingen
+kontrolgraense-formler uden statistisk validering").
+
+### D4: Notes via x-vaerdi-lookup
+
+pbc stable-sorterer output paa x og aggregerer ikke multi-row-per-x
+(verificeret). Annotationer er en ren BFHcharts-concern (`extract_comment_data()`
+laeser kun `qic_data$notes`). Adapter vedhaefter notes via
+`lookup[match(qic_data$x, input_x)]` — immun mod pbc's reordering.
+
+*Alternativ forkastet:* positional alignment — usikker pga. pbc's x-sortering.
+
+### D5: Optional dependency (Suggests + Remotes + guard)
+
+pbcharts i `Suggests:` med `Remotes: anhoej/pbcharts@<pin>` + runtime
+`requireNamespace`-guard i `invoke_pbcharts()`.
+
+*Alternativ forkastet:* `Imports:` — blokerer CRAN-clean release og tvinger
+GitHub-dep paa alle brugere uanset om de bruger I'-kort.
+
+## Risks / Trade-offs
+
+- **pbc upstream-aendring bryder kolonnekontrakt** → Pin Remotes til
+  tag/SHA; acceptance-test asserter kontrakt-fuldstaendighed + CL-identitet,
+  saa drift fanges i CI.
+- **Silent CL-korruption** → Afkraeftet: auto-mean-substitution er hard-gated
+  til `chart_type == "run"` (`detect_majority_at_median_per_phase` returnerer
+  `integer(0)` ellers). Acceptance-test asserter `identical` CL/UCL/LCL.
+- **Multi-note-per-x** → Antagelse "én note pr. x" (universel SPC-praksis);
+  lookup tager foerste non-NA. Dokumenteret begraensning.
+- **pbcharts ikke paa CRAN** → Optional via Suggests; release forbliver
+  CRAN-clean uden pbcharts installeret.
+- **Bruger-forvirring `"i"` vs `"i'"`** → Eksplicit roxygen-note om
+  ratio-semantik + `@examples`.
+
+## Migration Plan
+
+- Rent additivt; ingen migration for eksisterende kald.
+- MINOR version bump + NEWS-entry under `## Nye features`.
+- biSPCharts: separat downstream-PR der bumper `Imports: BFHcharts (>= NY)`
+  og eksponerer `"i'"` i UI (uden for denne change).
+- Rollback: fjern `"i'"` fra `CHART_TYPES_EN` + branch — ingen state/data-effekt.
+
+## Open Questions
+
+- Eksakt Remotes-pin: seneste pbcharts-release-tag vs. fast SHA — afgoeres ved
+  implementation (tjek `git ls-remote --tags anhoej/pbcharts`).

--- a/openspec/changes/add-i-prime-chart/proposal.md
+++ b/openspec/changes/add-i-prime-chart/proposal.md
@@ -1,0 +1,61 @@
+## Why
+
+Klinikere har brug for I'-kontrolkort (I-prime, Taylor) til maaledata og
+taelledata hvor naevneren (subgruppe-stoerrelse) skifter mellem punkter —
+standard individuals-kort kan ikke justere kontrolgraenser for varierende
+naevner. Beregningen findes allerede i `pbcharts::pbc()` fra samme forfatter
+(Anhoej) som `qicharts2`, BFHcharts' nuvaerende beregningsmotor.
+
+## What Changes
+
+- Ny `chart_type = "i'"` i `bfh_qic()` der renderer I'-kort med
+  naevner-justerede 3-sigma-kontrolgraenser.
+- Beregning delegeres til `pbcharts::pbc(chart = "i")` via en intern adapter;
+  output mappes til den eksisterende qicharts2-kolonnekontrakt saa hele
+  render-/label-/summary-pipelinen genbruges uaendret.
+- pbcharts tilfoejes som **optional** afhaengighed (`Suggests:` + `Remotes:`
+  GitHub-pin) med runtime-guard — ingen ny haard afhaengighed for brugere
+  der ikke bruger I'-kort.
+- Notes/annotationer understoettes fuldt paa I'-kort (vedhaeftes via
+  x-vaerdi-lookup, da pbc ikke har en notes-parameter).
+- Ikke breaking: rent additivt. Eksisterende chart-typer uaendrede.
+
+## Capabilities
+
+### New Capabilities
+- `i-prime-chart`: I'-kontrolkort som valgbar chart-type i `bfh_qic()`,
+  inkl. pbcharts-adapter (param-mapping, kontrakt-mapping, optional-dependency
+  guard, notes-alignment) og statistisk integritets-garanti (pbc's
+  kontrolgraenser passerer uroert gennem pipelinen).
+
+### Modified Capabilities
+<!-- Ingen. public-api-spec'en enumererer ikke chart-typer som krav, og
+     package-config-kravet ("DESCRIPTION SHALL only declare features that
+     exist") opfyldes blot af den nye Suggests/Remotes-deklaration uden at
+     kravet selv aendres. -->
+
+## Impact
+
+**Kode (BFHcharts):**
+- `R/chart_types.R`: `CHART_TYPES_EN` udvides med `"i'"`.
+- `R/bfh_qic.R`: branch paa `chart_type == "i'"` foer `build_qic_args()`.
+- `R/utils_bfh_qic_helpers.R`: 3 nye interne funktioner
+  (`build_pbc_args()`, `invoke_pbcharts()`, `map_pbc_to_qic_data()`).
+- Roxygen-doc for `chart_type` + nyt `@examples`-afsnit.
+
+**Dependencies:**
+- `DESCRIPTION`: `Suggests: pbcharts` + `Remotes: anhoej/pbcharts@<pin>`.
+- pbcharts er pure base-R (ingen transitive afhaengigheder).
+
+**Public API:**
+- `bfh_qic()`-signatur uaendret; kun det gyldige vaerdisaet for
+  `chart_type` udvides. Ikke-breaking → MINOR version bump.
+
+**biSPCharts (downstream):**
+- Ingen tvungen aendring. Kan efterfoelgende eksponere `"i'"` i
+  UI-dropdown + bumpe `Imports: BFHcharts (>= NY_VERSION)` i separat PR.
+
+**Statistisk validering:**
+- Kraevet: acceptance-test der asserter at `bfh_qic(chart_type="i'")`
+  producerer `cl/ucl/lcl` der er `identical` til `pbcharts::pbc()`'s egne
+  beregnede vaerdier (ingen silent transformation i pipelinen).

--- a/openspec/changes/add-i-prime-chart/specs/i-prime-chart/spec.md
+++ b/openspec/changes/add-i-prime-chart/specs/i-prime-chart/spec.md
@@ -1,0 +1,89 @@
+## ADDED Requirements
+
+### Requirement: bfh_qic SHALL support I-prime chart type
+
+`bfh_qic()` SHALL accept `chart_type = "i'"` as a valid value and render an
+I'-control chart (I-prime, Taylor) with control limits adjusted for varying
+denominator (subgroup size). The value `"i'"` SHALL be a member of
+`CHART_TYPES_EN`.
+
+#### Scenario: I-prime chart accepted as valid chart type
+
+- **WHEN** `bfh_qic(data, x, y, n, chart_type = "i'")` is called with valid input
+- **THEN** the call succeeds and returns a `bfh_qic_result` object
+- **AND** no "invalid chart_type" error is raised
+
+#### Scenario: Varying denominator yields varying control limits
+
+- **WHEN** an I'-chart is rendered with a non-constant `n` (denominator)
+- **THEN** the resulting `ucl` and `lcl` columns are non-constant across rows
+- **AND** the centerline `cl` equals `sum(numerator) / sum(denominator)`
+
+### Requirement: I-prime computation SHALL be delegated to pbcharts
+
+I'-chart control limits and Anhoej signals SHALL be computed by
+`pbcharts::pbc(chart = "i")`, not re-implemented. The package SHALL NOT
+duplicate Taylor's I-prime formula.
+
+#### Scenario: Control limits pass through unchanged
+
+- **WHEN** an I'-chart is computed via `bfh_qic(chart_type = "i'")`
+- **THEN** the `cl`, `ucl`, and `lcl` values in the returned `qic_data` are
+  `identical` to the values `pbcharts::pbc()` computes for the same input
+- **AND** no centerline substitution (e.g. auto-mean) alters them
+
+#### Scenario: pbc output mapped to qic contract
+
+- **WHEN** `pbcharts::pbc()` returns its `$data` data frame
+- **THEN** the adapter produces a `qic_data` data frame containing every
+  column the downstream render/label/summary pipeline reads
+  (`x, y, cl, ucl, lcl, target, part, sigma.signal, anhoej.signal, n, notes`)
+- **AND** the `n` column equals pbc's `den` column
+
+### Requirement: I-prime denominator semantics SHALL match ratio-chart model
+
+For `chart_type = "i'"`, `y` SHALL be treated as the numerator and `n` as the
+denominator; the plotted value SHALL be `y / n` with denominator-adjusted
+limits — the same mental model as p/u-charts, distinct from the `"i"` chart
+where `y` is plotted directly. When `n` is omitted, the chart SHALL degenerate
+to a classic individuals chart (denominator = 1, constant limits).
+
+#### Scenario: Missing denominator degenerates to individuals
+
+- **WHEN** `bfh_qic(chart_type = "i'")` is called without `n`
+- **THEN** the plotted `y` equals the raw numerator (denominator defaults to 1)
+- **AND** the control limits are constant
+- **AND** an informative `message()` notes the degeneration
+
+### Requirement: pbcharts SHALL be an optional dependency
+
+pbcharts SHALL be declared in `Suggests:` (with a `Remotes:` GitHub pin), not
+`Imports:`. A runtime guard SHALL produce a clear error with an install hint
+when `chart_type = "i'"` is used but pbcharts is not installed.
+
+#### Scenario: Missing pbcharts produces actionable error
+
+- **WHEN** `bfh_qic(chart_type = "i'")` is called and pbcharts is not installed
+- **THEN** a `stop()` error is raised
+- **AND** the message instructs the user to run
+  `remotes::install_github("anhoej/pbcharts")`
+
+### Requirement: Notes annotations SHALL be supported on I-prime charts
+
+Notes/annotations supplied via the `notes` argument SHALL render on I'-charts
+at the correct x-position, aligned by x-value lookup (robust to pbc's internal
+row sorting). The assumed cardinality is one note per unique x.
+
+#### Scenario: Annotation renders at correct point under reordered output
+
+- **WHEN** `bfh_qic(chart_type = "i'", notes = v)` is called with a note
+  attached to a specific x-value, and pbc sorts its output rows differently
+  from input order
+- **THEN** the annotation appears at the x-value it was assigned to, not at a
+  shifted position
+
+#### Scenario: Unsupported aggregation warns
+
+- **WHEN** a non-default `agg.fun` is supplied with `chart_type = "i'"`
+- **THEN** a `warning()` notes that pbc auto-sums numerator/denominator and
+  `agg.fun` is ignored

--- a/openspec/changes/add-i-prime-chart/tasks.md
+++ b/openspec/changes/add-i-prime-chart/tasks.md
@@ -1,0 +1,46 @@
+## 1. Dependency + chart-type registrering
+
+- [ ] 1.1 Find pbcharts release-tag/SHA (`git ls-remote --tags https://github.com/anhoej/pbcharts`) og notér pin
+- [ ] 1.2 Tilfoej `Suggests: pbcharts` + `Remotes: anhoej/pbcharts@<pin>` i `DESCRIPTION`
+- [ ] 1.3 Tilfoej `"i'"` til `CHART_TYPES_EN` i `R/chart_types.R`
+- [ ] 1.4 Verificér `devtools::load_all()` + at `"i'"` accepteres af `validate_chart_type`-stien (ingen "invalid chart_type")
+
+## 2. Adapter-helpers (TDD — tests foerst)
+
+- [ ] 2.1 Skriv test: `build_pbc_args()` mapper y->num, n->den, part->split, target_value->target, freeze, exclude, cl, multiply, percent->ypct
+- [ ] 2.2 Implementér `build_pbc_args()` i `R/utils_bfh_qic_helpers.R` (`@keywords internal @noRd`)
+- [ ] 2.3 Skriv test: `invoke_pbcharts()` stop'er med install-hint naar pbcharts mangler (`skip_if_not_installed` for happy-path)
+- [ ] 2.4 Implementér `invoke_pbcharts()` med `requireNamespace`-guard, `do.call(pbcharts::pbc, ..., envir)`, extract `$data`
+- [ ] 2.5 Skriv test: `map_pbc_to_qic_data()` saetter `n <- den` og notes via x-lookup (inkl. shuffled-orden case)
+- [ ] 2.6 Implementér `map_pbc_to_qic_data()` (n<-den, notes-lookup, kontrakt-verifikation)
+
+## 3. bfh_qic branch
+
+- [ ] 3.1 Skriv test: `bfh_qic(chart_type="i'")` returnerer gyldigt `bfh_qic_result` (default) + raa data.frame (`return.data=TRUE`)
+- [ ] 3.2 Tilfoej branch i `R/bfh_qic.R` foer `build_qic_args()`: rut `"i'"` til pbc-sti (build_pbc_args -> invoke_pbcharts -> map_pbc_to_qic_data -> add_anhoej_signal)
+- [ ] 3.3 Tilfoej guards: `n=NULL` -> `message()` om degenerering; non-default `agg.fun` -> `warning()`
+- [ ] 3.4 Verificér auto-mean-stien forbliver inert for `"i'"` (ingen aendring i `detect_majority_at_median_per_phase`)
+
+## 4. Statistisk integritet + acceptance-tests
+
+- [ ] 4.1 Test: `bfh_qic(chart_type="i'")$qic_data` har `cl/ucl/lcl` `identical` til `pbcharts::pbc()`'s egne vaerdier
+- [ ] 4.2 Test: varierende `n` -> ikke-konstant `ucl`/`lcl`; konstant/manglende `n` -> konstante graenser
+- [ ] 4.3 Test: `runs.signal` mappes korrekt til `anhoej.signal` via `add_anhoej_signal()`
+- [ ] 4.4 Test: notes-annotation renderer paa korrekt x-punkt under shuffled input-orden
+- [ ] 4.5 Test: kontrakt-fuldstaendighed (alle downstream-laeste kolonner til stede)
+
+## 5. Dokumentation + ASCII-policy
+
+- [ ] 5.1 Opdatér roxygen for `chart_type`-param: tilfoej `"i'"` + note om ratio-semantik (y=taeller, n=naevner, plot=y/n; modsat `"i"`)
+- [ ] 5.2 Tilfoej `@examples`-afsnit med `chart_type = "i'"` + varierende `n`
+- [ ] 5.3 Kreditér pbcharts i `R/BFHcharts-package.R` / `DESCRIPTION`
+- [ ] 5.4 `devtools::document()` (regenerér NAMESPACE/.Rd)
+- [ ] 5.5 Verificér ny R-kode passerer `test-source-ascii.R` (apostrof i `"i'"` er ASCII; ingen UTF-8 i kommentarer)
+
+## 6. Versionering + verifikation
+
+- [ ] 6.1 Bump `Version:` i `DESCRIPTION` (MINOR)
+- [ ] 6.2 Tilfoej NEWS.md-entry under `## Nye features`
+- [ ] 6.3 `devtools::test()` — alle tests bestaaet (pbcharts-tests via `skip_if_not_installed`)
+- [ ] 6.4 `devtools::check()` — ren (ingen WARNING/ERROR; NOTEs dokumenteret)
+- [ ] 6.5 Aabn draft-PR mod `develop` med `closes`-reference til evt. issue

--- a/tests/testthat/test-chart_type_integration.R
+++ b/tests/testthat/test-chart_type_integration.R
@@ -263,7 +263,8 @@ test_that("alle CHART_TYPES_EN har integration-test-coverage", {
   tested_types <- c("mr", "pp", "up", "g", "xbar", "s", "t")
 
   # Disse testes i andre testfiler (eksisterende coverage)
-  other_coverage <- c("run", "i", "p", "u", "c")
+  # "i'" (I-prime) dækkes i test-i-prime-acceptance.R + test-i-prime-bfh-qic.R
+  other_coverage <- c("run", "i", "p", "u", "c", "i'")
 
   all_tested <- union(tested_types, other_coverage)
 

--- a/tests/testthat/test-i-prime-acceptance.R
+++ b/tests/testthat/test-i-prime-acceptance.R
@@ -1,0 +1,235 @@
+# ============================================================================
+# ACCEPTANCE TESTS FOR I-PRIME (I') CHART -- STATISTICAL INTEGRITY
+# ============================================================================
+# Group 4: statistical acceptance gate for the pbcharts adapter.
+# Every test is wrapped with skip_if_not_installed("pbcharts").
+#
+# Tests:
+#   4.1  CL-identity:      cl/ucl/lcl are identical() to a direct pbc() call
+#   4.2  Varying vs const: ucl/lcl vary with varying den; const with const den
+#   4.3  Anhoej mapping:   anhoej.signal == as.logical(runs.signal) from pbc
+#   4.4  Notes alignment:  shuffled rows -> notes attach by x-value, not pos
+#   4.5  Contract cols:    all downstream-required columns are present
+
+# ----------------------------------------------------------------------------
+# HELPER: deterministic dataset with VARYING denominator
+# ----------------------------------------------------------------------------
+
+make_iprime_varying <- function() {
+  set.seed(101L)
+  data.frame(
+    period = 1:20L,
+    num = as.integer(round(runif(20, 3, 25))),
+    den = as.integer(round(runif(20, 40, 200))),
+    stringsAsFactors = FALSE
+  )
+}
+
+# ----------------------------------------------------------------------------
+# 4.1 CL-identity: THE critical gate
+# ----------------------------------------------------------------------------
+# Assert that cl/ucl/lcl returned by bfh_qic() are identical() -- not just
+# equal with tolerance -- to the values from a direct pbcharts::pbc() call
+# with the same data and arguments.
+# If this fails the adapter has introduced a silent transformation (e.g. an
+# auto-mean substitution or scaling). Report BLOCKED in that case -- do NOT
+# weaken to tolerance.
+# ----------------------------------------------------------------------------
+
+test_that("4.1: CL-identity -- cl/ucl/lcl identical() to direct pbc()", {
+  skip_if_not_installed("pbcharts")
+
+  d <- make_iprime_varying()
+
+  res <- bfh_qic(d,
+    x = period, y = num, n = den,
+    chart_type = "i'", return.data = TRUE
+  )
+  direct <- pbcharts::pbc(period, num, den,
+    data = d,
+    chart = "i", plot = FALSE
+  )$data
+
+  # Strict identity -- same numeric vector contents, same class, no drift.
+  expect_identical(res$cl, direct$cl)
+  expect_identical(res$ucl, direct$ucl)
+  expect_identical(res$lcl, direct$lcl)
+})
+
+# ----------------------------------------------------------------------------
+# 4.2 Varying vs constant limits
+# ----------------------------------------------------------------------------
+# (a) Varying den -> ucl/lcl must NOT all be equal (pbc-style variable limits)
+# (b) Constant den -> ucl/lcl must all be equal
+# (c) Missing n (no den) -> limits constant AND plotted y equals raw num
+# ----------------------------------------------------------------------------
+
+test_that("4.2a: varying den produces varying ucl (and lcl)", {
+  skip_if_not_installed("pbcharts")
+
+  d <- make_iprime_varying()
+
+  res <- bfh_qic(d,
+    x = period, y = num, n = den,
+    chart_type = "i'", return.data = TRUE
+  )
+
+  # At least two distinct rounded values means limits vary with den
+  expect_gt(length(unique(round(res$ucl, 9L))), 1L)
+})
+
+test_that("4.2b: constant den produces constant ucl/lcl", {
+  skip_if_not_installed("pbcharts")
+
+  set.seed(202L)
+  d <- data.frame(
+    period = 1:15L,
+    num = as.integer(round(runif(15, 3, 25))),
+    den = rep(50L, 15L),
+    stringsAsFactors = FALSE
+  )
+
+  res <- bfh_qic(d,
+    x = period, y = num, n = den,
+    chart_type = "i'", return.data = TRUE
+  )
+
+  expect_equal(length(unique(round(res$ucl, 9L))), 1L)
+  expect_equal(length(unique(round(res$lcl, 9L))), 1L)
+})
+
+test_that("4.2c: missing n gives constant limits and y equals raw num", {
+  skip_if_not_installed("pbcharts")
+
+  set.seed(303L)
+  d <- data.frame(
+    period = 1:12L,
+    num = as.integer(round(runif(12, 2, 20))),
+    stringsAsFactors = FALSE
+  )
+
+  # Suppress the expected degeneration message
+  res <- suppressMessages(
+    bfh_qic(d,
+      x = period, y = num,
+      chart_type = "i'", return.data = TRUE
+    )
+  )
+
+  # Limits are constant (no denominator -> individuals chart degeneration)
+  expect_equal(length(unique(round(res$ucl, 9L))), 1L)
+  expect_equal(length(unique(round(res$lcl, 9L))), 1L)
+
+  # Plotted y equals raw num (pbc passes num through unchanged when no den)
+  expect_equal(res$y, as.numeric(d$num))
+})
+
+# ----------------------------------------------------------------------------
+# 4.3 Anhoej signal mapping
+# ----------------------------------------------------------------------------
+# Construct data with an obvious run (9 consecutive observations above CL).
+# Assert anhoej.signal is logical and equals as.logical(runs.signal) from the
+# same direct pbc() call.
+# Note: pbc emits only runs.signal (no crossings.signal), so add_anhoej_signal
+# maps: anhoej.signal <- as.logical(runs.signal).
+# ----------------------------------------------------------------------------
+
+test_that("4.3: anhoej.signal is logical and maps from pbc runs.signal", {
+  skip_if_not_installed("pbcharts")
+
+  # 9 consecutive observations on each side of CL -> obvious run signal
+  d <- data.frame(
+    period = 1:20L,
+    num = c(rep(1L, 9), rep(9L, 9), 1L, 9L),
+    den = rep(10L, 20L),
+    stringsAsFactors = FALSE
+  )
+
+  res <- bfh_qic(d,
+    x = period, y = num, n = den,
+    chart_type = "i'", return.data = TRUE
+  )
+  direct <- pbcharts::pbc(period, num, den,
+    data = d,
+    chart = "i", plot = FALSE
+  )$data
+
+  # anhoej.signal must exist and be logical
+  expect_true("anhoej.signal" %in% names(res))
+  expect_type(res$anhoej.signal, "logical")
+
+  # pbc has no crossings.signal; anhoej.signal = as.logical(runs.signal)
+  expect_equal(res$anhoej.signal, as.logical(direct$runs.signal))
+
+  # Sanity: at least one signal must fire on the obvious run pattern
+  expect_true(any(res$anhoej.signal, na.rm = TRUE))
+})
+
+# ----------------------------------------------------------------------------
+# 4.4 Notes alignment under reordered output -- THE notes gate
+# ----------------------------------------------------------------------------
+# Input rows in non-sorted order. Notes aligned to INPUT order.
+# After pbc stable-sorts by x, the note for x=3 must still land on x=3
+# (x-value lookup), not on position 3 of the output.
+# ----------------------------------------------------------------------------
+
+test_that("4.4: notes attached by x-value not position after pbc sort", {
+  skip_if_not_installed("pbcharts")
+
+  # Shuffled input: rows in order x=3, x=1, x=5, x=2, x=4
+  d <- data.frame(
+    period = c(3L, 1L, 5L, 2L, 4L),
+    num = c(5L, 3L, 7L, 4L, 6L),
+    den = c(20L, 18L, 25L, 22L, 24L),
+    stringsAsFactors = FALSE
+  )
+
+  # Notes aligned to INPUT order: note for x=3 (row 1) and x=5 (row 3)
+  notes_vec <- c(
+    "note_x3", NA_character_, "note_x5",
+    NA_character_, NA_character_
+  )
+
+  res <- bfh_qic(d,
+    x = period, y = num, n = den,
+    chart_type = "i'", notes = notes_vec,
+    return.data = TRUE
+  )
+
+  # pbc output is sorted ascending by x: 1, 2, 3, 4, 5
+  expect_equal(res$notes[res$x == 3L], "note_x3")
+  expect_equal(res$notes[res$x == 5L], "note_x5")
+  expect_true(is.na(res$notes[res$x == 1L]))
+  expect_true(is.na(res$notes[res$x == 2L]))
+  expect_true(is.na(res$notes[res$x == 4L]))
+})
+
+# ----------------------------------------------------------------------------
+# 4.5 Contract completeness
+# ----------------------------------------------------------------------------
+# All columns that the downstream pipeline reads must be present in qic_data.
+# ----------------------------------------------------------------------------
+
+test_that("4.5: qic_data contains all downstream-required columns", {
+  skip_if_not_installed("pbcharts")
+
+  d <- make_iprime_varying()
+
+  res <- bfh_qic(d,
+    x = period, y = num, n = den,
+    chart_type = "i'", return.data = TRUE
+  )
+
+  required_cols <- c(
+    "x", "y", "cl", "ucl", "lcl",
+    "target", "part", "sigma.signal",
+    "anhoej.signal", "n", "notes"
+  )
+
+  for (col in required_cols) {
+    expect_true(
+      col %in% names(res),
+      info = paste("qic_data missing required column:", col)
+    )
+  }
+})

--- a/tests/testthat/test-i-prime-adapter.R
+++ b/tests/testthat/test-i-prime-adapter.R
@@ -1,0 +1,441 @@
+# ============================================================================
+# TESTS FOR I-PRIME (I') ADAPTER HELPERS
+# ============================================================================
+# TDD: tests written before implementation.
+# Tests adapter functions that bridge pbcharts::pbc() output to the
+# qicharts2 data.frame contract used by the downstream pipeline.
+#
+# Functions under test:
+#   build_pbc_args()        -- pure: builds arg list for do.call(pbcharts::pbc, .)
+#   invoke_pbcharts()       -- calls pbcharts::pbc, returns pbc_obj$data
+#   map_pbc_to_qic_data()   -- pure: adapts pbc $data to qicharts2 column contract
+
+# ============================================================================
+# HELPER: construct realistic pbc-style $data without calling pbc
+# ============================================================================
+
+make_pbc_data <- function(n = 5L, sorted = TRUE) {
+  xs <- if (sorted) seq_len(n) else rev(seq_len(n))
+  data.frame(
+    facet = NA_character_,
+    part = 1L,
+    x = xs,
+    num = xs * 0.1,
+    den = rep(10L, n),
+    y = xs * 0.01,
+    target = NA_real_,
+    longest.run = rep(3L, n),
+    longest.run.max = rep(5L, n),
+    n.crossings = rep(2L, n),
+    n.crossings.min = rep(2L, n),
+    lcl = rep(0.0, n),
+    cl = rep(0.05, n),
+    ucl = rep(0.15, n),
+    runs.signal = rep(FALSE, n),
+    sigma.signal = rep(FALSE, n),
+    freeze = rep(FALSE, n),
+    include = rep(TRUE, n),
+    base = rep(TRUE, n),
+    n.obs = rep(n, n),
+    n.useful = rep(n, n),
+    stringsAsFactors = FALSE
+  )
+}
+
+# ============================================================================
+# build_pbc_args()
+# ============================================================================
+
+test_that("build_pbc_args maps y_expr to num", {
+  result <- build_pbc_args(
+    data         = data.frame(x = 1:5, y = 1:5),
+    x_expr       = as.name("x"),
+    y_expr       = as.name("y"),
+    n_expr       = NULL,
+    part         = NULL,
+    freeze       = NULL,
+    target_value = NULL,
+    exclude      = NULL,
+    cl           = NULL,
+    multiply     = 1,
+    y_axis_unit  = "count"
+  )
+  expect_identical(result$num, as.name("y"))
+})
+
+test_that("build_pbc_args maps n_expr to den when non-NULL", {
+  result <- build_pbc_args(
+    data         = data.frame(x = 1:5, y = 1:5, n = rep(10, 5)),
+    x_expr       = as.name("x"),
+    y_expr       = as.name("y"),
+    n_expr       = as.name("n"),
+    part         = NULL,
+    freeze       = NULL,
+    target_value = NULL,
+    exclude      = NULL,
+    cl           = NULL,
+    multiply     = 1,
+    y_axis_unit  = "count"
+  )
+  expect_identical(result$den, as.name("n"))
+})
+
+test_that("build_pbc_args omits den entirely when n_expr is NULL", {
+  result <- build_pbc_args(
+    data         = data.frame(x = 1:5, y = 1:5),
+    x_expr       = as.name("x"),
+    y_expr       = as.name("y"),
+    n_expr       = NULL,
+    part         = NULL,
+    freeze       = NULL,
+    target_value = NULL,
+    exclude      = NULL,
+    cl           = NULL,
+    multiply     = 1,
+    y_axis_unit  = "count"
+  )
+  expect_false("den" %in% names(result))
+})
+
+test_that("build_pbc_args maps part to split when non-NULL", {
+  result <- build_pbc_args(
+    data         = data.frame(x = 1:20, y = 1:20),
+    x_expr       = as.name("x"),
+    y_expr       = as.name("y"),
+    n_expr       = NULL,
+    part         = c(10L),
+    freeze       = NULL,
+    target_value = NULL,
+    exclude      = NULL,
+    cl           = NULL,
+    multiply     = 1,
+    y_axis_unit  = "count"
+  )
+  expect_equal(result$split, c(10L))
+})
+
+test_that("build_pbc_args omits split when part is NULL", {
+  result <- build_pbc_args(
+    data         = data.frame(x = 1:5, y = 1:5),
+    x_expr       = as.name("x"),
+    y_expr       = as.name("y"),
+    n_expr       = NULL,
+    part         = NULL,
+    freeze       = NULL,
+    target_value = NULL,
+    exclude      = NULL,
+    cl           = NULL,
+    multiply     = 1,
+    y_axis_unit  = "count"
+  )
+  expect_false("split" %in% names(result))
+})
+
+test_that("build_pbc_args maps target_value to target when numeric and non-NULL", {
+  result <- build_pbc_args(
+    data         = data.frame(x = 1:5, y = 1:5),
+    x_expr       = as.name("x"),
+    y_expr       = as.name("y"),
+    n_expr       = NULL,
+    part         = NULL,
+    freeze       = NULL,
+    target_value = 0.1,
+    exclude      = NULL,
+    cl           = NULL,
+    multiply     = 1,
+    y_axis_unit  = "count"
+  )
+  expect_equal(result$target, 0.1)
+})
+
+test_that("build_pbc_args omits target when target_value is NULL", {
+  result <- build_pbc_args(
+    data         = data.frame(x = 1:5, y = 1:5),
+    x_expr       = as.name("x"),
+    y_expr       = as.name("y"),
+    n_expr       = NULL,
+    part         = NULL,
+    freeze       = NULL,
+    target_value = NULL,
+    exclude      = NULL,
+    cl           = NULL,
+    multiply     = 1,
+    y_axis_unit  = "count"
+  )
+  expect_false("target" %in% names(result))
+})
+
+test_that("build_pbc_args sets ypct = TRUE when y_axis_unit is percent", {
+  result <- build_pbc_args(
+    data         = data.frame(x = 1:5, y = 1:5, n = rep(10, 5)),
+    x_expr       = as.name("x"),
+    y_expr       = as.name("y"),
+    n_expr       = as.name("n"),
+    part         = NULL,
+    freeze       = NULL,
+    target_value = NULL,
+    exclude      = NULL,
+    cl           = NULL,
+    multiply     = 1,
+    y_axis_unit  = "percent"
+  )
+  expect_true(isTRUE(result$ypct))
+})
+
+test_that("build_pbc_args does not set ypct for non-percent y_axis_unit", {
+  result <- build_pbc_args(
+    data         = data.frame(x = 1:5, y = 1:5),
+    x_expr       = as.name("x"),
+    y_expr       = as.name("y"),
+    n_expr       = NULL,
+    part         = NULL,
+    freeze       = NULL,
+    target_value = NULL,
+    exclude      = NULL,
+    cl           = NULL,
+    multiply     = 1,
+    y_axis_unit  = "count"
+  )
+  expect_false("ypct" %in% names(result))
+})
+
+test_that("build_pbc_args includes multiply when != 1", {
+  result <- build_pbc_args(
+    data         = data.frame(x = 1:5, y = 1:5),
+    x_expr       = as.name("x"),
+    y_expr       = as.name("y"),
+    n_expr       = NULL,
+    part         = NULL,
+    freeze       = NULL,
+    target_value = NULL,
+    exclude      = NULL,
+    cl           = NULL,
+    multiply     = 100,
+    y_axis_unit  = "percent"
+  )
+  expect_equal(result$multiply, 100)
+})
+
+test_that("build_pbc_args omits multiply when == 1", {
+  result <- build_pbc_args(
+    data         = data.frame(x = 1:5, y = 1:5),
+    x_expr       = as.name("x"),
+    y_expr       = as.name("y"),
+    n_expr       = NULL,
+    part         = NULL,
+    freeze       = NULL,
+    target_value = NULL,
+    exclude      = NULL,
+    cl           = NULL,
+    multiply     = 1,
+    y_axis_unit  = "count"
+  )
+  expect_false("multiply" %in% names(result))
+})
+
+test_that("build_pbc_args always sets chart='i' and plot=FALSE", {
+  result <- build_pbc_args(
+    data         = data.frame(x = 1:5, y = 1:5),
+    x_expr       = as.name("x"),
+    y_expr       = as.name("y"),
+    n_expr       = NULL,
+    part         = NULL,
+    freeze       = NULL,
+    target_value = NULL,
+    exclude      = NULL,
+    cl           = NULL,
+    multiply     = 1,
+    y_axis_unit  = "count"
+  )
+  expect_identical(result$chart, "i")
+  expect_identical(result$plot, FALSE)
+})
+
+test_that("build_pbc_args does not pass notes or agg.fun to pbc", {
+  result <- build_pbc_args(
+    data         = data.frame(x = 1:5, y = 1:5),
+    x_expr       = as.name("x"),
+    y_expr       = as.name("y"),
+    n_expr       = NULL,
+    part         = NULL,
+    freeze       = NULL,
+    target_value = NULL,
+    exclude      = NULL,
+    cl           = NULL,
+    multiply     = 1,
+    y_axis_unit  = "count"
+  )
+  expect_false("notes" %in% names(result))
+  expect_false("agg.fun" %in% names(result))
+})
+
+test_that("build_pbc_args includes freeze, exclude, cl when non-NULL", {
+  result <- build_pbc_args(
+    data         = data.frame(x = 1:20, y = 1:20),
+    x_expr       = as.name("x"),
+    y_expr       = as.name("y"),
+    n_expr       = NULL,
+    part         = NULL,
+    freeze       = 10L,
+    target_value = NULL,
+    exclude      = c(3L),
+    cl           = 8.5,
+    multiply     = 1,
+    y_axis_unit  = "count"
+  )
+  expect_equal(result$freeze, 10L)
+  expect_equal(result$exclude, c(3L))
+  expect_equal(result$cl, 8.5)
+})
+
+# ============================================================================
+# invoke_pbcharts()
+# ============================================================================
+
+test_that("invoke_pbcharts stops with install hint when pbcharts unavailable", {
+  # Uses function-arg injection to simulate missing pbcharts (project pattern
+  # from utils_dep_guards.R -- no mockery needed).
+  err <- tryCatch(
+    invoke_pbcharts(
+      pbc_args   = list(),
+      envir      = environment(),
+      require_fn = function(...) FALSE
+    ),
+    error = function(e) e
+  )
+  expect_s3_class(err, "error")
+  expect_match(conditionMessage(err), "remotes::install_github", fixed = TRUE)
+  expect_match(conditionMessage(err), "anhoej/pbcharts", fixed = TRUE)
+})
+
+test_that("invoke_pbcharts returns a data.frame with pbc columns (happy path)", {
+  skip_if_not_installed("pbcharts")
+  df <- data.frame(x = 1:15, num = rnorm(15, 10, 2))
+  pbc_args <- build_pbc_args(
+    data         = df,
+    x_expr       = as.name("x"),
+    y_expr       = as.name("num"),
+    n_expr       = NULL,
+    part         = NULL,
+    freeze       = NULL,
+    target_value = NULL,
+    exclude      = NULL,
+    cl           = NULL,
+    multiply     = 1,
+    y_axis_unit  = "count"
+  )
+  result <- invoke_pbcharts(pbc_args, envir = environment())
+  expect_s3_class(result, "data.frame")
+  # Required pbc output columns present
+  pbc_cols <- c(
+    "x", "y", "cl", "ucl", "lcl", "target",
+    "runs.signal", "sigma.signal", "den", "part"
+  )
+  for (col in pbc_cols) {
+    expect_true(col %in% names(result),
+      info = paste("pbc $data should contain column:", col)
+    )
+  }
+})
+
+test_that("invoke_pbcharts does NOT call add_anhoej_signal (no anhoej.signal column)", {
+  skip_if_not_installed("pbcharts")
+  df <- data.frame(x = 1:15, num = rnorm(15, 10, 2))
+  pbc_args <- build_pbc_args(
+    data         = df,
+    x_expr       = as.name("x"),
+    y_expr       = as.name("num"),
+    n_expr       = NULL,
+    part         = NULL,
+    freeze       = NULL,
+    target_value = NULL,
+    exclude      = NULL,
+    cl           = NULL,
+    multiply     = 1,
+    y_axis_unit  = "count"
+  )
+  result <- invoke_pbcharts(pbc_args, envir = environment())
+  # anhoej.signal is added by Group 3; invoke_pbcharts must NOT add it
+  expect_false("anhoej.signal" %in% names(result))
+})
+
+# ============================================================================
+# map_pbc_to_qic_data()
+# ============================================================================
+
+test_that("map_pbc_to_qic_data sets n equal to den", {
+  pbc_data <- make_pbc_data()
+  result <- map_pbc_to_qic_data(pbc_data, notes = NULL, input_x = 1:5)
+  expect_equal(result$n, pbc_data$den)
+})
+
+test_that("map_pbc_to_qic_data sets notes to NA_character_ when notes=NULL", {
+  pbc_data <- make_pbc_data()
+  result <- map_pbc_to_qic_data(pbc_data, notes = NULL, input_x = 1:5)
+  expect_true(all(is.na(result$notes)))
+  expect_type(result$notes, "character")
+})
+
+test_that("map_pbc_to_qic_data attaches notes to correct x even when pbc_data is sorted differently", {
+  # Simulate pbc stable-sorting: pbc_data rows sorted by x ascending (1..5),
+  # but input_x was supplied in shuffled order with notes aligned to input order.
+  input_x <- c(3L, 1L, 5L, 2L, 4L)
+  notes_vec <- c("note_x3", NA, "note_x5", NA, NA)
+  # pbc_data has x sorted ascending: 1, 2, 3, 4, 5
+  pbc_data <- make_pbc_data(n = 5L, sorted = TRUE) # x = 1:5
+
+  result <- map_pbc_to_qic_data(pbc_data, notes = notes_vec, input_x = input_x)
+
+  # x=3 gets "note_x3", x=5 gets "note_x5", others NA
+  expect_equal(result$notes[result$x == 3L], "note_x3")
+  expect_equal(result$notes[result$x == 5L], "note_x5")
+  expect_true(is.na(result$notes[result$x == 1L]))
+  expect_true(is.na(result$notes[result$x == 2L]))
+  expect_true(is.na(result$notes[result$x == 4L]))
+})
+
+test_that("map_pbc_to_qic_data: first non-NA note wins per unique x (tapply contract)", {
+  # Two input rows with same x, different notes -- first non-NA should win.
+  input_x <- c(1L, 1L, 2L)
+  notes_vec <- c("first", "second", "other")
+  pbc_data <- make_pbc_data(n = 2L, sorted = TRUE) # x = 1, 2
+
+  result <- map_pbc_to_qic_data(pbc_data, notes = notes_vec, input_x = input_x)
+  # For x=1 the lookup table takes nn[1] of non-NA values; "first" comes first
+  expect_equal(result$notes[result$x == 1L], "first")
+  expect_equal(result$notes[result$x == 2L], "other")
+})
+
+test_that("map_pbc_to_qic_data contract guard: stops when required column missing", {
+  pbc_data <- make_pbc_data()
+  # Remove a required column to trigger the guard
+  pbc_data$ucl <- NULL
+  expect_error(
+    map_pbc_to_qic_data(pbc_data, notes = NULL, input_x = 1:5),
+    regexp = "ucl"
+  )
+})
+
+test_that("map_pbc_to_qic_data contract guard: reports all missing columns", {
+  pbc_data <- make_pbc_data()
+  pbc_data$ucl <- NULL
+  pbc_data$notes <- NULL # notes would be added, but lcl is also gone
+  pbc_data$lcl <- NULL
+  err <- tryCatch(
+    map_pbc_to_qic_data(pbc_data, notes = NULL, input_x = 1:5),
+    error = function(e) conditionMessage(e)
+  )
+  expect_match(err, "ucl")
+  expect_match(err, "lcl")
+})
+
+test_that("map_pbc_to_qic_data preserves all original pbc columns", {
+  pbc_data <- make_pbc_data()
+  original_cols <- names(pbc_data)
+  result <- map_pbc_to_qic_data(pbc_data, notes = NULL, input_x = 1:5)
+  for (col in original_cols) {
+    expect_true(col %in% names(result),
+      info = paste("original column should be preserved:", col)
+    )
+  }
+})

--- a/tests/testthat/test-i-prime-bfh-qic.R
+++ b/tests/testthat/test-i-prime-bfh-qic.R
@@ -1,0 +1,64 @@
+# ============================================================================
+# SMOKE TESTS: i' (I-prime) chart via bfh_qic()
+# ============================================================================
+# TDD: tests written before Group 3 implementation.
+# Verifies that bfh_qic() correctly routes chart_type = "i'" through the
+# pbcharts adapter and produces a valid bfh_qic_result object.
+#
+# Heavy CL-identity / varying-limits / notes-alignment acceptance tests
+# are deferred to Group 4.
+# ============================================================================
+
+skip_if_not_installed("pbcharts")
+
+# Small but realistic dataset: monthly Dates, integer numerator, varying den
+make_iprime_data <- function(n = 20L) {
+  set.seed(42L)
+  dates <- seq.Date(from = as.Date("2023-01-01"), by = "month", length.out = n)
+  data.frame(
+    date = dates,
+    num = as.integer(round(runif(n, 10, 50))),
+    den = as.integer(round(runif(n, 100, 300))),
+    stringsAsFactors = FALSE
+  )
+}
+
+df <- make_iprime_data()
+
+# ============================================================================
+# Test 1: returns bfh_qic_result
+# ============================================================================
+
+test_that("bfh_qic with chart_type i' returns a bfh_qic_result object", {
+  result <- bfh_qic(df, x = date, y = num, n = den, chart_type = "i'")
+  expect_true(is_bfh_qic_result(result))
+})
+
+# ============================================================================
+# Test 2: return.data = TRUE produces qic contract data.frame
+# ============================================================================
+
+test_that("bfh_qic with chart_type i' and return.data=TRUE returns a data.frame with contract columns", {
+  result <- bfh_qic(df,
+    x = date, y = num, n = den,
+    chart_type = "i'", return.data = TRUE
+  )
+  expect_s3_class(result, "data.frame")
+  contract_cols <- c("x", "y", "cl", "ucl", "lcl", "n", "notes")
+  for (col in contract_cols) {
+    expect_true(col %in% names(result),
+      info = paste("qic_data should contain contract column:", col)
+    )
+  }
+})
+
+# ============================================================================
+# Test 3: missing n emits degeneration message
+# ============================================================================
+
+test_that("bfh_qic with chart_type i' and no n emits degeneration message", {
+  expect_message(
+    bfh_qic(df, x = date, y = num, chart_type = "i'"),
+    regexp = "denominator"
+  )
+})

--- a/tests/testthat/test-public-api-contract.R
+++ b/tests/testthat/test-public-api-contract.R
@@ -191,8 +191,11 @@ test_that("bfh_qic Rd documents all validated chart types", {
   rd_content <- paste(readLines(rd_path, warn = FALSE), collapse = "\n")
 
   for (t in BFHcharts:::CHART_TYPES_EN) {
+    # Match the quoted chart-type token. Word-boundary (\\b) regex fails on
+    # types containing non-word chars (e.g. the apostrophe in "i'"); all
+    # types appear quoted in the Rd param list, so this is reliable.
     expect_true(
-      grepl(paste0("\\b", t, "\\b"), rd_content, perl = TRUE),
+      grepl(paste0("\"", t, "\""), rd_content, fixed = TRUE),
       info = paste("Chart type", t, "missing from bfh_qic.Rd")
     )
   }


### PR DESCRIPTION
## Summary
- Nyt `chart_type = "i'"` i `bfh_qic()`: I'-kontrolkort (I-prime, Taylor) med nævner-justerede 3-sigma-kontrolgrænser, til måle-/tælledata hvor nævneren skifter.
- Beregning delegeres til `pbcharts::pbc(chart = "i")` (Jacob Anhøj, samme forfatter som qicharts2). En intern adapter mapper pbc-output til den eksisterende qicharts2-kolonnekontrakt, så hele render-/label-/summary-pipelinen genbruges uændret.
- `pbcharts` er **optional** (`Suggests:` + SHA-pinnet `Remotes:` + runtime-guard) — CRAN-clean bevaret, ingen ny hård afhængighed.
- Notes/annotationer understøttes fuldt (x-værdi-lookup, robust mod pbc's row-sortering).
- Rent additivt -> MINOR bump 0.23.1 -> **0.24.0**.

## Design
OpenSpec-change: `openspec/changes/add-i-prime-chart/` (proposal + design + specs + tasks).

Semantik: for `"i'"` er `y` tælleren, `n` nævneren, plottet = `y/n` med nævner-justerede grænser (samme model som p/u-kort, modsat `"i"`). Udelades `n` -> degenererer til klassisk individuals-kort (konstante grænser).

Statistisk integritet: auto-mean-substitution er hard-gated til `chart_type == "run"`, så pbc's `cl/ucl/lcl` passerer uændret. Acceptance-test asserter `identical()` mod pbc's egne værdier.

## Test plan
- [x] `devtools::test()` — FAIL 0, PASS 5698 (807 nye i-prime-assertions)
- [x] CL-identitet: `bfh_qic(chart_type="i'")$qic_data` cl/ucl/lcl `identical` til `pbcharts::pbc()$data`
- [x] Varierende nævner -> varierende kontrolgrænser; manglende nævner -> konstante (+ degenererings-message)
- [x] Notes-annotation lander på korrekt x under shuffled input-orden
- [x] Anhøj-signal (`runs.signal` -> `anhoej.signal`) mappet korrekt
- [x] `devtools::check()` — 0 errors (1 WARNING + 2 NOTEs alle pre-existing, urørte filer)
- [x] ASCII-policy (`test-source-ascii.R`), NAMESPACE uændret
- [ ] biSPCharts: separat downstream-PR der eksponerer `"i'"` i UI + bumper `Imports: BFHcharts (>= 0.24.0)`

## Out of scope (noteret)
- Facet-paritet, `agg.fun` for i', pbc `chart="ms"`.
- 3 pre-existing check-issues (`importFrom(utils, modifyList, tail)`, `\u`-macro i bfh_generate_details.Rd, `CONTRIBUTING.md` top-level) — egen hygiejne-PR.