### PR TITLE
refactor(i-prime)!: rename chart_type "i'" to "ip"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BFHcharts
 Title: SPC Visualization for Healthcare Quality Improvement
-Version: 0.24.0
+Version: 0.25.0
 Authors@R: c(
     person(
       "Johan", "Reventlow",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# BFHcharts 0.25.0
+
+## Breaking changes
+
+* **`chart_type`-værdien for I-prime-kortet er omdøbt fra `"i'"` til `"ip"`.**
+  Den nye værdi følger samme mønster som de øvrige prime-kort (`pp` for
+  P-prime, `up` for U-prime), og undgår apostroffen der gav unødig friktion
+  i string-håndtering. Migration: skift `chart_type = "i'"` til
+  `chart_type = "ip"` i alle kald. Det er en hård omdøbning -- `"i'"`
+  accepteres ikke længere. (Introduceret i 0.24.0; omdøbt før bred udbredelse.)
+
 # BFHcharts 0.24.0
 
 ## Nye features

--- a/R/bfh_qic.R
+++ b/R/bfh_qic.R
@@ -20,9 +20,9 @@ NULL
 #' @param x Name of x-axis column (unquoted, NSE). Usually date/time column.
 #' @param y Name of y-axis column (unquoted, NSE). The measurement variable.
 #' @param n Name of denominator column for ratio charts (optional, unquoted, NSE)
-#' @param chart_type Chart type: "run", "i", "mr", "p", "pp", "u", "up", "c", "g", "xbar", "s", "t", "i'"
+#' @param chart_type Chart type: "run", "i", "mr", "p", "pp", "u", "up", "c", "g", "xbar", "s", "t", "ip"
 #'
-#'   **I-prime chart** (`"i'"`): An individuals control chart with
+#'   **I-prime chart** (`"ip"`): An individuals control chart with
 #'   varying denominators, computed via the \pkg{pbcharts} package
 #'   (Taylor method). Unlike the standard `"i"` chart -- where `y` is
 #'   plotted directly -- the I-prime chart models a ratio: `y` is the
@@ -167,7 +167,7 @@ NULL
 #' - **xbar**: X-bar chart
 #' - **s**: S-chart
 #' - **t**: T-chart (time between events)
-#' - **i'**: I-prime chart (individuals with varying denominators, via pbcharts)
+#' - **ip**: I-prime chart (individuals with varying denominators, via pbcharts)
 #'
 #' **Y-Axis Units:**
 #' - **count**: Integer counts with K/M notation
@@ -638,7 +638,7 @@ NULL
 #'     x = month,
 #'     y = events,
 #'     n = denom,
-#'     chart_type = "i'",
+#'     chart_type = "ip",
 #'     y_axis_unit = "percent",
 #'     chart_title = "I-prime Chart - Event Rate with Varying Denominator"
 #'   )
@@ -717,19 +717,19 @@ bfh_qic <- function(data,
     target_text = target_text
   )
 
-  # ---- Byg qic_args + kald qicharts2 (eller pbcharts for i') ----
-  if (identical(chart_type, "i'")) {
+  # ---- Byg qic_args + kald qicharts2 (eller pbcharts for ip) ----
+  if (identical(chart_type, "ip")) {
     # Guards: emit before compute so they fire regardless of pbc outcome.
     if (is.null(n_expr)) {
       message(
-        "chart_type = \"i'\": no denominator column supplied. ",
+        "chart_type = \"ip\": no denominator column supplied. ",
         "Without a denominator, the I-prime chart degenerates to a standard ",
         "individuals chart with constant control limits."
       )
     }
     if (isTRUE(agg_fun_supplied)) {
       warning(
-        "chart_type = \"i'\": pbc() auto-sums numerator and denominator ",
+        "chart_type = \"ip\": pbc() auto-sums numerator and denominator ",
         "within each time period, so the 'agg.fun' argument is ignored ",
         "for I-prime charts.",
         call. = FALSE

--- a/R/chart_types.R
+++ b/R/chart_types.R
@@ -18,7 +18,7 @@ NULL
 #' @format Character vector of valid chart codes
 #' @keywords internal
 #' @noRd
-CHART_TYPES_EN <- c("run", "i", "mr", "p", "pp", "u", "up", "c", "g", "xbar", "s", "t", "i'")
+CHART_TYPES_EN <- c("run", "i", "mr", "p", "pp", "u", "up", "c", "g", "xbar", "s", "t", "ip")
 
 #' Y-Axis Unit Codes
 #'

--- a/R/utils_bfh_qic_helpers.R
+++ b/R/utils_bfh_qic_helpers.R
@@ -908,7 +908,7 @@ build_pbc_args <- function(data,
 invoke_pbcharts <- function(pbc_args, envir, require_fn = requireNamespace) {
   if (!require_fn("pbcharts", quietly = TRUE)) {
     stop(
-      "pbcharts is required for the i-prime (i') chart type. ",
+      "pbcharts is required for the i-prime (ip) chart type. ",
       "Install with: remotes::install_github(\"anhoej/pbcharts\")",
       call. = FALSE
     )

--- a/man/bfh_qic.Rd
+++ b/man/bfh_qic.Rd
@@ -45,9 +45,9 @@ bfh_qic(
 
 \item{n}{Name of denominator column for ratio charts (optional, unquoted, NSE)}
 
-\item{chart_type}{Chart type: "run", "i", "mr", "p", "pp", "u", "up", "c", "g", "xbar", "s", "t", "i'"
+\item{chart_type}{Chart type: "run", "i", "mr", "p", "pp", "u", "up", "c", "g", "xbar", "s", "t", "ip"
 
-\strong{I-prime chart} (\code{"i'"}): An individuals control chart with
+\strong{I-prime chart} (\code{"ip"}): An individuals control chart with
 varying denominators, computed via the \pkg{pbcharts} package
 (Taylor method). Unlike the standard \code{"i"} chart -- where \code{y} is
 plotted directly -- the I-prime chart models a ratio: \code{y} is the
@@ -231,7 +231,7 @@ applied to count rates. Requires n.
 \item \strong{xbar}: X-bar chart
 \item \strong{s}: S-chart
 \item \strong{t}: T-chart (time between events)
-\item \strong{i'}: I-prime chart (individuals with varying denominators, via pbcharts)
+\item \strong{ip}: I-prime chart (individuals with varying denominators, via pbcharts)
 }
 
 \strong{Y-Axis Units:}
@@ -702,18 +702,22 @@ plot_mr <- bfh_qic(
 if (requireNamespace("pbcharts", quietly = TRUE)) {
   df_iprime <- data.frame(
     month = seq.Date(as.Date("2023-01-01"), by = "month", length.out = 24),
-    events = c(2L, 3L, 1L, 4L, 2L, 3L, 5L, 2L, 1L, 3L,
-               2L, 4L, 1L, 2L, 3L, 2L, 4L, 1L, 3L, 2L, 4L, 3L, 1L, 2L),
-    denom  = c(80L, 95L, 70L, 105L, 85L, 90L, 110L, 75L, 65L, 100L,
-               80L, 95L, 70L, 85L, 90L, 75L, 100L, 70L, 95L, 80L,
-               105L, 90L, 65L, 85L)
+    events = c(
+      2L, 3L, 1L, 4L, 2L, 3L, 5L, 2L, 1L, 3L,
+      2L, 4L, 1L, 2L, 3L, 2L, 4L, 1L, 3L, 2L, 4L, 3L, 1L, 2L
+    ),
+    denom = c(
+      80L, 95L, 70L, 105L, 85L, 90L, 110L, 75L, 65L, 100L,
+      80L, 95L, 70L, 85L, 90L, 75L, 100L, 70L, 95L, 80L,
+      105L, 90L, 65L, 85L
+    )
   )
   plot_iprime <- bfh_qic(
     data = df_iprime,
     x = month,
     y = events,
     n = denom,
-    chart_type = "i'",
+    chart_type = "ip",
     y_axis_unit = "percent",
     chart_title = "I-prime Chart - Event Rate with Varying Denominator"
   )

--- a/openspec/changes/add-i-prime-chart/design.md
+++ b/openspec/changes/add-i-prime-chart/design.md
@@ -18,7 +18,7 @@ GitHub (ikke CRAN).
 ## Goals / Non-Goals
 
 **Goals:**
-- Tilfoej `chart_type = "i'"` rent additivt uden at roere eksisterende kort.
+- Tilfoej `chart_type = "ip"` rent additivt uden at roere eksisterende kort.
 - Genbrug hele den eksisterende pipeline ved at mappe pbc-output til
   qicharts2-kontrakten i stedet for at duplikere render-logik.
 - Hold pbcharts som optional afhaengighed (CRAN-clean release bevares).
@@ -35,7 +35,7 @@ GitHub (ikke CRAN).
 
 ### D1: Adapter-seam foer build-step (ikke inde i invoke)
 
-Branch paa `chart_type == "i'"` i `bfh_qic.R` **foer** `build_qic_args()`,
+Branch paa `chart_type == "ip"` i `bfh_qic.R` **foer** `build_qic_args()`,
 med en parallel `build_pbc_args()` + `invoke_pbcharts()` + `map_pbc_to_qic_data()`
 sti der konsumerer de samme captured NSE-symboler.
 
@@ -91,7 +91,7 @@ GitHub-dep paa alle brugere uanset om de bruger I'-kort.
   lookup tager foerste non-NA. Dokumenteret begraensning.
 - **pbcharts ikke paa CRAN** → Optional via Suggests; release forbliver
   CRAN-clean uden pbcharts installeret.
-- **Bruger-forvirring `"i"` vs `"i'"`** → Eksplicit roxygen-note om
+- **Bruger-forvirring `"i"` vs `"ip"`** → Eksplicit roxygen-note om
   ratio-semantik + `@examples`.
 
 ## Migration Plan
@@ -99,8 +99,8 @@ GitHub-dep paa alle brugere uanset om de bruger I'-kort.
 - Rent additivt; ingen migration for eksisterende kald.
 - MINOR version bump + NEWS-entry under `## Nye features`.
 - biSPCharts: separat downstream-PR der bumper `Imports: BFHcharts (>= NY)`
-  og eksponerer `"i'"` i UI (uden for denne change).
-- Rollback: fjern `"i'"` fra `CHART_TYPES_EN` + branch — ingen state/data-effekt.
+  og eksponerer `"ip"` i UI (uden for denne change).
+- Rollback: fjern `"ip"` fra `CHART_TYPES_EN` + branch — ingen state/data-effekt.
 
 ## Open Questions
 

--- a/openspec/changes/add-i-prime-chart/proposal.md
+++ b/openspec/changes/add-i-prime-chart/proposal.md
@@ -8,7 +8,7 @@ naevner. Beregningen findes allerede i `pbcharts::pbc()` fra samme forfatter
 
 ## What Changes
 
-- Ny `chart_type = "i'"` i `bfh_qic()` der renderer I'-kort med
+- Ny `chart_type = "ip"` i `bfh_qic()` der renderer I'-kort med
   naevner-justerede 3-sigma-kontrolgraenser.
 - Beregning delegeres til `pbcharts::pbc(chart = "i")` via en intern adapter;
   output mappes til den eksisterende qicharts2-kolonnekontrakt saa hele
@@ -37,8 +37,8 @@ naevner. Beregningen findes allerede i `pbcharts::pbc()` fra samme forfatter
 ## Impact
 
 **Kode (BFHcharts):**
-- `R/chart_types.R`: `CHART_TYPES_EN` udvides med `"i'"`.
-- `R/bfh_qic.R`: branch paa `chart_type == "i'"` foer `build_qic_args()`.
+- `R/chart_types.R`: `CHART_TYPES_EN` udvides med `"ip"`.
+- `R/bfh_qic.R`: branch paa `chart_type == "ip"` foer `build_qic_args()`.
 - `R/utils_bfh_qic_helpers.R`: 3 nye interne funktioner
   (`build_pbc_args()`, `invoke_pbcharts()`, `map_pbc_to_qic_data()`).
 - Roxygen-doc for `chart_type` + nyt `@examples`-afsnit.
@@ -52,10 +52,10 @@ naevner. Beregningen findes allerede i `pbcharts::pbc()` fra samme forfatter
   `chart_type` udvides. Ikke-breaking → MINOR version bump.
 
 **biSPCharts (downstream):**
-- Ingen tvungen aendring. Kan efterfoelgende eksponere `"i'"` i
+- Ingen tvungen aendring. Kan efterfoelgende eksponere `"ip"` i
   UI-dropdown + bumpe `Imports: BFHcharts (>= NY_VERSION)` i separat PR.
 
 **Statistisk validering:**
-- Kraevet: acceptance-test der asserter at `bfh_qic(chart_type="i'")`
+- Kraevet: acceptance-test der asserter at `bfh_qic(chart_type="ip")`
   producerer `cl/ucl/lcl` der er `identical` til `pbcharts::pbc()`'s egne
   beregnede vaerdier (ingen silent transformation i pipelinen).

--- a/openspec/changes/add-i-prime-chart/specs/i-prime-chart/spec.md
+++ b/openspec/changes/add-i-prime-chart/specs/i-prime-chart/spec.md
@@ -2,14 +2,14 @@
 
 ### Requirement: bfh_qic SHALL support I-prime chart type
 
-`bfh_qic()` SHALL accept `chart_type = "i'"` as a valid value and render an
+`bfh_qic()` SHALL accept `chart_type = "ip"` as a valid value and render an
 I'-control chart (I-prime, Taylor) with control limits adjusted for varying
-denominator (subgroup size). The value `"i'"` SHALL be a member of
+denominator (subgroup size). The value `"ip"` SHALL be a member of
 `CHART_TYPES_EN`.
 
 #### Scenario: I-prime chart accepted as valid chart type
 
-- **WHEN** `bfh_qic(data, x, y, n, chart_type = "i'")` is called with valid input
+- **WHEN** `bfh_qic(data, x, y, n, chart_type = "ip")` is called with valid input
 - **THEN** the call succeeds and returns a `bfh_qic_result` object
 - **AND** no "invalid chart_type" error is raised
 
@@ -27,7 +27,7 @@ duplicate Taylor's I-prime formula.
 
 #### Scenario: Control limits pass through unchanged
 
-- **WHEN** an I'-chart is computed via `bfh_qic(chart_type = "i'")`
+- **WHEN** an I'-chart is computed via `bfh_qic(chart_type = "ip")`
 - **THEN** the `cl`, `ucl`, and `lcl` values in the returned `qic_data` are
   `identical` to the values `pbcharts::pbc()` computes for the same input
 - **AND** no centerline substitution (e.g. auto-mean) alters them
@@ -42,7 +42,7 @@ duplicate Taylor's I-prime formula.
 
 ### Requirement: I-prime denominator semantics SHALL match ratio-chart model
 
-For `chart_type = "i'"`, `y` SHALL be treated as the numerator and `n` as the
+For `chart_type = "ip"`, `y` SHALL be treated as the numerator and `n` as the
 denominator; the plotted value SHALL be `y / n` with denominator-adjusted
 limits — the same mental model as p/u-charts, distinct from the `"i"` chart
 where `y` is plotted directly. When `n` is omitted, the chart SHALL degenerate
@@ -50,7 +50,7 @@ to a classic individuals chart (denominator = 1, constant limits).
 
 #### Scenario: Missing denominator degenerates to individuals
 
-- **WHEN** `bfh_qic(chart_type = "i'")` is called without `n`
+- **WHEN** `bfh_qic(chart_type = "ip")` is called without `n`
 - **THEN** the plotted `y` equals the raw numerator (denominator defaults to 1)
 - **AND** the control limits are constant
 - **AND** an informative `message()` notes the degeneration
@@ -59,11 +59,11 @@ to a classic individuals chart (denominator = 1, constant limits).
 
 pbcharts SHALL be declared in `Suggests:` (with a `Remotes:` GitHub pin), not
 `Imports:`. A runtime guard SHALL produce a clear error with an install hint
-when `chart_type = "i'"` is used but pbcharts is not installed.
+when `chart_type = "ip"` is used but pbcharts is not installed.
 
 #### Scenario: Missing pbcharts produces actionable error
 
-- **WHEN** `bfh_qic(chart_type = "i'")` is called and pbcharts is not installed
+- **WHEN** `bfh_qic(chart_type = "ip")` is called and pbcharts is not installed
 - **THEN** a `stop()` error is raised
 - **AND** the message instructs the user to run
   `remotes::install_github("anhoej/pbcharts")`
@@ -76,7 +76,7 @@ row sorting). The assumed cardinality is one note per unique x.
 
 #### Scenario: Annotation renders at correct point under reordered output
 
-- **WHEN** `bfh_qic(chart_type = "i'", notes = v)` is called with a note
+- **WHEN** `bfh_qic(chart_type = "ip", notes = v)` is called with a note
   attached to a specific x-value, and pbc sorts its output rows differently
   from input order
 - **THEN** the annotation appears at the x-value it was assigned to, not at a
@@ -84,6 +84,6 @@ row sorting). The assumed cardinality is one note per unique x.
 
 #### Scenario: Unsupported aggregation warns
 
-- **WHEN** a non-default `agg.fun` is supplied with `chart_type = "i'"`
+- **WHEN** a non-default `agg.fun` is supplied with `chart_type = "ip"`
 - **THEN** a `warning()` notes that pbc auto-sums numerator/denominator and
   `agg.fun` is ignored

--- a/openspec/changes/add-i-prime-chart/tasks.md
+++ b/openspec/changes/add-i-prime-chart/tasks.md
@@ -2,8 +2,8 @@
 
 - [ ] 1.1 Find pbcharts release-tag/SHA (`git ls-remote --tags https://github.com/anhoej/pbcharts`) og notér pin
 - [ ] 1.2 Tilfoej `Suggests: pbcharts` + `Remotes: anhoej/pbcharts@<pin>` i `DESCRIPTION`
-- [ ] 1.3 Tilfoej `"i'"` til `CHART_TYPES_EN` i `R/chart_types.R`
-- [ ] 1.4 Verificér `devtools::load_all()` + at `"i'"` accepteres af `validate_chart_type`-stien (ingen "invalid chart_type")
+- [ ] 1.3 Tilfoej `"ip"` til `CHART_TYPES_EN` i `R/chart_types.R`
+- [ ] 1.4 Verificér `devtools::load_all()` + at `"ip"` accepteres af `validate_chart_type`-stien (ingen "invalid chart_type")
 
 ## 2. Adapter-helpers (TDD — tests foerst)
 
@@ -16,14 +16,14 @@
 
 ## 3. bfh_qic branch
 
-- [ ] 3.1 Skriv test: `bfh_qic(chart_type="i'")` returnerer gyldigt `bfh_qic_result` (default) + raa data.frame (`return.data=TRUE`)
-- [ ] 3.2 Tilfoej branch i `R/bfh_qic.R` foer `build_qic_args()`: rut `"i'"` til pbc-sti (build_pbc_args -> invoke_pbcharts -> map_pbc_to_qic_data -> add_anhoej_signal)
+- [ ] 3.1 Skriv test: `bfh_qic(chart_type="ip")` returnerer gyldigt `bfh_qic_result` (default) + raa data.frame (`return.data=TRUE`)
+- [ ] 3.2 Tilfoej branch i `R/bfh_qic.R` foer `build_qic_args()`: rut `"ip"` til pbc-sti (build_pbc_args -> invoke_pbcharts -> map_pbc_to_qic_data -> add_anhoej_signal)
 - [ ] 3.3 Tilfoej guards: `n=NULL` -> `message()` om degenerering; non-default `agg.fun` -> `warning()`
-- [ ] 3.4 Verificér auto-mean-stien forbliver inert for `"i'"` (ingen aendring i `detect_majority_at_median_per_phase`)
+- [ ] 3.4 Verificér auto-mean-stien forbliver inert for `"ip"` (ingen aendring i `detect_majority_at_median_per_phase`)
 
 ## 4. Statistisk integritet + acceptance-tests
 
-- [ ] 4.1 Test: `bfh_qic(chart_type="i'")$qic_data` har `cl/ucl/lcl` `identical` til `pbcharts::pbc()`'s egne vaerdier
+- [ ] 4.1 Test: `bfh_qic(chart_type="ip")$qic_data` har `cl/ucl/lcl` `identical` til `pbcharts::pbc()`'s egne vaerdier
 - [ ] 4.2 Test: varierende `n` -> ikke-konstant `ucl`/`lcl`; konstant/manglende `n` -> konstante graenser
 - [ ] 4.3 Test: `runs.signal` mappes korrekt til `anhoej.signal` via `add_anhoej_signal()`
 - [ ] 4.4 Test: notes-annotation renderer paa korrekt x-punkt under shuffled input-orden
@@ -31,11 +31,11 @@
 
 ## 5. Dokumentation + ASCII-policy
 
-- [ ] 5.1 Opdatér roxygen for `chart_type`-param: tilfoej `"i'"` + note om ratio-semantik (y=taeller, n=naevner, plot=y/n; modsat `"i"`)
-- [ ] 5.2 Tilfoej `@examples`-afsnit med `chart_type = "i'"` + varierende `n`
+- [ ] 5.1 Opdatér roxygen for `chart_type`-param: tilfoej `"ip"` + note om ratio-semantik (y=taeller, n=naevner, plot=y/n; modsat `"i"`)
+- [ ] 5.2 Tilfoej `@examples`-afsnit med `chart_type = "ip"` + varierende `n`
 - [ ] 5.3 Kreditér pbcharts i `R/BFHcharts-package.R` / `DESCRIPTION`
 - [ ] 5.4 `devtools::document()` (regenerér NAMESPACE/.Rd)
-- [ ] 5.5 Verificér ny R-kode passerer `test-source-ascii.R` (apostrof i `"i'"` er ASCII; ingen UTF-8 i kommentarer)
+- [ ] 5.5 Verificér ny R-kode passerer `test-source-ascii.R` (apostrof i `"ip"` er ASCII; ingen UTF-8 i kommentarer)
 
 ## 6. Versionering + verifikation
 

--- a/tests/testthat/test-chart_type_integration.R
+++ b/tests/testthat/test-chart_type_integration.R
@@ -263,8 +263,8 @@ test_that("alle CHART_TYPES_EN har integration-test-coverage", {
   tested_types <- c("mr", "pp", "up", "g", "xbar", "s", "t")
 
   # Disse testes i andre testfiler (eksisterende coverage)
-  # "i'" (I-prime) dækkes i test-i-prime-acceptance.R + test-i-prime-bfh-qic.R
-  other_coverage <- c("run", "i", "p", "u", "c", "i'")
+  # "ip" (I-prime) dækkes i test-i-prime-acceptance.R + test-i-prime-bfh-qic.R
+  other_coverage <- c("run", "i", "p", "u", "c", "ip")
 
   all_tested <- union(tested_types, other_coverage)
 

--- a/tests/testthat/test-i-prime-acceptance.R
+++ b/tests/testthat/test-i-prime-acceptance.R
@@ -1,5 +1,5 @@
 # ============================================================================
-# ACCEPTANCE TESTS FOR I-PRIME (I') CHART -- STATISTICAL INTEGRITY
+# ACCEPTANCE TESTS FOR I-PRIME (ip) CHART -- STATISTICAL INTEGRITY
 # ============================================================================
 # Group 4: statistical acceptance gate for the pbcharts adapter.
 # Every test is wrapped with skip_if_not_installed("pbcharts").
@@ -43,7 +43,7 @@ test_that("4.1: CL-identity -- cl/ucl/lcl identical() to direct pbc()", {
 
   res <- bfh_qic(d,
     x = period, y = num, n = den,
-    chart_type = "i'", return.data = TRUE
+    chart_type = "ip", return.data = TRUE
   )
   direct <- pbcharts::pbc(period, num, den,
     data = d,
@@ -71,7 +71,7 @@ test_that("4.2a: varying den produces varying ucl (and lcl)", {
 
   res <- bfh_qic(d,
     x = period, y = num, n = den,
-    chart_type = "i'", return.data = TRUE
+    chart_type = "ip", return.data = TRUE
   )
 
   # At least two distinct rounded values means limits vary with den
@@ -91,7 +91,7 @@ test_that("4.2b: constant den produces constant ucl/lcl", {
 
   res <- bfh_qic(d,
     x = period, y = num, n = den,
-    chart_type = "i'", return.data = TRUE
+    chart_type = "ip", return.data = TRUE
   )
 
   expect_equal(length(unique(round(res$ucl, 9L))), 1L)
@@ -112,7 +112,7 @@ test_that("4.2c: missing n gives constant limits and y equals raw num", {
   res <- suppressMessages(
     bfh_qic(d,
       x = period, y = num,
-      chart_type = "i'", return.data = TRUE
+      chart_type = "ip", return.data = TRUE
     )
   )
 
@@ -147,7 +147,7 @@ test_that("4.3: anhoej.signal is logical and maps from pbc runs.signal", {
 
   res <- bfh_qic(d,
     x = period, y = num, n = den,
-    chart_type = "i'", return.data = TRUE
+    chart_type = "ip", return.data = TRUE
   )
   direct <- pbcharts::pbc(period, num, den,
     data = d,
@@ -192,7 +192,7 @@ test_that("4.4: notes attached by x-value not position after pbc sort", {
 
   res <- bfh_qic(d,
     x = period, y = num, n = den,
-    chart_type = "i'", notes = notes_vec,
+    chart_type = "ip", notes = notes_vec,
     return.data = TRUE
   )
 
@@ -217,7 +217,7 @@ test_that("4.5: qic_data contains all downstream-required columns", {
 
   res <- bfh_qic(d,
     x = period, y = num, n = den,
-    chart_type = "i'", return.data = TRUE
+    chart_type = "ip", return.data = TRUE
   )
 
   required_cols <- c(

--- a/tests/testthat/test-i-prime-bfh-qic.R
+++ b/tests/testthat/test-i-prime-bfh-qic.R
@@ -1,8 +1,8 @@
 # ============================================================================
-# SMOKE TESTS: i' (I-prime) chart via bfh_qic()
+# SMOKE TESTS: ip (I-prime) chart via bfh_qic()
 # ============================================================================
 # TDD: tests written before Group 3 implementation.
-# Verifies that bfh_qic() correctly routes chart_type = "i'" through the
+# Verifies that bfh_qic() correctly routes chart_type = "ip" through the
 # pbcharts adapter and produces a valid bfh_qic_result object.
 #
 # Heavy CL-identity / varying-limits / notes-alignment acceptance tests
@@ -29,8 +29,8 @@ df <- make_iprime_data()
 # Test 1: returns bfh_qic_result
 # ============================================================================
 
-test_that("bfh_qic with chart_type i' returns a bfh_qic_result object", {
-  result <- bfh_qic(df, x = date, y = num, n = den, chart_type = "i'")
+test_that("bfh_qic with chart_type ip returns a bfh_qic_result object", {
+  result <- bfh_qic(df, x = date, y = num, n = den, chart_type = "ip")
   expect_true(is_bfh_qic_result(result))
 })
 
@@ -38,10 +38,10 @@ test_that("bfh_qic with chart_type i' returns a bfh_qic_result object", {
 # Test 2: return.data = TRUE produces qic contract data.frame
 # ============================================================================
 
-test_that("bfh_qic with chart_type i' and return.data=TRUE returns a data.frame with contract columns", {
+test_that("bfh_qic with chart_type ip and return.data=TRUE returns a data.frame with contract columns", {
   result <- bfh_qic(df,
     x = date, y = num, n = den,
-    chart_type = "i'", return.data = TRUE
+    chart_type = "ip", return.data = TRUE
   )
   expect_s3_class(result, "data.frame")
   contract_cols <- c("x", "y", "cl", "ucl", "lcl", "n", "notes")
@@ -56,9 +56,9 @@ test_that("bfh_qic with chart_type i' and return.data=TRUE returns a data.frame 
 # Test 3: missing n emits degeneration message
 # ============================================================================
 
-test_that("bfh_qic with chart_type i' and no n emits degeneration message", {
+test_that("bfh_qic with chart_type ip and no n emits degeneration message", {
   expect_message(
-    bfh_qic(df, x = date, y = num, chart_type = "i'"),
+    bfh_qic(df, x = date, y = num, chart_type = "ip"),
     regexp = "denominator"
   )
 })

--- a/tests/testthat/test-public-api-contract.R
+++ b/tests/testthat/test-public-api-contract.R
@@ -191,9 +191,8 @@ test_that("bfh_qic Rd documents all validated chart types", {
   rd_content <- paste(readLines(rd_path, warn = FALSE), collapse = "\n")
 
   for (t in BFHcharts:::CHART_TYPES_EN) {
-    # Match the quoted chart-type token. Word-boundary (\\b) regex fails on
-    # types containing non-word chars (e.g. the apostrophe in "i'"); all
-    # types appear quoted in the Rd param list, so this is reliable.
+    # Match the quoted chart-type token via fixed-string search; all types
+    # appear quoted in the Rd param list, so this is reliable.
     expect_true(
       grepl(paste0("\"", t, "\""), rd_content, fixed = TRUE),
       info = paste("Chart type", t, "missing from bfh_qic.Rd")


### PR DESCRIPTION
## Summary

- Renames the I-prime chart's `chart_type` value from `"i'"` to `"ip"`, matching the base-letter+`p` pattern of the other prime charts (`pp` P-prime, `up` U-prime). The apostrophe was the only outlier and caused string-handling friction.
- **BREAKING CHANGE** (pre-1.0 MINOR): `"i'"` is no longer accepted; callers must use `"ip"`. Introduced in 0.24.0, renamed before broad adoption.
- Version `0.24.0` → `0.25.0` + NEWS breaking-changes entry.

## Scope

- `CHART_TYPES_EN`, `bfh_qic()` dispatch + roxygen, pbcharts error message
- Regenerated `man/bfh_qic.Rd`
- Tests + openspec proposal/spec updated to `"ip"`
- Danish UI labels (`I'-kort`) and pbcharts internal `chart='i'` arg unchanged

## Downstream

biSPCharts (only consumer) adapted in a coordinated branch (`chore/bfhcharts-iprime-rename`), held until this is released as `v0.25.0`.

## Test plan

- [x] `devtools::document()` regenerates Rd without `i'`
- [x] Targeted suites green: i-prime acceptance/adapter/bfh-qic, chart_type_integration, public-api-contract, chart_types
- [x] Full pre-push suite passed on push
- [ ] `devtools::check()` clean (run before release)