### PR TITLE
fix(validation): error when y/n column missing from data (closes #413)

### DIFF
--- a/R/utils_bfh_qic_helpers.R
+++ b/R/utils_bfh_qic_helpers.R
@@ -540,8 +540,18 @@ validate_bfh_qic_inputs <- function(data,
     }
   }
 
-  # y column must be numeric (or integer). Early error prevents
-  # cryptic qicharts2 chain failures on e.g. character/factor input.
+  # y column must exist in data and be numeric (or integer). Early error
+  # prevents NSE silent fallback to calling environment when column is missing,
+  # which would silently plot stale data from a global variable.
+  if (!is.null(y_expr_char) && nzchar(y_expr_char) && !y_expr_char %in% names(data)) {
+    stop(
+      sprintf(
+        "Column '%s' not found in `data`. Available columns: %s",
+        y_expr_char, paste(names(data), collapse = ", ")
+      ),
+      call. = FALSE
+    )
+  }
   if (!is.null(y_expr_char) && y_expr_char %in% names(data)) {
     y_data <- data[[y_expr_char]]
     if (!is.numeric(y_data)) {
@@ -577,6 +587,18 @@ validate_bfh_qic_inputs <- function(data,
         )
       }
     }
+  }
+
+  # n column must exist in data when specified. Same NSE silent-fallback risk
+  # as y: a missing n column silently resolves to a global variable.
+  if (!is.null(n_expr_char) && nzchar(n_expr_char) && !n_expr_char %in% names(data)) {
+    stop(
+      sprintf(
+        "Column '%s' (n) not found in `data`. Available columns: %s",
+        n_expr_char, paste(names(data), collapse = ", ")
+      ),
+      call. = FALSE
+    )
   }
 
   # notes must be a character vector (or all-NA) with same length as data.

--- a/tests/testthat/test-bfh_qic_edge_cases.R
+++ b/tests/testthat/test-bfh_qic_edge_cases.R
@@ -477,3 +477,19 @@ test_that("anhoej.signal kan være NA for en kort serie (n=6)", {
   # Enten er alle NA (for meget kort serie) eller logisk — ikke tvunget til FALSE
   expect_true(is.logical(anhoej_vals))
 })
+
+test_that("bfh_qic errors when y column missing from data", {
+  df <- data.frame(date = 1:10, value = 1:10)
+  expect_error(
+    bfh_qic(df, x = date, y = missing_col),
+    "missing_col"
+  )
+})
+
+test_that("bfh_qic errors when n column missing from data", {
+  df <- data.frame(date = 1:10, value = 1:10, denom = 1:10)
+  expect_error(
+    bfh_qic(df, x = date, y = value, n = missing_n, chart_type = "p"),
+    "missing_n"
+  )
+})


### PR DESCRIPTION
## Summary

- Adds existence check for `y` column in `validate_bfh_qic_inputs()`: stops with an informative error listing available columns when the column is not found in `data`
- Adds existence check for `n` column with the same pattern
- Both checks guard against NSE silent fallback to the calling environment, which previously allowed a stale global variable to produce a chart with wrong clinical data and no warning
- Adds two regression tests in `test-bfh_qic_edge_cases.R` covering missing `y` and missing `n`

## Test plan

- [x] `devtools::test(filter = "edge_cases")` — 54 pass, 0 fail
- [x] `devtools::test(filter = "helpers")` — 104 pass, 0 fail
- [x] Full test suite via pre-push hook — 5700 pass, 0 fail

Closes #413