### PR TITLE
docs: remove stale docs link, add ip chart type to docs (closes #417, closes #418)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ Følgende funktioner er markeret som `@keywords internal` og tilgængelige via `
 - Kun brugt internt af `bfh_qic()`
 
 *Constants:*
-- `CHART_TYPES_EN` - Chart type identifiers (`run`, `i`, `mr`, `p`, `pp`, `u`, `up`, `c`, `g`, `xbar`, `s`, `t`)
+- `CHART_TYPES_EN` - Chart type identifiers (`run`, `i`, `mr`, `p`, `pp`, `u`, `up`, `c`, `g`, `xbar`, `s`, `t`, `ip`)
 - Brugere passer strings direkte: `chart_type = "p"`, ikke konstant-opslag
 
 **Rationale:** **Simpelt primært API** - brugere lærer reelt kun `bfh_qic()`; de sekundære exports er kun nødvendige ved eksport/analysetekst. Resten af kompleksiteten er skjult under motorhjelmen. Advanced users kan tilgå internals med `BFHcharts:::function_name()`.

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ funktioner bruges kun til eksport, analysetekst og introspektion af resultatet.
 | `xbar` | Xbar-chart (delgruppe-gennemsnit) |
 | `s` | S-chart (delgruppe-standardafvigelse) |
 | `t` | T-chart (tid mellem hændelser) |
+| `ip` | I-prime chart (i-chart med varierende nævner; y/n ratio; kræver `pbcharts` under `Suggests`) |
 
 `y_axis_unit` styrer akseformatering og accepterer `"count"`, `"percent"`,
 `"rate"` eller `"time"`.
@@ -421,8 +422,9 @@ hospitalsfarver håndteres af
 ## Dokumentation
 
 - Roxygen-reference, fx `?bfh_qic` eller `help(package = "BFHcharts")`
-- Arkitekturnoter i [`docs/`](docs/DOCUMENTATION_OVERVIEW.md)
-- ADR'er i `inst/adr/`
+- Vignetter: `browseVignettes("BFHcharts")` — charttype-guide, faser, eksport m.m.
+- Arkitekturbeslutninger (ADR'er) i [`inst/adr/`](inst/adr/)
+- Tekniske noter i [`docs/`](docs/)
 
 ## Licens
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,5 +1,9 @@
 # BFHcharts Development Roadmap
 
+> **Historisk dokument** — dette roadmap er fra oktober 2025 og afspejler ikke
+> pakkens aktuelle tilstand (v0.25+). Det bevares som historisk reference.
+> Aktuelle planer og issues: <https://github.com/johanreventlow/BFHcharts/issues>
+
 Komplet oversigt over alle planlagte forbedringer og features for BFHcharts pakken.
 
 **Sidste opdateret:** 2025-10-12

--- a/vignettes/chart-types.Rmd
+++ b/vignettes/chart-types.Rmd
@@ -55,7 +55,10 @@ Denne vignette mapper kliniske spørgsmål til charttyper og giver beslutningsre
   │   │   → xbar-chart (mean) + s-chart (variation)
   │   │
   │   ├── Individuelle målinger (én måling per periode)?
-  │   │   → i-chart + mr-chart (moving range)
+  │   │   ├── Fast nævner (eller ingen nævner)?
+  │   │   │   → i-chart + mr-chart (moving range)
+  │   │   └── Varierende nævner (y/n ratio, fx tid per patient)?
+  │   │       → ip-chart (I-prime, individuelle målinger med varierende nævner)
   │   │
   │   └── For lille n eller ikke-normal fordeling?
   │       → run-chart (kun centerlinje, ingen kontrolgrænser)
@@ -119,6 +122,25 @@ Simpler end u-chart men kræver konstans-antagelsen.
 
 For målinger hvor du har én værdi per periode (fx daglig ventetid). Brug **altid**
 sammen med `mr`-chart for at se variation mellem konsekutive målinger.
+
+### `ip` — I-prime chart (individuelle målinger med varierende nævner)
+
+Bruges når din y-variabel er et **ratio** (y/n) og nævneren varierer fra periode
+til periode — fx tid per patient, ressourceforbrug per indlæggelse. I-prime
+justerer kontrolgrænserne for den varierende nævner på samme måde som Laney-korrektionen
+gør for `pp` og `up`.
+
+```{r ip-example, eval = FALSE}
+# Gennemsnitlig liggetid per indlæggelse (dage / indlæggelser)
+bfh_qic(data,
+  x = month, y = stay_days, n = admissions,
+  chart_type = "ip",
+  y_axis_unit = "rate",
+  chart_title = "Gennemsnitlig liggetid"
+)
+```
+
+**Krav**: `n` (nævner) skal angives. Kræver `pbcharts`-pakken under `Suggests`.
 
 ### `xbar` + `s` — subgrouped kontinuerte data
 


### PR DESCRIPTION
## Summary

- **#417**: README Dokumentation section pointed to `docs/DOCUMENTATION_OVERVIEW.md` (file no longer exists). Replaced with links to vignettes (`browseVignettes`), `inst/adr/`, and `docs/`. `docs/ROADMAP.md` gets a historical note since it predates v0.25.
- **#418**: `ip` (I-prime chart, added v0.24.0, renamed from `i'` in v0.25.0) was missing from all user-facing docs. Added to README Diagramtyper table, vignette decision tree + per-type section, and CLAUDE.md constant list.

## Test plan

- [ ] Verify README renders correctly on GitHub (Dokumentation section links, ip table row)
- [ ] Verify `vignettes/chart-types.Rmd` knits without errors
- [ ] Verify no remaining `DOCUMENTATION_OVERVIEW` references: `grep -r "DOCUMENTATION_OVERVIEW" . --include="*.md" --include="*.R" --include="*.Rmd"` returns empty