### PR TITLE
fix(export): pass language to analysis functions in bfh_export_pdf (closes #419)

### DIFF
--- a/R/utils_export_helpers.R
+++ b/R/utils_export_helpers.R
@@ -252,6 +252,8 @@ validate_bfh_export_pdf_inputs <- function(x, output, metadata, dpi,
 prepare_export_metadata <- function(x, metadata, auto_analysis, use_ai,
                                     analysis_min_chars, analysis_max_chars,
                                     data_consent = NULL, use_rag = FALSE) {
+  language <- x$config$language %||% "da"
+
   if (isTRUE(auto_analysis) && is.null(metadata$analysis)) {
     metadata$analysis <- bfh_generate_analysis(
       x = x,
@@ -260,12 +262,13 @@ prepare_export_metadata <- function(x, metadata, auto_analysis, use_ai,
       data_consent = data_consent,
       use_rag = use_rag,
       min_chars = analysis_min_chars,
-      max_chars = analysis_max_chars
+      max_chars = analysis_max_chars,
+      language = language
     )
   }
 
   if (is.null(metadata$details)) {
-    metadata$details <- bfh_generate_details(x)
+    metadata$details <- bfh_generate_details(x, language = language)
   }
 
   metadata

--- a/tests/testthat/test-i18n.R
+++ b/tests/testthat/test-i18n.R
@@ -219,3 +219,57 @@ test_that("texts_loader stadig virker som mock-parameter", {
   expect_match(analysis, "CUSTOM_STABILITY")
   expect_match(analysis, "CUSTOM_ACTION")
 })
+
+# Issue #419: prepare_export_metadata must pass language from x$config$language
+# to bfh_generate_details() and bfh_generate_analysis(), so that a chart
+# created with language = "en" produces English text in the PDF.
+test_that("prepare_export_metadata passes language from config to bfh_generate_details", {
+  set.seed(42)
+  data <- data.frame(
+    date = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 12),
+    value = rnorm(12, mean = 50, sd = 5)
+  )
+  result_en <- bfh_qic(data,
+    x = date, y = value, chart_type = "i",
+    language = "en"
+  )
+
+  meta <- BFHcharts:::prepare_export_metadata(
+    x = result_en,
+    metadata = list(),
+    auto_analysis = FALSE,
+    use_ai = FALSE,
+    analysis_min_chars = 300,
+    analysis_max_chars = 375
+  )
+
+  # English details must contain English labels, not Danish
+  expect_true(grepl("Period", meta$details))
+  expect_false(grepl("Periode", meta$details))
+})
+
+test_that("prepare_export_metadata passes language from config to bfh_generate_analysis", {
+  set.seed(42)
+  data <- data.frame(
+    date = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 12),
+    value = rnorm(12, mean = 50, sd = 5)
+  )
+  result_en <- bfh_qic(data,
+    x = date, y = value, chart_type = "i",
+    language = "en"
+  )
+
+  meta <- BFHcharts:::prepare_export_metadata(
+    x = result_en,
+    metadata = list(),
+    auto_analysis = TRUE,
+    use_ai = FALSE,
+    analysis_min_chars = 300,
+    analysis_max_chars = 375
+  )
+
+  # Analysis must be English: no Danish phrases expected
+  expect_false(grepl("stabil og forudsigelig|niveauskift", meta$analysis))
+  expect_type(meta$analysis, "character")
+  expect_true(nchar(meta$analysis) > 0)
+})


### PR DESCRIPTION
## Summary

- `prepare_export_metadata()` in `R/utils_export_helpers.R` was not forwarding `language` to `bfh_generate_details()` or `bfh_generate_analysis()`, so a chart created with `language = "en"` always produced Danish text in PDF exports.
- Fix: read `x$config$language %||% "da"` at the top of `prepare_export_metadata()` and pass it as the `language` argument to both functions.
- Two new regression tests added to `tests/testthat/test-i18n.R` covering the `prepare_export_metadata()` passthrough for both `details` and `analysis`.

## Test plan

- [x] `devtools::test(filter = "i18n")` — 125 tests pass (including 2 new regression tests)
- [x] `devtools::test(filter = "export")` — 457 pass, 46 skipped (render tests require env flag), 0 fail
- [x] Pre-push full suite — all tests green
- [ ] Manual smoke test: `bfh_export_pdf()` with `language = "en"` chart should produce English text in the generated PDF (requires Quarto + render env)