### PR TITLE
ci(pdf-smoke): remove stale continue-on-error flags (closes #414)

### DIFF
--- a/.github/workflows/pdf-smoke.yaml
+++ b/.github/workflows/pdf-smoke.yaml
@@ -114,7 +114,7 @@ jobs:
           BFHCHARTS_TEST_FULL: "true"
         run: |
           Rscript -e "
-            devtools::load_all('.')
+            pkgload::load_all('.')
             testthat::test_file(
               'tests/testthat/test-production-template-renders.R',
               reporter = testthat::ProgressReporter

--- a/.github/workflows/pdf-smoke.yaml
+++ b/.github/workflows/pdf-smoke.yaml
@@ -10,10 +10,6 @@
 #   inst/templates/typst/bfh-template/bfh-template.typ (production template).
 #   DejaVu/Liberation fonts are installed as Mari (proprietary) substitutes.
 #
-#   continue-on-error: true on the render step while fix-pdf-template-asset-contract
-#   is pending merge (production template may depend on untracked assets).
-#   Remove continue-on-error once that change is merged.
-#
 # Branch-protection (MANUAL STEP):
 #   This job must be added to required-status-checks in branch protection rules
 #   for main and develop on GitHub:
@@ -46,7 +42,6 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
       # Instructs render_smoke.R to use production template instead of test-template.
-      # continue-on-error on the render step until fix-pdf-template-asset-contract merges.
       BFHCHARTS_SMOKE_USE_PRODUCTION_TEMPLATE: "true"
 
     steps:
@@ -95,10 +90,6 @@ jobs:
           needs: check
 
       - name: Run PDF smoke render
-        # continue-on-error: true while fix-pdf-template-asset-contract is pending merge.
-        # Production template may require untracked assets (fonts/images). Remove once
-        # that OpenSpec change is merged and all assets are tracked.
-        continue-on-error: true
         run: Rscript tests/smoke/render_smoke.R
         shell: bash
 
@@ -118,7 +109,6 @@ jobs:
         shell: bash
 
       - name: Run production template smoke (BFHCHARTS_TEST_RENDER=true)
-        continue-on-error: true
         env:
           BFHCHARTS_TEST_RENDER: "true"
           BFHCHARTS_TEST_FULL: "true"


### PR DESCRIPTION
## Summary

- Removes both `continue-on-error: true` flags from the PDF smoke render workflow (steps: "Run PDF smoke render" and "Run production template smoke")
- Removes all stale comments referencing the `fix-pdf-template-asset-contract` OpenSpec change (header block + inline env comment), which is merged and archived
- Template assets (`inst/templates/typst/bfh-template/bfh-template.typ` and fonts) are confirmed git-tracked via `git ls-files`

## Test plan

- [ ] Verify PDF smoke render CI job fails on a PR that intentionally breaks the render pipeline
- [ ] Confirm the workflow runs green on this PR