### PR TITLE
feat(errors): add condition classes for programmatic error handling (closes #424)

### DIFF
--- a/R/export_pdf.R
+++ b/R/export_pdf.R
@@ -329,23 +329,27 @@ bfh_export_pdf <- function(x,
   # Shiny input with strict_json = FALSE).
   if (!is.logical(restrict_template) || length(restrict_template) != 1L ||
     is.na(restrict_template)) {
-    stop(
-      "restrict_template must be TRUE or FALSE (single non-NA logical)",
-      "\n  Got: ", paste(class(restrict_template), collapse = "/"),
-      " (length ", length(restrict_template), ")",
-      call. = FALSE
+    bfh_abort(
+      paste0(
+        "restrict_template must be TRUE or FALSE (single non-NA logical)",
+        "\n  Got: ", paste(class(restrict_template), collapse = "/"),
+        " (length ", length(restrict_template), ")"
+      ),
+      class = "bfhcharts_export_error"
     )
   }
   if (restrict_template && !is.null(template_path)) {
-    stop(
-      "template_path is not allowed when restrict_template = TRUE.",
-      "\n  Only the packaged BFHcharts template may be used in this configuration.",
-      "\n  To opt in to a trusted custom Typst template, pass",
-      " restrict_template = FALSE explicitly.",
-      "\n  WARNING: custom templates are compiled with full filesystem access",
-      " (equivalent to source()) -- never forward user-supplied input to",
-      " template_path.",
-      call. = FALSE
+    bfh_abort(
+      paste0(
+        "template_path is not allowed when restrict_template = TRUE.",
+        "\n  Only the packaged BFHcharts template may be used in this configuration.",
+        "\n  To opt in to a trusted custom Typst template, pass",
+        " restrict_template = FALSE explicitly.",
+        "\n  WARNING: custom templates are compiled with full filesystem access",
+        " (equivalent to source()) -- never forward user-supplied input to",
+        " template_path."
+      ),
+      class = "bfhcharts_export_error"
     )
   }
 
@@ -368,7 +372,9 @@ bfh_export_pdf <- function(x,
   }
   if (!is.logical(strict_baseline) || length(strict_baseline) != 1L ||
     is.na(strict_baseline)) {
-    stop("strict_baseline must be TRUE or FALSE", call. = FALSE)
+    bfh_abort("strict_baseline must be TRUE or FALSE",
+      class = "bfhcharts_export_error"
+    )
   }
   .validate_strict_baseline(x, strict_baseline)
 
@@ -384,12 +390,14 @@ bfh_export_pdf <- function(x,
 
   # ---- 4. Quarto-tjek --------------------------------------------------------
   if (!quarto_available()) {
-    stop(
-      "Quarto CLI not found or version too old. PDF export requires Quarto >= 1.4.0.\n",
-      "  Install or update from: https://quarto.org\n",
-      "  After installation, restart R and try again.\n",
-      "  Typst support was added in Quarto 1.4.",
-      call. = FALSE
+    bfh_abort(
+      paste0(
+        "Quarto CLI not found or version too old. PDF export requires Quarto >= 1.4.0.\n",
+        "  Install or update from: https://quarto.org\n",
+        "  After installation, restart R and try again.\n",
+        "  Typst support was added in Quarto 1.4."
+      ),
+      class = "bfhcharts_export_error"
     )
   }
 
@@ -504,7 +512,9 @@ recalculate_labels_for_export <- function(x, target_width_mm, target_height_mm,
                                           label_size = NULL) {
   # Validate input
   if (!inherits(x, "bfh_qic_result")) {
-    stop("x must be a bfh_qic_result object", call. = FALSE)
+    bfh_abort("x must be a bfh_qic_result object",
+      class = "bfhcharts_export_error"
+    )
   }
 
   # Convert target dimensions to inches for label positioning
@@ -583,7 +593,9 @@ recalculate_labels_for_export <- function(x, target_width_mm, target_height_mm,
     return(invisible(NULL))
   }
   if (!is.function(fn)) {
-    stop("inject_assets must be a function or NULL", call. = FALSE)
+    bfh_abort("inject_assets must be a function or NULL",
+      class = "bfhcharts_export_error"
+    )
   }
 
   if (!isTRUE(getOption(BFHCHARTS_OPT_ALLOW_GLOBALENV_INJECT, default = FALSE))) {
@@ -592,13 +604,15 @@ recalculate_labels_for_export <- function(x, target_width_mm, target_height_mm,
     if (!is.null(fn_env)) {
       top_name <- environmentName(topenv(fn_env))
       if (!top_name %in% allowed_namespaces) {
-        stop(
-          "inject_assets must come from a trusted package namespace ",
-          "(e.g., MyOrgAssets::inject_my_assets), not from '", top_name, "'. ",
-          "Accepting functions from arbitrary environments is a privilege-escalation ",
-          "risk in production. If this is intentional in development, suppress with ",
-          "options(BFHcharts.allow_globalenv_inject = TRUE).",
-          call. = FALSE
+        bfh_abort(
+          paste0(
+            "inject_assets must come from a trusted package namespace ",
+            "(e.g., MyOrgAssets::inject_my_assets), not from '", top_name, "'. ",
+            "Accepting functions from arbitrary environments is a privilege-escalation ",
+            "risk in production. If this is intentional in development, suppress with ",
+            "options(BFHcharts.allow_globalenv_inject = TRUE)."
+          ),
+          class = "bfhcharts_export_error"
         )
       }
     }
@@ -632,11 +646,13 @@ recalculate_labels_for_export <- function(x, target_width_mm, target_height_mm,
 prepare_plot_for_export <- function(plot, margin_mm = 0) {
   # Validate inputs
   if (!inherits(plot, "ggplot")) {
-    stop("plot must be a ggplot2 object", call. = FALSE)
+    bfh_abort("plot must be a ggplot2 object", class = "bfhcharts_export_error")
   }
 
   if (!is.numeric(margin_mm) || length(margin_mm) != 1 || margin_mm < 0) {
-    stop("margin_mm must be a non-negative number", call. = FALSE)
+    bfh_abort("margin_mm must be a non-negative number",
+      class = "bfhcharts_export_error"
+    )
   }
 
   # Set plot margins (axis title removal is now in apply_spc_theme)

--- a/R/utils_bfh_qic_helpers.R
+++ b/R/utils_bfh_qic_helpers.R
@@ -508,13 +508,13 @@ validate_bfh_qic_inputs <- function(data,
                                     notes = NULL,
                                     target_text = NULL) {
   if (!is.data.frame(data)) {
-    stop("data must be a data frame", call. = FALSE)
+    bfh_abort("data must be a data frame", class = "bfhcharts_input_error")
   }
 
   if (nrow(data) == 0L) {
-    stop(
+    bfh_abort(
       "'data' is empty; bfh_qic() requires at least one row",
-      call. = FALSE
+      class = "bfhcharts_input_error"
     )
   }
 
@@ -522,20 +522,20 @@ validate_bfh_qic_inputs <- function(data,
   # error prevents cryptic qicharts2 failures on e.g. character input.
   if (!is.null(x_expr_char)) {
     if (!x_expr_char %in% names(data)) {
-      stop(
+      bfh_abort(
         sprintf("Column '%s' not found in data", x_expr_char),
-        call. = FALSE
+        class = "bfhcharts_input_error"
       )
     }
     x_data <- data[[x_expr_char]]
     if (!(is.numeric(x_data) || inherits(x_data, "Date") ||
       inherits(x_data, "POSIXct") || is.integer(x_data))) {
-      stop(
+      bfh_abort(
         sprintf(
           "Column '%s' has class '%s'. x must be numeric, Date, or POSIXct. Use as.Date() or as.POSIXct() to convert.",
           x_expr_char, class(x_data)[1]
         ),
-        call. = FALSE
+        class = "bfhcharts_input_error"
       )
     }
   }
@@ -545,12 +545,12 @@ validate_bfh_qic_inputs <- function(data,
   if (!is.null(y_expr_char) && y_expr_char %in% names(data)) {
     y_data <- data[[y_expr_char]]
     if (!is.numeric(y_data)) {
-      stop(
+      bfh_abort(
         sprintf(
           "column '%s' (y) must be numeric, got: %s",
           y_expr_char, paste(class(y_data), collapse = "/")
         ),
-        call. = FALSE
+        class = "bfhcharts_input_error"
       )
     }
 
@@ -563,7 +563,7 @@ validate_bfh_qic_inputs <- function(data,
     if (chart_type %in% count_chart_types) {
       neg_idx <- which(!is.na(y_data) & y_data < 0)
       if (length(neg_idx) > 0L) {
-        stop(
+        bfh_abort(
           sprintf(
             paste0(
               "column '%s' (y) contains negative values at row(s): %s. ",
@@ -573,7 +573,7 @@ validate_bfh_qic_inputs <- function(data,
             paste(utils::head(neg_idx, 5), collapse = ", "),
             chart_type
           ),
-          call. = FALSE
+          class = "bfhcharts_input_error"
         )
       }
     }
@@ -582,15 +582,17 @@ validate_bfh_qic_inputs <- function(data,
   # notes must be a character vector (or all-NA) with same length as data.
   if (!is.null(notes)) {
     if (!is.character(notes) && !all(is.na(notes))) {
-      stop("`notes` must be a character vector or NULL", call. = FALSE)
+      bfh_abort("`notes` must be a character vector or NULL",
+        class = "bfhcharts_input_error"
+      )
     }
     if (length(notes) != nrow(data)) {
-      stop(
+      bfh_abort(
         sprintf(
           "`notes` must have same length as data (got %d, expected %d)",
           length(notes), nrow(data)
         ),
-        call. = FALSE
+        class = "bfhcharts_input_error"
       )
     }
   }
@@ -598,26 +600,26 @@ validate_bfh_qic_inputs <- function(data,
   # target_text must be a single character string (scalar) when provided.
   if (!is.null(target_text)) {
     if (!is.character(target_text) || length(target_text) != 1L) {
-      stop(
+      bfh_abort(
         "`target_text` must be a single character string or NULL",
-        call. = FALSE
+        class = "bfhcharts_input_error"
       )
     }
   }
 
   if (!chart_type %in% CHART_TYPES_EN) {
-    stop(sprintf(
+    bfh_abort(sprintf(
       "chart_type must be one of: %s",
       paste(CHART_TYPES_EN, collapse = ", ")
-    ), call. = FALSE)
+    ), class = "bfhcharts_input_error")
   }
 
   valid_units <- Y_AXIS_UNITS
   if (!y_axis_unit %in% valid_units) {
-    stop(sprintf(
+    bfh_abort(sprintf(
       "y_axis_unit must be one of: %s",
       paste(valid_units, collapse = ", ")
-    ), call. = FALSE)
+    ), class = "bfhcharts_input_error")
   }
 
   validate_position_indices(part, "part", nrow(data),
@@ -690,7 +692,7 @@ validate_bfh_qic_inputs <- function(data,
   agg_fun_out <- if (agg_fun_supplied) match.arg(agg.fun, c("mean", "median", "sum", "sd")) else NULL
 
   if (!is.logical(return.data) || length(return.data) != 1 || is.na(return.data)) {
-    stop("return.data must be TRUE or FALSE", call. = FALSE)
+    bfh_abort("return.data must be TRUE or FALSE", class = "bfhcharts_input_error")
   }
 
   if (!is.null(plot_margin)) {
@@ -698,15 +700,19 @@ validate_bfh_qic_inputs <- function(data,
       # margin()-objekt -- trust brugerens input
     } else if (is.numeric(plot_margin)) {
       if (length(plot_margin) != 4) {
-        stop(
-          "plot_margin must be either:\n",
-          "  - A numeric vector of length 4: c(top, right, bottom, left) in mm\n",
-          "  - A margin object: margin(t, r, b, l, unit = '...')",
-          call. = FALSE
+        bfh_abort(
+          paste0(
+            "plot_margin must be either:\n",
+            "  - A numeric vector of length 4: c(top, right, bottom, left) in mm\n",
+            "  - A margin object: margin(t, r, b, l, unit = '...')"
+          ),
+          class = "bfhcharts_input_error"
         )
       }
       if (any(plot_margin < 0)) {
-        stop("plot_margin values must be non-negative", call. = FALSE)
+        bfh_abort("plot_margin values must be non-negative",
+          class = "bfhcharts_input_error"
+        )
       }
       if (any(plot_margin > 100)) {
         warning(
@@ -716,12 +722,14 @@ validate_bfh_qic_inputs <- function(data,
         )
       }
     } else {
-      stop(
-        "plot_margin must be either:\n",
-        "  - A numeric vector of length 4: c(top, right, bottom, left) in mm\n",
-        "  - A margin object: margin(t, r, b, l, unit = '...')\n",
-        "Got: ", class(plot_margin)[1],
-        call. = FALSE
+      bfh_abort(
+        paste0(
+          "plot_margin must be either:\n",
+          "  - A numeric vector of length 4: c(top, right, bottom, left) in mm\n",
+          "  - A margin object: margin(t, r, b, l, unit = '...')\n",
+          "Got: ", class(plot_margin)[1]
+        ),
+        class = "bfhcharts_input_error"
       )
     }
   }

--- a/R/utils_export_helpers.R
+++ b/R/utils_export_helpers.R
@@ -21,14 +21,16 @@
   if (!is.null(freeze_val) && length(freeze_val) == 1L &&
     is.numeric(freeze_val) && !is.na(freeze_val) &&
     freeze_val < MIN_BASELINE_N) {
-    stop(
-      sprintf(
-        "freeze = %s: baseline har faerre end %d punkter (MIN_BASELINE_N). ",
-        as.integer(freeze_val), MIN_BASELINE_N
+    bfh_abort(
+      paste0(
+        sprintf(
+          "freeze = %s: baseline har faerre end %d punkter (MIN_BASELINE_N). ",
+          as.integer(freeze_val), MIN_BASELINE_N
+        ),
+        "Saet strict_baseline = FALSE for at acceptere kortere baseline ",
+        "(kontrolgraenser kan vaere statistisk usikre)."
       ),
-      "Saet strict_baseline = FALSE for at acceptere kortere baseline ",
-      "(kontrolgraenser kan vaere statistisk usikre).",
-      call. = FALSE
+      class = "bfhcharts_export_error"
     )
   }
   qd <- x$qic_data
@@ -36,14 +38,16 @@
     phase_sizes <- as.integer(table(qd$part))
     short_phases <- which(phase_sizes < MIN_BASELINE_N)
     if (length(short_phases) > 0L) {
-      stop(
-        sprintf(
-          "Fase(r) %s har faerre end %d punkter (MIN_BASELINE_N). ",
-          paste(short_phases, collapse = ", "), MIN_BASELINE_N
+      bfh_abort(
+        paste0(
+          sprintf(
+            "Fase(r) %s har faerre end %d punkter (MIN_BASELINE_N). ",
+            paste(short_phases, collapse = ", "), MIN_BASELINE_N
+          ),
+          "Saet strict_baseline = FALSE for at acceptere kortere faser ",
+          "(kontrolgraenser kan vaere statistisk usikre)."
         ),
-        "Saet strict_baseline = FALSE for at acceptere kortere faser ",
-        "(kontrolgraenser kan vaere statistisk usikre).",
-        call. = FALSE
+        class = "bfhcharts_export_error"
       )
     }
   }
@@ -68,35 +72,39 @@
   }
   if (is.numeric(x)) {
     if (length(x) != 1L) {
-      stop(
-        "metadata$target must be a scalar (length 1), got length ", length(x),
-        call. = FALSE
+      bfh_abort(
+        paste0("metadata$target must be a scalar (length 1), got length ", length(x)),
+        class = "bfhcharts_export_error"
       )
     }
     if (!is.finite(x)) {
-      stop(
-        "metadata$target must be a finite numeric (no NA/Inf/NaN), got: ", x,
-        call. = FALSE
+      bfh_abort(
+        paste0("metadata$target must be a finite numeric (no NA/Inf/NaN), got: ", x),
+        class = "bfhcharts_export_error"
       )
     }
     return(invisible(NULL))
   }
   if (is.character(x)) {
     if (length(x) != 1L) {
-      stop(
-        "metadata$target must be a scalar (length 1), got length ", length(x),
-        call. = FALSE
+      bfh_abort(
+        paste0("metadata$target must be a scalar (length 1), got length ", length(x)),
+        class = "bfhcharts_export_error"
       )
     }
     if (is.na(x)) {
-      stop("metadata$target must not be NA", call. = FALSE)
+      bfh_abort("metadata$target must not be NA",
+        class = "bfhcharts_export_error"
+      )
     }
     return(invisible(NULL))
   }
-  stop(
-    "metadata$target must be NULL, a single finite numeric, or a single character string.\n",
-    "  Got class: ", paste(class(x), collapse = "/"),
-    call. = FALSE
+  bfh_abort(
+    paste0(
+      "metadata$target must be NULL, a single finite numeric, or a single character string.\n",
+      "  Got class: ", paste(class(x), collapse = "/")
+    ),
+    class = "bfhcharts_export_error"
   )
 }
 
@@ -112,17 +120,19 @@ validate_bfh_export_pdf_inputs <- function(x, output, metadata, dpi,
                                            batch_session, template_path) {
   # Klasse-tjek
   if (!inherits(x, "bfh_qic_result")) {
-    stop(
-      "x must be a bfh_qic_result object from bfh_qic().\n",
-      "  Got class: ", paste(class(x), collapse = ", "),
-      call. = FALSE
+    bfh_abort(
+      paste0(
+        "x must be a bfh_qic_result object from bfh_qic().\n",
+        "  Got class: ", paste(class(x), collapse = ", ")
+      ),
+      class = "bfhcharts_export_error"
     )
   }
 
   validate_export_path(output, extension = "pdf", ext_action = "stop")
 
   if (!is.list(metadata)) {
-    stop("metadata must be a list", call. = FALSE)
+    bfh_abort("metadata must be a list", class = "bfhcharts_export_error")
   }
 
   # Metadata felt-validering
@@ -167,11 +177,13 @@ validate_bfh_export_pdf_inputs <- function(x, output, metadata, dpi,
         if (is.null(value)) next
         if (!is.character(value) || length(value) != 1L || is.na(value) ||
           !nzchar(value)) {
-          stop(
-            "metadata$logo_path must be a single non-empty character string or NULL",
-            "\n  Got: ", paste(class(value), collapse = "/"),
-            " (length ", length(value), ")",
-            call. = FALSE
+          bfh_abort(
+            paste0(
+              "metadata$logo_path must be a single non-empty character string or NULL",
+              "\n  Got: ", paste(class(value), collapse = "/"),
+              " (length ", length(value), ")"
+            ),
+            class = "bfhcharts_export_error"
           )
         }
         .check_traversal(value)
@@ -181,19 +193,23 @@ validate_bfh_export_pdf_inputs <- function(x, output, metadata, dpi,
 
       if (!is.null(value) && !is.character(value)) {
         if (field == "date" && inherits(value, "Date")) next
-        stop(
-          "metadata$", field, " must be a character string",
-          if (field == "date") " (or Date object)" else "",
-          "\n  Got: ", class(value)[1],
-          call. = FALSE
+        bfh_abort(
+          paste0(
+            "metadata$", field, " must be a character string",
+            if (field == "date") " (or Date object)" else "",
+            "\n  Got: ", class(value)[1]
+          ),
+          class = "bfhcharts_export_error"
         )
       }
 
       if (is.character(value) && nchar(value) > 10000) {
-        stop(
-          "metadata$", field, " exceeds maximum length of 10,000 characters\n",
-          "  Current length: ", nchar(value),
-          call. = FALSE
+        bfh_abort(
+          paste0(
+            "metadata$", field, " exceeds maximum length of 10,000 characters\n",
+            "  Current length: ", nchar(value)
+          ),
+          class = "bfhcharts_export_error"
         )
       }
     }
@@ -201,42 +217,54 @@ validate_bfh_export_pdf_inputs <- function(x, output, metadata, dpi,
 
   # Valgfrie parameter-validering
   if (!is.null(inject_assets) && !is.function(inject_assets)) {
-    stop("inject_assets must be a function or NULL", call. = FALSE)
+    bfh_abort("inject_assets must be a function or NULL",
+      class = "bfhcharts_export_error"
+    )
   }
 
   if (!is.null(font_path)) {
     if (!is.character(font_path) || length(font_path) != 1) {
-      stop("font_path must be a single character string or NULL", call. = FALSE)
+      bfh_abort("font_path must be a single character string or NULL",
+        class = "bfhcharts_export_error"
+      )
     }
   }
 
   if (!is.numeric(dpi) || length(dpi) != 1 || is.na(dpi) || dpi <= 0) {
-    stop("dpi must be a single positive numeric value", call. = FALSE)
+    bfh_abort("dpi must be a single positive numeric value",
+      class = "bfhcharts_export_error"
+    )
   }
 
   # batch_session validering
   if (!is.null(batch_session)) {
     if (!inherits(batch_session, "bfh_export_session")) {
-      stop(
+      bfh_abort(
         "batch_session must be a bfh_export_session object from bfh_create_export_session()",
-        call. = FALSE
+        class = "bfhcharts_export_error"
       )
     }
     if (batch_session$closed()) {
-      stop("batch_session is already closed", call. = FALSE)
+      bfh_abort("batch_session is already closed",
+        class = "bfhcharts_export_error"
+      )
     }
     if (!is.null(template_path)) {
-      stop(
-        "batch_session cannot be combined with template_path.\n",
-        "  Custom templates are not supported in batch sessions.",
-        call. = FALSE
+      bfh_abort(
+        paste0(
+          "batch_session cannot be combined with template_path.\n",
+          "  Custom templates are not supported in batch sessions."
+        ),
+        class = "bfhcharts_export_error"
       )
     }
     if (!is.null(inject_assets)) {
-      stop(
-        "batch_session cannot be combined with inject_assets.\n",
-        "  Pass inject_assets to bfh_create_export_session() instead.",
-        call. = FALSE
+      bfh_abort(
+        paste0(
+          "batch_session cannot be combined with inject_assets.\n",
+          "  Pass inject_assets to bfh_create_export_session() instead."
+        ),
+        class = "bfhcharts_export_error"
       )
     }
   }
@@ -284,29 +312,35 @@ validate_template_path <- function(template_path) {
   }
 
   if (!is.character(template_path) || length(template_path) != 1) {
-    stop("template_path must be a single character string", call. = FALSE)
+    bfh_abort("template_path must be a single character string",
+      class = "bfhcharts_export_error"
+    )
   }
   validate_export_path(template_path)
 
   if (!file.exists(template_path)) {
-    stop(
-      "Custom template file not found: ", basename(template_path), "\n",
-      "  Ensure the file exists and the path is correct.",
-      call. = FALSE
+    bfh_abort(
+      paste0(
+        "Custom template file not found: ", basename(template_path), "\n",
+        "  Ensure the file exists and the path is correct."
+      ),
+      class = "bfhcharts_export_error"
     )
   }
   template_path <- validate_export_path(template_path, normalize = TRUE)
   if (dir.exists(template_path)) {
-    stop(
-      "template_path must be a file, not a directory: ", basename(template_path),
-      call. = FALSE
+    bfh_abort(
+      paste0("template_path must be a file, not a directory: ", basename(template_path)),
+      class = "bfhcharts_export_error"
     )
   }
   if (!grepl("\\.typ$", template_path, ignore.case = TRUE)) {
-    stop(
-      "template_path must be a .typ file: ", basename(template_path), "\n",
-      "  Typst templates require the .typ extension.",
-      call. = FALSE
+    bfh_abort(
+      paste0(
+        "template_path must be a .typ file: ", basename(template_path), "\n",
+        "  Typst templates require the .typ extension."
+      ),
+      class = "bfhcharts_export_error"
     )
   }
 
@@ -399,10 +433,9 @@ export_chart_svg <- function(plot_for_export, chart_svg, dpi) {
       device   = "svg"
     ),
     error = function(e) {
-      stop(
-        "Failed to save chart image\n",
-        "  Error: ", conditionMessage(e),
-        call. = FALSE
+      bfh_abort(
+        paste0("Failed to save chart image\n  Error: ", conditionMessage(e)),
+        class = "bfhcharts_export_error"
       )
     }
   )

--- a/R/utils_helpers.R
+++ b/R/utils_helpers.R
@@ -8,6 +8,61 @@
 NULL
 
 # ============================================================================
+# CLASSED CONDITION HELPERS
+# ============================================================================
+
+# Internal helpers that emit classed conditions so callers (e.g. biSPCharts)
+# can catch by class instead of string-matching error messages.
+#
+# Error class hierarchy:
+#   bfhcharts_input_error  < bfhcharts_error  < error
+#   bfhcharts_export_error < bfhcharts_error  < error
+#
+# Warning class hierarchy:
+#   bfhcharts_warning < warning
+#
+# Usage:
+#   bfh_abort("msg", class = "bfhcharts_input_error")
+#   bfh_warn("msg",  class = "bfhcharts_warning")
+
+#' Emit a classed BFHcharts error
+#'
+#' @param msg Character scalar. Human-readable error message.
+#' @param class Character scalar. Sub-class for the condition, e.g.
+#'   "bfhcharts_input_error" or "bfhcharts_export_error".
+#' @param call The call to attach to the condition (default NULL).
+#' @param ... Additional fields passed to rlang::abort().
+#' @return Does not return; always signals an error.
+#' @keywords internal
+#' @noRd
+bfh_abort <- function(msg, class, call = NULL, ...) {
+  rlang::abort(
+    msg,
+    class = c(class, "bfhcharts_error"),
+    call = call,
+    ...
+  )
+}
+
+#' Emit a classed BFHcharts warning
+#'
+#' @param msg Character scalar. Human-readable warning message.
+#' @param class Character scalar. Sub-class for the condition.
+#' @param call The call to attach to the condition (default NULL).
+#' @param ... Additional fields passed to rlang::warn().
+#' @return Invisibly NULL; always signals a warning.
+#' @keywords internal
+#' @noRd
+bfh_warn <- function(msg, class, call = NULL, ...) {
+  rlang::warn(
+    msg,
+    class = c(class, "bfhcharts_warning"),
+    call = call,
+    ...
+  )
+}
+
+# ============================================================================
 # SAFE AGGREGATION
 # ============================================================================
 

--- a/R/utils_path_policy.R
+++ b/R/utils_path_policy.R
@@ -130,8 +130,9 @@ validate_export_path <- function(path,
   ext_action <- match.arg(ext_action)
 
   if (!is.character(path) || length(path) != 1L || nchar(path) == 0L) {
-    stop("path must be a non-empty character string specifying the file path",
-      call. = FALSE
+    bfh_abort(
+      "path must be a non-empty character string specifying the file path",
+      class = "bfhcharts_export_error"
     )
   }
 
@@ -140,16 +141,20 @@ validate_export_path <- function(path,
 
   if (!is.null(extension)) {
     if (!extension %in% ALLOWED_EXPORT_EXTENSIONS) {
-      stop(
-        "extension '", extension, "' is not in the allowed export extensions: ",
-        paste(ALLOWED_EXPORT_EXTENSIONS, collapse = ", "),
-        call. = FALSE
+      bfh_abort(
+        paste0(
+          "extension '", extension, "' is not in the allowed export extensions: ",
+          paste(ALLOWED_EXPORT_EXTENSIONS, collapse = ", ")
+        ),
+        class = "bfhcharts_export_error"
       )
     }
     pattern <- paste0("\\.", extension, "$")
     if (!grepl(pattern, path, ignore.case = TRUE)) {
       msg <- paste0("path does not have .", extension, " extension: ", basename(path))
-      if (ext_action == "stop") stop(msg, call. = FALSE)
+      if (ext_action == "stop") {
+        bfh_abort(msg, class = "bfhcharts_export_error")
+      }
       if (ext_action == "warn") warning(msg, call. = FALSE)
     }
   }
@@ -162,11 +167,13 @@ validate_export_path <- function(path,
     if (!is.null(allow_root)) {
       root <- normalizePath(allow_root, mustWork = TRUE)
       if (!startsWith(resolved, root)) {
-        stop(
-          "path resolves outside the allowed root\n",
-          "  Resolved: ", resolved, "\n",
-          "  Root:     ", root,
-          call. = FALSE
+        bfh_abort(
+          paste0(
+            "path resolves outside the allowed root\n",
+            "  Resolved: ", resolved, "\n",
+            "  Root:     ", root
+          ),
+          class = "bfhcharts_export_error"
         )
       }
     }
@@ -180,30 +187,41 @@ validate_export_path <- function(path,
 .check_traversal <- function(path) {
   parts <- strsplit(path, "[/\\\\]")[[1]]
   if (any(parts == "..")) {
-    stop(
-      "path traversal attempt detected:",
-      " '..' is not allowed as a path component\n",
-      "  Provided path: ", basename(path),
-      call. = FALSE
+    bfh_abort(
+      paste0(
+        "path traversal attempt detected:",
+        " '..' is not allowed as a path component\n",
+        "  Provided path: ", basename(path)
+      ),
+      class = "bfhcharts_export_error"
     )
   }
 }
 
 .check_metachars <- function(path) {
-  # NUL-byte kan ikke optraede i R-strings under normale forhold, men kontroller
-  # for sikkerheds skyld (rawToChar/Encoding-edgecases).
+  # NUL-byte cannot appear in R strings under normal conditions, but check
+  # defensively for rawToChar/Encoding edge cases.
   if (any(charToRaw(path) == as.raw(0L))) {
-    stop("path contains disallowed unsafe characters (NUL byte)", call. = FALSE)
+    bfh_abort(
+      "path contains disallowed unsafe characters (NUL byte)",
+      class = "bfhcharts_export_error"
+    )
   }
   if (any(vapply(SHELL_METACHARS_OUTPUT_PATH, function(ch) grepl(ch, path, fixed = TRUE), logical(1L)))) {
-    stop("path contains disallowed unsafe characters", call. = FALSE)
+    bfh_abort(
+      "path contains disallowed unsafe characters",
+      class = "bfhcharts_export_error"
+    )
   }
 }
 
-# Variant til binary-stier: tillader parens/braces (Windows Program Files-stier),
-# men afviser egentlige shell-injection-tegn.
+# Variant for binary paths: allows parens/braces (Windows Program Files paths),
+# but rejects actual shell-injection characters.
 .check_metachars_binary <- function(path) {
   if (any(vapply(SHELL_METACHARS_BINARY, function(ch) grepl(ch, path, fixed = TRUE), logical(1L)))) {
-    stop("binary path contains disallowed unsafe characters", call. = FALSE)
+    bfh_abort(
+      "binary path contains disallowed unsafe characters",
+      class = "bfhcharts_export_error"
+    )
   }
 }

--- a/tests/testthat/test-bfh_qic_helpers.R
+++ b/tests/testthat/test-bfh_qic_helpers.R
@@ -679,3 +679,73 @@ test_that(".muffle_expected_warnings propagerer generel type-warning uaendret", 
   w <- capture_warnings_from_muffler("object 'foo' not found")
   expect_length(w, 1)
 })
+
+# ============================================================================
+# Classed conditions: bfhcharts_input_error
+# ============================================================================
+
+test_that("validate_bfh_qic_inputs emits bfhcharts_input_error for non-data.frame data", {
+  expect_error(
+    call_validate(data = list(x = 1:5, y = 1:5)),
+    class = "bfhcharts_input_error"
+  )
+})
+
+test_that("validate_bfh_qic_inputs emits bfhcharts_input_error for invalid chart_type", {
+  expect_error(
+    call_validate(chart_type = "xyz"),
+    class = "bfhcharts_input_error"
+  )
+})
+
+test_that("validate_bfh_qic_inputs emits bfhcharts_input_error for invalid y_axis_unit", {
+  expect_error(
+    call_validate(y_axis_unit = "liters"),
+    class = "bfhcharts_input_error"
+  )
+})
+
+test_that("validate_bfh_qic_inputs emits bfhcharts_input_error for invalid return.data", {
+  expect_error(
+    call_validate(return.data = "ja"),
+    class = "bfhcharts_input_error"
+  )
+})
+
+test_that("validate_bfh_qic_inputs emits bfhcharts_input_error for bad plot_margin", {
+  expect_error(
+    call_validate(plot_margin = c(1, 2, 3)),
+    class = "bfhcharts_input_error"
+  )
+})
+
+test_that("validate_bfh_qic_inputs emits bfhcharts_input_error for missing x column", {
+  expect_error(
+    call_validate(x_expr_char = "missing_col"),
+    class = "bfhcharts_input_error"
+  )
+})
+
+test_that("validate_bfh_qic_inputs emits bfhcharts_input_error for invalid notes", {
+  d <- data.frame(x = 1:5, y = 1:5)
+  expect_error(
+    call_validate(data = d, notes = 1:5),
+    class = "bfhcharts_input_error"
+  )
+})
+
+test_that("validate_bfh_qic_inputs emits bfhcharts_input_error for non-character target_text", {
+  expect_error(
+    call_validate(target_text = 42),
+    class = "bfhcharts_input_error"
+  )
+})
+
+test_that("bfhcharts_input_error is also a bfhcharts_error", {
+  err <- tryCatch(
+    call_validate(chart_type = "xyz"),
+    error = function(e) e
+  )
+  expect_true(inherits(err, "bfhcharts_error"))
+  expect_true(inherits(err, "bfhcharts_input_error"))
+})

--- a/tests/testthat/test-export_pdf.R
+++ b/tests/testthat/test-export_pdf.R
@@ -2011,3 +2011,50 @@ test_that("bfh_export_pdf accepts custom analysis length parameters", {
     )
   )
 })
+
+# ============================================================================
+# Classed conditions: bfhcharts_export_error
+# ============================================================================
+
+test_that("bfh_export_pdf emits bfhcharts_export_error for invalid x", {
+  temp_file <- withr::local_tempfile(fileext = ".pdf")
+  expect_error(
+    bfh_export_pdf("not a result", temp_file),
+    class = "bfhcharts_export_error"
+  )
+})
+
+test_that("bfh_export_pdf emits bfhcharts_export_error for empty output path", {
+  data <- data.frame(
+    month = seq(as.Date("2024-01-01"), by = "month", length.out = 12),
+    infections = rpois(12, lambda = 15)
+  )
+  result <- bfh_qic(data, month, infections, chart_type = "i")
+  expect_error(
+    bfh_export_pdf(result, ""),
+    class = "bfhcharts_export_error"
+  )
+})
+
+test_that("bfh_export_pdf emits bfhcharts_export_error for restrict_template violation", {
+  data <- data.frame(
+    month = seq(as.Date("2024-01-01"), by = "month", length.out = 12),
+    infections = rpois(12, lambda = 15)
+  )
+  result <- bfh_qic(data, month, infections, chart_type = "i")
+  temp_file <- withr::local_tempfile(fileext = ".pdf")
+  expect_error(
+    bfh_export_pdf(result, temp_file, template_path = "/some/template.typ"),
+    class = "bfhcharts_export_error"
+  )
+})
+
+test_that("bfhcharts_export_error is also a bfhcharts_error", {
+  temp_file <- withr::local_tempfile(fileext = ".pdf")
+  err <- tryCatch(
+    bfh_export_pdf("not a result", temp_file),
+    error = function(e) e
+  )
+  expect_true(inherits(err, "bfhcharts_error"))
+  expect_true(inherits(err, "bfhcharts_export_error"))
+})

--- a/tests/testthat/test-path-policy.R
+++ b/tests/testthat/test-path-policy.R
@@ -407,3 +407,45 @@ test_that(".safe_system2_capture applies shQuote on non-Windows (mocked)", {
     info = "POSIX branch must wrap path args in single-quotes via shQuote"
   )
 })
+
+# ============================================================================
+# Classed conditions: bfhcharts_export_error
+# ============================================================================
+
+test_that("validate_export_path emits bfhcharts_export_error for non-string path", {
+  expect_error(
+    validate_export_path(NULL),
+    class = "bfhcharts_export_error"
+  )
+  expect_error(
+    validate_export_path(""),
+    class = "bfhcharts_export_error"
+  )
+})
+
+test_that("validate_export_path emits bfhcharts_export_error for shell metacharacters", {
+  expect_error(
+    validate_export_path("out; rm -rf /"),
+    class = "bfhcharts_export_error"
+  )
+  expect_error(
+    validate_export_path("out | cat"),
+    class = "bfhcharts_export_error"
+  )
+})
+
+test_that("validate_export_path emits bfhcharts_export_error for path traversal", {
+  expect_error(
+    validate_export_path("../etc/passwd"),
+    class = "bfhcharts_export_error"
+  )
+})
+
+test_that("bfhcharts_export_error is also a bfhcharts_error", {
+  err <- tryCatch(
+    validate_export_path("out; evil"),
+    error = function(e) e
+  )
+  expect_true(inherits(err, "bfhcharts_error"))
+  expect_true(inherits(err, "bfhcharts_export_error"))
+})


### PR DESCRIPTION
## Summary

- Introduces `bfh_abort()` and `bfh_warn()` helpers in `R/utils_helpers.R` that wrap `rlang::abort()`/`rlang::warn()` with a `bfhcharts_error` / `bfhcharts_warning` super-class
- Migrates all `stop()` calls in the two targeted validation paths to use classed conditions:
  - `validate_bfh_qic_inputs()` → `bfhcharts_input_error`
  - `validate_export_path()`, `validate_bfh_export_pdf_inputs()`, `.validate_strict_baseline()`, `.validate_metadata_target()`, `validate_template_path()`, `.validate_inject_assets()` → `bfhcharts_export_error`
- Adds parallel `expect_error(..., class = "bfhcharts_input_error")` and `expect_error(..., class = "bfhcharts_export_error")` assertions in the three test files; existing regexp-tests preserved unchanged

biSPCharts can now catch by class instead of string-matching:
```r
tryCatch(bfh_qic(...), bfhcharts_input_error = function(e) { ... })
tryCatch(bfh_export_pdf(...), bfhcharts_export_error = function(e) { ... })
```

## Test plan

- [x] `devtools::test(filter = "bfh_qic_helpers|export_pdf|path_policy")` — 412 PASS, 28 SKIP (render tests)
- [x] `devtools::test(filter = "source-ascii|security|harden")` — 179 PASS, 5 SKIP, 1 pre-existing WARN
- [x] Full pre-push test suite — all tests green
- [x] ASCII compliance verified (`tools::showNonASCIIfile()` on all 5 R source files)