### PR TITLE
refactor(analysis): remove dormant legacy pipeline (closes #415)

### DIFF
--- a/R/spc_analysis.R
+++ b/R/spc_analysis.R
@@ -10,9 +10,8 @@
 
 # Konverter ASCII-operatorer (>=, <=) til Unicode-sammentrukne tegn
 # (\U2265, \U2264) i target-display-strenge til klinisk prose-rendering.
-# Bruges af baade .evaluate_target_arm() (legacy) og spc_render.R
-# (struktureret pipeline). Holder operator-mappingen i en enkelt
-# autoritativ kilde.
+# Bruges af spc_render.R (struktureret pipeline). Holder operator-mappingen
+# i en enkelt autoritativ kilde.
 .normalize_target_operators <- function(x) {
   if (is.null(x) || !nzchar(x)) {
     return(x)
@@ -26,8 +25,7 @@
 # "at" | "over" | "under" -- eller NULL hvis target ej sat. Caller
 # resolverer keys via i18n_lookup(paste0("labels.level_*.", key)).
 #
-# Erstatter dual-computation i build_fallback_analysis() (linje 990-1013)
-# og struktureret spc_render.R (.compute_level_direction +
+# Shared helper for spc_render.R (.compute_level_direction +
 # .compute_level_vs_target).
 .compute_level_keys <- function(centerline, target_value, has_target,
                                 y_axis_unit = NULL) {
@@ -61,7 +59,7 @@
 #     reference for kontekstuel praecision).
 # Returnerer TRUE naar de to display-strenge repraesenterer samme tal.
 #
-# Brugt af .compute_level_keys() + .evaluate_target_arm() til at flippe
+# Brugt af .compute_level_keys() til at flippe
 # "lige over" -> "paa maalet"/"goal_met" naar visuel lighed gaelder.
 .cl_displays_at_target_pct <- function(centerline, target_value) {
   if (!is_valid_scalar(centerline) || !is_valid_scalar(target_value)) {
@@ -76,43 +74,6 @@
   }
   cl_pct_whole <- round(centerline * 100)
   isTRUE(cl_pct_whole == target_pct_whole)
-}
-
-# Beregn near_target / at_target tolerance via sigma-cascade.
-#
-# Cascade (uaendret fra original logik):
-#   1. sigma_hat tilgaengelig     -> 3*sigma_hat (kontrolgraense-bredde / 2)
-#   2. sigma_data tilgaengelig    -> sd(y)
-#   3. ingen sigma                -> 1e-9 (kraever eksakt match)
-#
-# Percent-units (is_percent=TRUE): tolerance capes ved
-#   min(3*sigma_hat, NEAR_TARGET_PCT_CAP, NEAR_TARGET_PCT_RELATIVE * target).
-# Absolut cap (3pp) haandterer noisy processes; relativ cap (25% af target)
-# haandterer smaa-target-cases hvor 3pp stadig er klinisk for stor.
-# Eksempler:
-#   target=15%, CL=19%, delta=4pp: cap=min(sigma,3pp,3.75pp)=3pp; 4pp>3pp -> NOT near
-#   target=3%,  CL=7%,  delta=4pp: cap=min(sigma,3pp,0.75pp)=0.75pp; 4pp>0.75pp -> NOT near
-#   target=90%, CL=87%, delta=3pp: cap=min(sigma,3pp,22.5pp)=3pp; 3pp<=3pp -> NEAR
-.near_target_tolerance <- function(sigma_hat, sigma_data, is_percent,
-                                   target_value = NULL) {
-  sigma_tol <- if (is_valid_scalar(sigma_hat) && is.finite(sigma_hat) &&
-    sigma_hat > 0) {
-    3 * sigma_hat
-  } else if (is_valid_scalar(sigma_data) && is.finite(sigma_data) &&
-    sigma_data > 0) {
-    sigma_data
-  } else {
-    1e-9
-  }
-  if (isTRUE(is_percent)) {
-    caps <- c(sigma_tol, NEAR_TARGET_PCT_CAP)
-    if (is_valid_scalar(target_value) && is.finite(target_value) &&
-      target_value > 0) {
-      caps <- c(caps, NEAR_TARGET_PCT_RELATIVE * target_value)
-    }
-    return(min(caps))
-  }
-  sigma_tol
 }
 
 # Resolve target for analysis context via fallback chain.
@@ -601,8 +562,7 @@ bfh_generate_analysis <- function(x,
     stop("min_chars must be less than max_chars", call. = FALSE)
   }
 
-  # Byg struktureret analyse-objekt (Phase 2 cut-over: bfh_analyse +
-  # bfh_render_analysis erstatter monolitisk build_fallback_analysis).
+  # Byg struktureret analyse-objekt via bfh_analyse + bfh_render_analysis.
   # Public-API-signatur uaendret -- intern delegation til ny pipeline.
   spc_analysis <- bfh_analyse(x, metadata = metadata, language = language)
   baseline_analysis <- bfh_render_analysis(
@@ -737,9 +697,8 @@ bfh_generate_analysis <- function(x,
 #   has_target                            (logical, derived: target_value + centerline gyldige)
 #   outliers_for_text                     (numeric, til pluralize_da + placeholder)
 #
-# Pure: samme input -> samme output. Bruges af build_fallback_analysis() til
-# at drive cascade-dispatch og budget-allokering uden at flade detection-
-# logikken sammen med i18n-opslag.
+# Pure: samme input -> samme output. Driver cascade-dispatch og budget-
+# allokering uden at flade detection-logikken sammen med i18n-opslag.
 # Atomic Anhoej-signal-detectors. Shared mellem .detect_signal_flags()
 # (feature-extraction) og AI-path has_signals (LLM-egress gate). Holder
 # semantik konsistent paa tvaers af call-sites -- ej re-implement risiko
@@ -910,7 +869,7 @@ bfh_generate_analysis <- function(x,
 #
 # goal_met, at_target og near_target er evalueret af caller; helper er pure
 # dispatch. Prioritet i direction-aware gren: goal_met > near_target >
-# goal_not_met (matcher .evaluate_target_arm() priority).
+# goal_not_met.
 .select_action_key <- function(flags, target_direction, goal_met, at_target,
                                near_target = FALSE) {
   is_stable <- flags$is_stable
@@ -958,335 +917,6 @@ bfh_generate_analysis <- function(x,
   } else {
     if (is_stable) "stable_no_target" else "unstable_no_target"
   }
-}
-
-
-# Evaluer maalvurderings-arm af fallback-analysen.
-#
-# Returnerer named list (target_text, goal_met, at_target, near_target).
-# Bruges af orchestrator + .select_action_key().
-#
-# Tre dispatch-veje (matcher .select_action_key()'s tre cascade-grene):
-#   1. has_target + target_direction: retningsbevidst goal_met-evaluering
-#      via centerline-vs-target sammenligning + sigma-cascade for
-#      near_target naar strict-condition fejler.
-#   2. has_target uden target_direction: vaerdineutral at_target/over/under
-#      med tolerance.
-#   3. !has_target: target_text = "".
-#
-# i18n-lookup foregaar her (ikke i orchestrator) for at holde
-# orchestrator fri af cascade-strukturer.
-.evaluate_target_arm <- function(context, flags, texts, target_budget,
-                                 language = "da",
-                                 extra_placeholders = list()) {
-  result <- list(
-    target_text = "", goal_met = FALSE,
-    at_target = FALSE, near_target = FALSE
-  )
-  if (!flags$has_target) {
-    return(result)
-  }
-
-  target_value <- context$target_value
-  target_direction <- context$target_direction
-  centerline <- context$centerline
-
-  # Foretraek display-streng fra input (fx "<= 2,5"), ellers format numerisk.
-  # language threades igennem til format_target_value() saa engelsk
-  # analyse-tekst faar "1.5" og dansk faar "1,5" (cycle 01 finding E4).
-  display_target <- if (!is.null(context$target_display) &&
-    nzchar(context$target_display)) {
-    context$target_display
-  } else {
-    format_target_value(target_value,
-      y_axis_unit = context$y_axis_unit,
-      language = language
-    )
-  }
-
-  # Erstat ASCII-operatorer med Unicode-sammentrukne tegn i analyseteksten.
-  # context$target_display selv bevares uaendret (invariant fra resolve_target()).
-  display_target <- .normalize_target_operators(display_target)
-
-  # Merge target-display med globale placeholders (level_direction, level_vs_target).
-  # Target tager precedence saa specifik target-display ikke kan overskrives.
-  data <- modifyList(extra_placeholders, list(target = display_target))
-
-  y_axis_unit <- context$y_axis_unit
-  is_percent <- identical(y_axis_unit, "percent")
-
-  if (!is.null(target_direction)) {
-    # Retningsbevidst: prioritet er strikt goal_met > near_target >
-    # goal_not_met. CL paa korrekt side af target laeses altid som
-    # "opfyldt" uanset afstand; near_target reserveres for "forkert side
-    # men inden for proces-stoej" (sigma-cascade matcher path A).
-    #
-    # Percent-units: display-precision-equality check foer strikt-numeric.
-    # CL og target der afrunder til samme chart-display-vaerdi (fx 1,0%
-    # vs 1%) klassificeres som goal_met. Forhindrer "lige over"-tekst
-    # naar laeseren visuelt ser CL paa maalstregen.
-    display_equal <- is_percent &&
-      .cl_displays_at_target_pct(centerline, target_value)
-    result$goal_met <- display_equal || switch(target_direction,
-      "higher" = centerline >= target_value,
-      "lower"  = centerline <= target_value,
-      FALSE
-    )
-    if (!result$goal_met) {
-      # Strict-condition fejler -- check om delta er inden for tolerance.
-      # Samme tre-vejs cascade som value-neutral gren (sigma_hat ->
-      # sigma_data -> eksakt). Tolerance-faldet for higher/lower er
-      # symmetrisk om target; retningen kodes via {level_direction}.
-      delta <- abs(centerline - target_value)
-      tolerance <- .near_target_tolerance(
-        context$sigma_hat, context$sigma_data, is_percent,
-        target_value = target_value
-      )
-      result$near_target <- delta <= tolerance
-    }
-    key <- if (result$goal_met) {
-      "goal_met"
-    } else if (result$near_target) {
-      "near_target"
-    } else {
-      "goal_not_met"
-    }
-    result$target_text <- pick_text(texts$target[[key]],
-      data = data,
-      budget = target_budget
-    )
-  } else {
-    # Vaerdineutral: at/over/under target med processkala-tolerance.
-    # Tre-vejs cascade (se openspec change at-target-tolerance-process-variation):
-    #   1. Kontrolgraense-baseret: |CL - target| <= 3 * sigma_hat
-    #      (svarer trivielt til LCL <= target <= UCL ved konstante 3-sigma-graenser)
-    #   2. Data-sigma fallback:    |CL - target| <= sd(y)
-    #      (run charts og no_variation hvor kontrolgraenser mangler)
-    #   3. Eksakt-match:           |CL - target| < 1e-9
-    #      (degenereret: konstant y, n=1, eller begge sigma er 0)
-    # Percent-units: capped ved NEAR_TARGET_PCT_CAP saa stoejende processer
-    # ej ratiionaliserer fjern-CL som "taet paa" (parity med direction-aware).
-    delta <- abs(centerline - target_value)
-    display_equal <- is_percent &&
-      .cl_displays_at_target_pct(centerline, target_value)
-    is_at_target <- display_equal ||
-      delta <= .near_target_tolerance(
-        context$sigma_hat, context$sigma_data, is_percent,
-        target_value = target_value
-      )
-    if (is_at_target) {
-      result$target_text <- pick_text(texts$target$at_target,
-        data = data,
-        budget = target_budget
-      )
-      result$at_target <- TRUE
-    } else if (centerline > target_value) {
-      result$target_text <- pick_text(texts$target$over_target,
-        data = data,
-        budget = target_budget
-      )
-    } else {
-      result$target_text <- pick_text(texts$target$under_target,
-        data = data,
-        budget = target_budget
-      )
-    }
-  }
-
-  result
-}
-
-
-# Intern funktion: Byg komplet fallback-analysetekst.
-#
-# BACKWARD-COMPAT LAYER (post-Phase-2 cut-over):
-# Primary path for bfh_generate_analysis() er nu bfh_analyse() +
-# bfh_render_analysis() (R/spc_compose.R + R/spc_render.R).
-# build_fallback_analysis bevares som intern fallback for direct-callere
-# (test-spc_analysis.R + eventuelle eksterne :::-konsumenter) -- vil
-# blive fjernet i naeste major release efter mindst et stabilt release-
-# cycle med den nye pipeline.
-#
-# Allokerer tegnbudget til stability/target/action dele og vaelger
-# passende variant for hver del. Naar context$target_direction er
-# non-NULL (udledt fra fx "<= 2,5"), bruges retningsbevidst maal-
-# vurdering (goal_met/goal_not_met) i stedet for vaerdineutral
-# at/over/under. ensure_within_max garanterer max_chars-graensen.
-#
-# @keywords internal
-# @noRd
-build_fallback_analysis <- function(context,
-                                    max_chars = 375,
-                                    language = "da",
-                                    texts_loader = NULL) {
-  if (is.null(texts_loader)) {
-    texts_loader <- function() load_spc_texts(language)
-  }
-  spc_stats <- context$spc_stats
-  target_value <- context$target_value
-  target_direction <- context$target_direction
-  centerline <- context$centerline
-  n_points <- context$n_points
-
-  # --- Detect signaler + target-tilstand ---
-  flags <- .detect_signal_flags(context)
-  has_runs <- flags$has_runs
-  has_crossings <- flags$has_crossings
-  has_outliers <- flags$has_outliers
-  is_stable <- flags$is_stable
-  no_variation <- flags$no_variation
-  has_target <- flags$has_target
-  outliers_for_text <- flags$outliers_for_text
-
-  # --- Budget-allokering ---
-  budgets <- .allocate_text_budget(max_chars, has_target)
-  stability_budget <- budgets$stability_budget
-  target_budget <- budgets$target_budget
-  action_budget <- budgets$action_budget
-
-  if (!is.function(texts_loader)) {
-    stop("texts_loader must be a function", call. = FALSE)
-  }
-  texts <- texts_loader()
-  # outliers_actual i placeholder_data bruger recent_count-vaerdien, saa YAML-
-  # skabelonernes {outliers_actual} placeholder ogsaa foelger "seneste 6 obs"-
-  # reglen. outliers_word giver korrekt dansk ental/flertal for 1 vs n.
-  outliers_n <- if (is_valid_scalar(outliers_for_text)) outliers_for_text else 0L
-
-  # level_direction / level_vs_target: target-relative position af centerlinje.
-  # Bruges som placeholders til at sammensaette saetninger som
-  # "Niveauet {level_vs_target} ({target})" -> "Niveauet ligger under maalet (90%)".
-  # For percent-units: "paa" rendres naar CL og target afrunder til samme
-  # chart-display-vaerdi (display-precision-equality). For andre units:
-  # strikt lighedstest (delta < 1e-9). Tomme strenge naar target ikke er
-  # sat, saa placeholderne kan staa i templates uden at generere fejl,
-  # men bor kun bruges i target-/goal-specifikke varianter for at give
-  # meningsfuld tekst.
-  level_keys <- .compute_level_keys(centerline, target_value, flags$has_target,
-    y_axis_unit = context$y_axis_unit)
-  level_direction <- if (!is.null(level_keys)) {
-    i18n_lookup(paste0("labels.level_direction.", level_keys$direction_key), language)
-  } else {
-    ""
-  }
-  level_vs_target <- if (!is.null(level_keys)) {
-    i18n_lookup(paste0("labels.level_vs_target.", level_keys$vs_target_key), language)
-  } else {
-    ""
-  }
-
-  # Formateret centerline-vaerdi til {centerline}-placeholder. Bruger
-  # format_target_value() saa centerline rendres pa samme skala som y-aksen
-  # (fx 85% paa percent-charts, 3.2 paa numeric-charts). target threades
-  # gennem saa percent-CL bevarer en decimal naar |CL - target| <= 2pp --
-  # matcher chart-label-praecision (format_y_value via
-  # format_percent_contextual). Tom-fallback til "ukendt"-label naar
-  # centerline er NULL/NA (degenereret data-tilfaelde).
-  cl_fmt <- if (!is.null(centerline) && !is.na(centerline)) {
-    format_target_value(centerline,
-      y_axis_unit = context$y_axis_unit,
-      language = language,
-      target = target_value
-    )
-  } else {
-    i18n_lookup("labels.misc.ukendt", language)
-  }
-
-  placeholder_data <- list(
-    runs_actual = spc_stats$runs_actual,
-    runs_expected = spc_stats$runs_expected,
-    crossings_actual = spc_stats$crossings_actual,
-    crossings_expected = spc_stats$crossings_expected,
-    outliers_actual = outliers_for_text,
-    outliers_word = pluralize_da(
-      outliers_n,
-      i18n_lookup("labels.outliers.singular", language),
-      i18n_lookup("labels.outliers.plural", language)
-    ),
-    effective_window = spc_stats$effective_window %||% RECENT_OBS_WINDOW,
-    centerline = cl_fmt,
-    level_direction = level_direction,
-    level_vs_target = level_vs_target
-  )
-
-  # --- 1. Stabilitetstekst ---
-  # Prioritet: no_variation > majority_at_centerline > auto_mean_unstable >
-  # signal-baseret dispatch.
-  # no_variation kraever Anhoej-stats er NA (alle identiske); majority_at_cl
-  # tillader normal variation men flagger >= 50% punkter eksakt paa CL;
-  # auto_mean_unstable fyrer naar CL er auto-skiftet til gennemsnit pga
-  # majoritets-paa-median, men signaler stadig er til stede.
-  if (no_variation) {
-    stability <- pick_text(
-      texts$stability$no_variation,
-      data = list(centerline = cl_fmt),
-      budget = stability_budget
-    )
-  } else if (isTRUE(flags$majority_at_cl)) {
-    stability <- pick_text(
-      texts$stability$majority_at_centerline,
-      data = list(centerline = cl_fmt),
-      budget = stability_budget
-    )
-  } else if (isTRUE(flags$auto_mean_unstable)) {
-    stability <- pick_text(
-      texts$stability$auto_mean_unstable,
-      data = list(centerline = cl_fmt),
-      budget = stability_budget
-    )
-  } else {
-    key <- .select_stability_key(flags)
-    stability <- pick_text(texts$stability[[key]],
-      data = placeholder_data,
-      budget = stability_budget
-    )
-  }
-
-  # --- 2. Maalvurdering ---
-  # extra_placeholders giver target-templates adgang til {level_direction},
-  # {level_vs_target} og {centerline} ved siden af det allerede formaterede
-  # {target}.
-  target_eval <- .evaluate_target_arm(
-    context, flags, texts,
-    target_budget,
-    language = language,
-    extra_placeholders = list(
-      centerline = cl_fmt,
-      level_direction = level_direction,
-      level_vs_target = level_vs_target
-    )
-  )
-  target_text <- target_eval$target_text
-  goal_met <- target_eval$goal_met
-  at_target <- target_eval$at_target
-  near_target <- target_eval$near_target
-
-  # --- 3. Handlingsforslag ---
-  # action-templates faar ogsaa adgang til level_*- og centerline-placeholders
-  # saa goal_met/goal_not_met-tekster kan beskrive niveau-position i forhold
-  # til maal.
-  action_key <- .select_action_key(flags, target_direction, goal_met,
-    at_target,
-    near_target = near_target
-  )
-  action <- pick_text(texts$action[[action_key]],
-    data = list(
-      centerline = cl_fmt,
-      level_direction = level_direction,
-      level_vs_target = level_vs_target
-    ),
-    budget = action_budget
-  )
-
-  # --- Kombiner ---
-  parts <- c(stability, target_text, action)
-  parts <- parts[nchar(parts) > 0]
-  text <- paste(parts, collapse = " ")
-
-  # --- Garanter max_chars-graensen (trim ved saetnings-/klausulgraense) ---
-  text <- ensure_within_max(text, max_chars)
-
-  return(text)
 }
 
 

--- a/tests/testthat/helper-fixtures.R
+++ b/tests/testthat/helper-fixtures.R
@@ -233,7 +233,7 @@ fixture_test_chart <- function(title = "Test", n = 12, lambda = 15) {
 # Analysis context (spc_analysis tests)
 # ----------------------------------------------------------------------------
 
-#' Minimal analyse-context til build_fallback_analysis() tests
+#' Minimal analyse-context (synthetic list matching bfh_build_analysis_context output)
 #'
 #' Konsoliderer `make_ctx()` fra test-spc_analysis.R.
 #'

--- a/tests/testthat/test-spc_analysis.R
+++ b/tests/testthat/test-spc_analysis.R
@@ -280,13 +280,6 @@ test_that("bfh_generate_analysis threads texts_loader to fallback pipeline", {
   expect_match(analysis, "CUSTOM_ACTION")
 })
 
-test_that("build_fallback_analysis validates texts_loader", {
-  expect_error(
-    BFHcharts:::build_fallback_analysis(list(), texts_loader = "bad"),
-    "texts_loader must be a function"
-  )
-})
-
 # ==============================================================================
 # pick_text() tests (intern funktion)
 # ==============================================================================
@@ -552,107 +545,156 @@ test_that("bfh_build_analysis_context bevarer numerisk target uden retning", {
 
 
 # ==============================================================================
-# build_fallback_analysis() — goal_met/goal_not_met + constraints
+# bfh_render_analysis() — goal_met/goal_not_met + constraints
+# (ported from legacy build_fallback_analysis tests per ADR-004)
 # ==============================================================================
 
-# Hjælpefunktion: fixture_analysis_context() er tilgængelig via helper-fixtures.R.
-
-test_that("build_fallback_analysis overstiger aldrig max_chars", {
+test_that("bfh_render_analysis overstiger aldrig max_chars", {
+  # Lower-direction: CL (45) <= target (50) -> goal_met. Stable data.
+  withr::with_seed(71L, {
+    d <- data.frame(
+      date  = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
+      value = round(rnorm(24, 45, 2), 1)
+    )
+  })
+  result <- bfh_qic(d,
+    x = date, y = value, chart_type = "i",
+    target_text = "<= 50"
+  )
+  analysis <- bfh_analyse(result)
   for (mx in c(200L, 275L, 375L, 500L)) {
-    ctx <- fixture_analysis_context(target_value = 50, target_direction = "lower", centerline = 45)
-    txt <- BFHcharts:::build_fallback_analysis(ctx, max_chars = mx)
+    txt <- bfh_render_analysis(analysis, max_chars = mx)
     expect_lte(nchar(txt), mx,
       label = sprintf("max_chars=%d giver %d tegn", mx, nchar(txt))
     )
   }
 })
 
-test_that("build_fallback_analysis bruger goal_met-tekst når target_direction er 'lower' og CL <= target", {
-  ctx <- fixture_analysis_context(
-    target_value = 2.5, target_direction = "lower", centerline = 2.0,
-    target_display = "<= 2,5"
+test_that("bfh_render_analysis bruger goal_met-tekst naar target_direction er 'lower' og CL <= target", {
+  # Lower-direction: steady process at mean=2.0, target="<= 2.5" -> goal_met.
+  withr::with_seed(72L, {
+    d <- data.frame(
+      date  = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
+      value = round(rnorm(24, 2.0, 0.1), 2)
+    )
+  })
+  result <- bfh_qic(d,
+    x = date, y = value, chart_type = "i",
+    target_text = "<= 2.5"
   )
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  # Skal INDEHOLDE "opfylder målet" eller "målet ... nået"
+  analysis <- bfh_analyse(result)
+  txt <- bfh_render_analysis(analysis)
+  # Skal INDEHOLDE "opfylder malet" eller "malet ... naet"
   expect_true(grepl("opfylder (udviklings)?målet|målet.*nået", txt),
     info = paste("Forventede goal_met-sprog, fik:", txt)
   )
-  # Må IKKE indeholde den værdineutrale "ligger under målet"
+  # Ma IKKE indeholde den vaerdineutrale "ligger under maalet"
   expect_false(grepl("ligger under målet", txt))
 })
 
-test_that("build_fallback_analysis bruger goal_not_met når CL overstiger 'lower'-target", {
-  ctx <- fixture_analysis_context(
-    target_value = 2.5, target_direction = "lower", centerline = 4.0,
-    target_display = "<= 2,5"
+test_that("bfh_render_analysis bruger goal_not_met naar CL overstiger 'lower'-target", {
+  # Lower-direction: steady process at mean=4.0, target="<= 2.5" -> goal_not_met.
+  withr::with_seed(73L, {
+    d <- data.frame(
+      date  = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
+      value = round(rnorm(24, 4.0, 0.1), 2)
+    )
+  })
+  result <- bfh_qic(d,
+    x = date, y = value, chart_type = "i",
+    target_text = "<= 2.5"
   )
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  # goal_not_met-tekster udtrykker negation paa flere maader afhaengigt af
-  # variant: "opfylder (endnu )?ikke maalet", "endnu ikke naaet", "er ikke
-  # naaet", "naar ikke (udviklings)?maalet". Daekker alle nuvaerende formuleringer.
-  expect_true(grepl("opfylder (endnu )?ikke (udviklings)?målet|endnu ikke nået|er ikke nået|når ikke (udviklings)?målet", txt),
+  analysis <- bfh_analyse(result)
+  txt <- bfh_render_analysis(analysis)
+  # goal_not_met-tekster: "opfylder (endnu )?ikke maalet", "endnu ikke naet",
+  # "er ikke naet", "naar ikke (udviklings)?maalet".
+  expect_true(
+    grepl("opfylder (endnu )?ikke (udviklings)?målet|endnu ikke nået|er ikke nået|når ikke (udviklings)?målet", txt),
     info = paste("Forventede goal_not_met-sprog, fik:", txt)
   )
 })
 
-test_that("build_fallback_analysis bruger goal_met for 'higher'-target når CL >= target", {
-  ctx <- fixture_analysis_context(
-    target_value = 90, target_direction = "higher", centerline = 95,
-    target_display = ">= 90"
+test_that("bfh_render_analysis bruger goal_met for 'higher'-target naar CL >= target", {
+  # Higher-direction: steady process at mean=95, target=">= 90" -> goal_met.
+  withr::with_seed(74L, {
+    d <- data.frame(
+      date  = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
+      value = round(rnorm(24, 95, 1), 1)
+    )
+  })
+  result <- bfh_qic(d,
+    x = date, y = value, chart_type = "i",
+    target_text = ">= 90"
   )
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
+  analysis <- bfh_analyse(result)
+  txt <- bfh_render_analysis(analysis)
   expect_true(grepl("opfylder (udviklings)?målet|målet.*nået", txt),
     info = paste("Forventede goal_met, fik:", txt)
   )
 })
 
-test_that("build_fallback_analysis bruger værdineutral tekst når target_direction er NULL", {
-  ctx <- fixture_analysis_context(target_value = 2.5, target_direction = NULL, centerline = 3.0)
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  # Den værdineutrale sti bruger "over" / "under" / "tæt på"
+test_that("bfh_render_analysis bruger vaerdineutral tekst naar target_direction er NULL", {
+  # Numeric target (no direction operator): CL ~3.0 vs target=2.5 -> over_target.
+  withr::with_seed(75L, {
+    d <- data.frame(
+      date  = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
+      value = round(rnorm(24, 3.0, 0.1), 2)
+    )
+  })
+  result <- bfh_qic(d,
+    x = date, y = value, chart_type = "i",
+    target_value = 2.5
+  )
+  analysis <- bfh_analyse(result)
+  txt <- bfh_render_analysis(analysis)
+  # Vaerdineutral sti: "over" / "under" / "taet paa"
   expect_true(grepl("over|under|tæt på", txt))
 })
 
-test_that("build_fallback_analysis reallokerer budget når target mangler", {
-  ctx_no_target <- fixture_analysis_context(target_value = NA_real_, target_direction = NULL)
-  txt <- BFHcharts:::build_fallback_analysis(ctx_no_target, max_chars = 400)
-  # Uden target skal stability+action fylde meste af max_chars.
-  # Floor justeret 250 -> 240 efter text-stramninger 2026-05 (cycle 06):
-  # stability.no_signals.detailed og action.stable_no_target.detailed
-  # blev forkortet -- ren tekst-justering, ej budget-allokerings-bug.
+test_that("bfh_render_analysis reallokerer budget naar target mangler", {
+  # No target -> stability+action fylder meste af max_chars.
+  d <- fixture_phase_stable()
+  result <- bfh_qic(d, x = date, y = value, chart_type = "i")
+  analysis <- bfh_analyse(result)
+  txt <- bfh_render_analysis(analysis, max_chars = 400)
+  # Floor justeret 250 -> 240 efter text-stramninger 2026-05 (cycle 06).
   expect_gte(nchar(txt), 240)
   expect_lte(nchar(txt), 400)
 })
 
-test_that("build_fallback_analysis bruger ental ved 1 outlier", {
-  stats <- list(
-    runs_actual = 5, runs_expected = 7,
-    crossings_actual = 8, crossings_expected = 5,
-    outliers_recent_count = 1
+test_that("bfh_render_analysis bruger ental ved 1 outlier", {
+  # Data med en enkelt outlier: 23 obs taet paa 50 + 1 obs >> UCL.
+  withr::with_seed(76L, {
+    vals <- round(rnorm(23, 50, 2), 1)
+  })
+  vals <- c(vals, 80) # klar outlier (langt over UCL)
+  d <- data.frame(
+    date  = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
+    value = vals
   )
-  ctx <- fixture_analysis_context(spc_stats = stats)
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  # Grammatisk korrekt dansk: enten "1 observation ligger" (direkte) eller
-  # "1 af de seneste [N] observationer ligger" (flertal i "af de seneste"-konstruktion,
-  # muligvis med et vinduesantal indskudt).
+  result <- bfh_qic(d, x = date, y = value, chart_type = "i")
+  analysis <- bfh_analyse(result)
+  txt <- bfh_render_analysis(analysis)
+  # Enten "1 observation" (direkte) eller "1 af de seneste [N] observationer"
   expect_match(txt, "1 observation\\b|1 af de seneste \\d* ?observationer")
-  # Må ikke indeholde "1 observationer" som direkte konstruktion
   expect_false(grepl("\\b1 observationer\\b", txt))
 })
 
-test_that("build_fallback_analysis bruger flertal ved 3 outliers", {
-  stats <- list(
-    runs_actual = 5, runs_expected = 7,
-    crossings_actual = 8, crossings_expected = 5,
-    outliers_recent_count = 3
+test_that("bfh_render_analysis bruger flertal ved 3 outliers", {
+  # Data med 3 outliers: 21 obs taet paa 50 + 3 obs >> UCL.
+  withr::with_seed(77L, {
+    vals <- round(rnorm(21, 50, 2), 1)
+  })
+  vals <- c(vals, 80, 82, 85) # 3 klare outliers
+  d <- data.frame(
+    date  = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
+    value = vals
   )
-  ctx <- fixture_analysis_context(spc_stats = stats)
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  # Grammatisk korrekt dansk: enten "3 observationer" (direkte) eller
-  # "3 af de seneste [N] observationer" (flertal i "af de seneste"-konstruktion,
-  # muligvis med et vinduesantal indskudt).
+  result <- bfh_qic(d, x = date, y = value, chart_type = "i")
+  analysis <- bfh_analyse(result)
+  txt <- bfh_render_analysis(analysis)
+  # Enten "3 observationer" (direkte) eller "3 af de seneste [N] observationer"
   expect_match(txt, "3 observationer|3 af de seneste \\d* ?observationer")
-  # Må aldrig bruge ental efter tal > 1
   expect_false(grepl("\\b3 observation\\b", txt))
 })
 
@@ -774,26 +816,29 @@ test_that("REGRESSION: bfh_build_analysis_context normaliserer '>= 90%' til 0.90
   expect_equal(ctx$target_direction, "higher")
 })
 
-test_that("REGRESSION: build_fallback_analysis producerer 'opfylder målet' for 91% vs >= 90%", {
-  # Dette er den direkte kliniske konsekvens-test:
-  # Med normaliseret target (0.90) og centerline (0.91) skal goal_met = TRUE
-  ctx <- fixture_analysis_context(
-    chart_type = "p",
-    y_axis_unit = "percent",
-    centerline = 0.91,
-    target_value = 0.90, # normaliseret (bug: var 90 -> FALSE)
-    target_direction = "higher",
-    target_display = ">= 90%"
+test_that("REGRESSION: bfh_render_analysis producerer 'opfylder maalet' for 91% vs >= 90%", {
+  # Direkte klinisk konsekvens-test: normaliseret target (0.90) og CL (0.91)
+  # skal give goal_met = TRUE (bug: target var 90 -> goal_met = FALSE).
+  set.seed(78L)
+  p_data <- data.frame(
+    date   = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
+    n      = rep(100L, 24),
+    events = rep(91L, 24) # 91% -> CL ~0.91
   )
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
+  result <- bfh_qic(p_data,
+    x = date, y = events, n = n,
+    chart_type = "p", y_axis_unit = "percent"
+  )
+  analysis <- bfh_analyse(result, metadata = list(target = ">= 90%"))
+  txt <- bfh_render_analysis(analysis)
 
-  # Teksten bør bekræfte at målet er nået
+  # Teksten skal bekraefte at maalet er naet
   expect_match(txt, "opfylder (udviklings)?målet|målet.*opfyldt|målet.*nået",
-    label = "Skal indeholde positivt målbekræftelse"
+    label = "Skal indeholde positivt maalbekraeftelse"
   )
   # Og IKKE den fejlagtige negative tekst
   expect_false(grepl("endnu ikke nået|opfylder ikke", txt),
-    label = "Må ikke indeholde fejlagtig negation"
+    label = "Ma ikke indeholde fejlagtig negation"
   )
 })
 
@@ -817,9 +862,10 @@ test_that("REGRESSION: lower-direction 3% vs '<= 5%' -> goal_met via normaliseri
   )
   expect_equal(ctx$target_direction, "lower")
 
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
+  analysis <- bfh_analyse(result, metadata = list(target = "<= 5%"))
+  txt <- bfh_render_analysis(analysis)
   expect_match(txt, "opfylder (udviklings)?målet|målet.*opfyldt",
-    label = "3% opfylder <= 5% mål"
+    label = "3% opfylder <= 5% maal"
   )
 })
 
@@ -1004,126 +1050,96 @@ test_that("Target fallback: no target anywhere yields NA target_value", {
 })
 
 # ==============================================================================
-# Process-variation-based at_target classification
+# Process-variation-based at_target classification via .within_sigma_tolerance
 # (openspec change: at-target-tolerance-process-variation)
+# Tests ported to .within_sigma_tolerance() (spc_features.R live implementation)
 # ==============================================================================
 
-test_that("at_target classifies CORRECTLY for tight process with small target (bug reproducer)", {
-  # Bug rapporteret af maintainer: target = "<1%" (proportionsskala: 0.01),
-  # centerline = 0.019, smalle kontrolgraenser (UCL-LCL ~= 0.01).
-  # Under den gamle regel: tolerance = max(0.01*0.05, 0.01) = 0.01 dominerer ->
-  # |0.019-0.01| = 0.009 <= 0.01 -> at_target = TRUE (forkert).
-  # Under den nye regel: sigma_hat = 0.01/6 ~= 0.0017, 3*sigma_hat ~= 0.005 ->
-  # 0.009 > 0.005 -> at_target = FALSE (korrekt).
-  # NB: target_direction = NULL, ellers rammer vi goal_not_met-grenen.
-  ctx <- fixture_analysis_context(
-    target_value = 0.01,
-    target_direction = NULL,
-    centerline = 0.019,
-    sigma_hat = 0.01 / 6, # half-width = 3*sigma => sigma = (UCL-LCL)/6
-    sigma_data = 0.002,
-    target_display = "0.01"
-  )
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  expect_true(grepl("over (udviklings)?m.let|over (udviklings)?malet", txt),
-    info = paste("Forventede over_target, fik:", txt)
-  )
-  expect_false(grepl("t.t p. (udviklings)?m.let|naer (udviklings)?m.let", txt))
-})
-
-test_that("at_target classifies CORRECTLY when target is inside wide control limits", {
-  # Vid process: UCL=12, LCL=2 -> sigma_hat = 10/6 ~= 1.67, 3*sigma_hat = 5.
-  # target=5, centerline=7 -> |7-5|=2 <= 5 -> at_target = TRUE.
-  ctx <- fixture_analysis_context(
-    target_value = 5,
-    target_direction = NULL,
-    centerline = 7,
-    sigma_hat = 10 / 6,
-    target_display = "5"
-  )
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  expect_true(grepl("t.t p. (udviklings)?m.let", txt),
-    info = paste("Forventede at_target, fik:", txt)
+test_that(".within_sigma_tolerance: tight process with small target -> NOT within", {
+  # Bug reproducer: target=0.01, delta=0.009, sigma_hat=0.01/6 ~=0.0017,
+  # 3*sigma_hat ~=0.005 -> delta (0.009) > tolerance (0.005) -> FALSE.
+  # Under the old rule max(0.01*0.05, 0.01)=0.01 dominated -> at_target (wrong).
+  sigma_hat <- 0.01 / 6
+  delta <- abs(0.019 - 0.01) # 0.009
+  expect_false(
+    BFHcharts:::.within_sigma_tolerance(delta, sigma_hat,
+      sigma_data = 0.002,
+      sigma_multiplier_hat = 3, is_percent = FALSE
+    ),
+    label = "delta=0.009 exceeds 3*sigma_hat=0.005 -> not within"
   )
 })
 
-test_that("at_target falls back to sd(y) when sigma_hat is NA (run chart)", {
-  # Run chart har ingen UCL/LCL -> sigma_hat = NA, men sigma_data = sd(y).
-  # target=10, centerline=11, sd(y)=2 -> |11-10|=1 <= 2 -> at_target = TRUE.
-  ctx <- fixture_analysis_context(
-    target_value = 10,
-    target_direction = NULL,
-    centerline = 11,
-    sigma_hat = NA_real_,
-    sigma_data = 2,
-    target_display = "10"
-  )
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  expect_true(grepl("t.t p. (udviklings)?m.let", txt),
-    info = paste("Forventede at_target via sd-fallback, fik:", txt)
+test_that(".within_sigma_tolerance: wide control limits -> within", {
+  # Vid process: UCL=12, LCL=2 -> sigma_hat=10/6~=1.67, 3*sigma_hat=5.
+  # delta=|7-5|=2 <= 5 -> TRUE.
+  sigma_hat <- 10 / 6
+  delta <- abs(7 - 5) # 2
+  expect_true(
+    BFHcharts:::.within_sigma_tolerance(delta, sigma_hat,
+      sigma_data = NA_real_,
+      sigma_multiplier_hat = 3, is_percent = FALSE
+    ),
+    label = "delta=2 <= 3*sigma_hat=5 -> within"
   )
 })
 
-test_that("at_target falls back to sd(y) and classifies over_target when delta exceeds sd", {
-  # Run chart hvor target ligger uden for sd-baeltet.
-  ctx <- fixture_analysis_context(
-    target_value = 10,
-    target_direction = NULL,
-    centerline = 15,
-    sigma_hat = NA_real_,
-    sigma_data = 2,
-    target_display = "10"
-  )
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  expect_true(grepl("over (udviklings)?m.let", txt),
-    info = paste("Forventede over_target, fik:", txt)
+test_that(".within_sigma_tolerance: sd(y) fallback when sigma_hat is NA (run chart)", {
+  # sigma_hat=NA, sigma_data=2 -> tolerance=2. delta=|11-10|=1 <= 2 -> TRUE.
+  delta <- abs(11 - 10) # 1
+  expect_true(
+    BFHcharts:::.within_sigma_tolerance(delta,
+      sigma_hat = NA_real_,
+      sigma_data = 2, sigma_multiplier_hat = 3, is_percent = FALSE
+    ),
+    label = "delta=1 <= sigma_data=2 -> within via sd-fallback"
   )
 })
 
-test_that("at_target uses exact-match when both sigma_hat and sigma_data are zero/NA", {
-  # Degenereret case: konstant y, ingen variation. CL == target -> at_target.
-  ctx <- fixture_analysis_context(
-    target_value = 5,
-    target_direction = NULL,
-    centerline = 5,
-    sigma_hat = 0,
-    sigma_data = 0,
-    target_display = "5"
-  )
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  expect_true(grepl("t.t p. (udviklings)?m.let", txt),
-    info = paste("Forventede at_target via eksakt-match, fik:", txt)
+test_that(".within_sigma_tolerance: sd(y) fallback -> NOT within when delta exceeds sd", {
+  # sigma_hat=NA, sigma_data=2. delta=|15-10|=5 > 2 -> FALSE.
+  delta <- abs(15 - 10) # 5
+  expect_false(
+    BFHcharts:::.within_sigma_tolerance(delta,
+      sigma_hat = NA_real_,
+      sigma_data = 2, sigma_multiplier_hat = 3, is_percent = FALSE
+    ),
+    label = "delta=5 > sigma_data=2 -> not within"
   )
 })
 
-test_that("at_target eksakt-match: lille forskel klassificeres som over/under", {
-  # CL er minimalt over target med ingen variation -> over_target.
-  ctx <- fixture_analysis_context(
-    target_value = 5,
-    target_direction = NULL,
-    centerline = 5.001,
-    sigma_hat = 0,
-    sigma_data = 0,
-    target_display = "5"
+test_that(".within_sigma_tolerance: exact-match (sigma=0) -> TRUE when delta=0", {
+  # Degenereret case: konstant y, sigma=0. CL==target -> delta=0 <= 1e-9 -> TRUE.
+  expect_true(
+    BFHcharts:::.within_sigma_tolerance(0,
+      sigma_hat = 0, sigma_data = 0,
+      sigma_multiplier_hat = 3, is_percent = FALSE
+    ),
+    label = "delta=0 <= 1e-9 tolerance -> within (exact match)"
   )
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  expect_true(grepl("over (udviklings)?m.let", txt))
 })
 
-test_that("at_target classifies inclusively at the 3*sigma_hat boundary", {
-  # Boundary case: |CL - target| = 3*sigma_hat exactly.
-  # Forventning: <=-konvention inkluderer graensen -> at_target.
+test_that(".within_sigma_tolerance: exact-match (sigma=0) -> FALSE when delta > 0", {
+  # CL minimalt over target, ingen variation -> delta=0.001 > 1e-9 -> FALSE.
+  expect_false(
+    BFHcharts:::.within_sigma_tolerance(0.001,
+      sigma_hat = 0, sigma_data = 0,
+      sigma_multiplier_hat = 3, is_percent = FALSE
+    ),
+    label = "delta=0.001 > 1e-9 tolerance -> not within"
+  )
+})
+
+test_that(".within_sigma_tolerance: inclusive at the 3*sigma_hat boundary", {
+  # Boundary: |CL - target| = 3*sigma_hat exactly. <=konvention -> TRUE.
   sigma <- 1
-  ctx <- fixture_analysis_context(
-    target_value = 8,
-    target_direction = NULL,
-    centerline = 5,
-    sigma_hat = sigma, # 3*sigma = 3; |5-8| = 3 = 3 -> at_target
-    target_display = "8"
-  )
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  expect_true(grepl("t.t p. (udviklings)?m.let", txt),
-    info = paste("Forventede at_target ved <=-graense, fik:", txt)
+  delta <- 3 * sigma # exactly at boundary
+  expect_true(
+    BFHcharts:::.within_sigma_tolerance(delta,
+      sigma_hat = sigma,
+      sigma_data = NA_real_, sigma_multiplier_hat = 3, is_percent = FALSE
+    ),
+    label = "delta = 3*sigma exactly -> within (inclusive boundary)"
   )
 })
 


### PR DESCRIPTION
## Summary

- Removes `build_fallback_analysis()`, `.evaluate_target_arm()`, `.near_target_tolerance()` per ADR-004
- These were the pre-Phase-2 monolithic analysis pipeline, fully superseded by `bfh_analyse()` + `bfh_render_analysis()`
- Deletes 367 lines from `R/spc_analysis.R`

## Test migrations

- **8 assertions ported** to `bfh_analyse()` + `bfh_render_analysis()` using real `bfh_qic_result` fixtures (goal_met/goal_not_met/at_target/budget/singular-plural)
- **7 sigma-cascade assertions ported** to `.within_sigma_tolerance()` direct unit tests (the live implementation in `spc_features.R`)
- **1 test deleted** — `build_fallback_analysis validates texts_loader` tested the deleted function's own plumbing, no live-pipeline equivalent

## Test plan

- [ ] `devtools::test(filter = "spc_analysis")` — 191 tests pass, 0 fail
- [ ] `devtools::test(filter = "integration")` — 145 tests pass, 0 fail
- [ ] `devtools::test(filter = "source-ascii")` — 1 test passes (no non-ASCII in R/*.R)
- [ ] Pre-push full test suite — all green (verified via push hook)