### PR TITLE
fix(api): rename summary columns to ASCII (closes #416)

### DIFF
--- a/BFHLLM_INTEGRATION.md
+++ b/BFHLLM_INTEGRATION.md
@@ -48,7 +48,7 @@ spc_metadata <- list(
                          resultat$summary$sigma_signal,
                          na.rm = TRUE),
     anhoej_rules = list(
-      longest_run = resultat$summary$længste_løb,
+      longest_run = resultat$summary$laengste_loeb,
       n_crossings = resultat$summary$antal_kryds,
       n_crossings_min = resultat$summary$antal_kryds_min
     )

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,14 @@
   `chart_type = "ip"` i alle kald. Det er en hård omdøbning -- `"i'"`
   accepteres ikke længere. (Introduceret i 0.24.0; omdøbt før bred udbredelse.)
 
+* **Kolonnenavnene i `result$summary` er omdøbt til ASCII-translitterationer.**
+  Danske UTF-8-navne medfoerte silent NULL naar brugere fulgte dokumentationens
+  ASCII-navne. De berorte kolonner: `laengste_loeb` (tidl. `laengste_loeb`
+  med UTF-8-bogstaver), `laengste_loeb_max`, `nedre_kontrolgraense`,
+  `oevre_kontrolgraense`, `kontrolgraenser_konstante` og de afledte
+  min/max/95-varianter. Migration: erstat UTF-8-navne med translittereringerne
+  i alle kald til `result$summary$...`. biSPCharts-tilpasning spoeres separat.
+
 # BFHcharts 0.24.0
 
 ## Nye features
@@ -868,15 +876,15 @@ develop. Verdict: APPROVE for produktion (multi-tenant Connect Cloud
   ```
 
   De nye `runs_signal` og `crossings_signal` er pure derivationer fra
-  eksisterende `længste_løb`/`længste_løb_max` og `antal_kryds`/`antal_kryds_min`
+  eksisterende `laengste_loeb`/`laengste_loeb_max` og `antal_kryds`/`antal_kryds_min`
   per fase. NA inheriterer fra inputs (degenererede faser hvor qicharts2
   returnerer NA). biSPCharts #468 sporer downstream-migration.
 
 * **`summary` numeriske kolonner returnerer raw qicharts2-precision** (ej
   længere afrundet til 1-2 decimaler). Påvirker `centerlinje`,
-  `nedre_kontrolgrænse`, `øvre_kontrolgrænse`, `nedre_kontrolgrænse_min/max`,
-  `øvre_kontrolgrænse_min/max`, `nedre_kontrolgrænse_95`,
-  `øvre_kontrolgrænse_95`. Display-formattere (`format_target_value()`,
+  `nedre_kontrolgraense`, `oevre_kontrolgraense`, `nedre_kontrolgraense_min/max`,
+  `oevre_kontrolgraense_min/max`, `nedre_kontrolgraense_95`,
+  `oevre_kontrolgraense_95`. Display-formattere (`format_target_value()`,
   `format_centerline_for_details()`) afrunder selv ved string-emission, så
   PDF-output forbliver byte-identisk. Logic-konsumere (target-sammenligning,
   statistisk videreanalyse) får nu korrekte resultater nær afrundings-
@@ -894,7 +902,7 @@ develop. Verdict: APPROVE for produktion (multi-tenant Connect Cloud
 ## Internal changes
 
 * ADR-002 addendum dokumenterer signal-rename + raw-precision-skift.
-* Konstans-detektion (`kontrolgrænser_konstante`) bevarer `decimal_places + 2`-
+* Konstans-detektion (`kontrolgraenser_konstante`) bevarer `decimal_places + 2`-
   tolerance for at absorbere floating-point drift fra qicharts2 -- detektions-
   logikken roundes, men de lagrede værdier forbliver raw.
 

--- a/R/spc_analysis.R
+++ b/R/spc_analysis.R
@@ -10,8 +10,9 @@
 
 # Konverter ASCII-operatorer (>=, <=) til Unicode-sammentrukne tegn
 # (\U2265, \U2264) i target-display-strenge til klinisk prose-rendering.
-# Bruges af spc_render.R (struktureret pipeline). Holder operator-mappingen
-# i en enkelt autoritativ kilde.
+# Bruges af baade .evaluate_target_arm() (legacy) og spc_render.R
+# (struktureret pipeline). Holder operator-mappingen i en enkelt
+# autoritativ kilde.
 .normalize_target_operators <- function(x) {
   if (is.null(x) || !nzchar(x)) {
     return(x)
@@ -25,7 +26,8 @@
 # "at" | "over" | "under" -- eller NULL hvis target ej sat. Caller
 # resolverer keys via i18n_lookup(paste0("labels.level_*.", key)).
 #
-# Shared helper for spc_render.R (.compute_level_direction +
+# Erstatter dual-computation i build_fallback_analysis() (linje 990-1013)
+# og struktureret spc_render.R (.compute_level_direction +
 # .compute_level_vs_target).
 .compute_level_keys <- function(centerline, target_value, has_target,
                                 y_axis_unit = NULL) {
@@ -59,7 +61,7 @@
 #     reference for kontekstuel praecision).
 # Returnerer TRUE naar de to display-strenge repraesenterer samme tal.
 #
-# Brugt af .compute_level_keys() til at flippe
+# Brugt af .compute_level_keys() + .evaluate_target_arm() til at flippe
 # "lige over" -> "paa maalet"/"goal_met" naar visuel lighed gaelder.
 .cl_displays_at_target_pct <- function(centerline, target_value) {
   if (!is_valid_scalar(centerline) || !is_valid_scalar(target_value)) {
@@ -74,6 +76,43 @@
   }
   cl_pct_whole <- round(centerline * 100)
   isTRUE(cl_pct_whole == target_pct_whole)
+}
+
+# Beregn near_target / at_target tolerance via sigma-cascade.
+#
+# Cascade (uaendret fra original logik):
+#   1. sigma_hat tilgaengelig     -> 3*sigma_hat (kontrolgraense-bredde / 2)
+#   2. sigma_data tilgaengelig    -> sd(y)
+#   3. ingen sigma                -> 1e-9 (kraever eksakt match)
+#
+# Percent-units (is_percent=TRUE): tolerance capes ved
+#   min(3*sigma_hat, NEAR_TARGET_PCT_CAP, NEAR_TARGET_PCT_RELATIVE * target).
+# Absolut cap (3pp) haandterer noisy processes; relativ cap (25% af target)
+# haandterer smaa-target-cases hvor 3pp stadig er klinisk for stor.
+# Eksempler:
+#   target=15%, CL=19%, delta=4pp: cap=min(sigma,3pp,3.75pp)=3pp; 4pp>3pp -> NOT near
+#   target=3%,  CL=7%,  delta=4pp: cap=min(sigma,3pp,0.75pp)=0.75pp; 4pp>0.75pp -> NOT near
+#   target=90%, CL=87%, delta=3pp: cap=min(sigma,3pp,22.5pp)=3pp; 3pp<=3pp -> NEAR
+.near_target_tolerance <- function(sigma_hat, sigma_data, is_percent,
+                                   target_value = NULL) {
+  sigma_tol <- if (is_valid_scalar(sigma_hat) && is.finite(sigma_hat) &&
+    sigma_hat > 0) {
+    3 * sigma_hat
+  } else if (is_valid_scalar(sigma_data) && is.finite(sigma_data) &&
+    sigma_data > 0) {
+    sigma_data
+  } else {
+    1e-9
+  }
+  if (isTRUE(is_percent)) {
+    caps <- c(sigma_tol, NEAR_TARGET_PCT_CAP)
+    if (is_valid_scalar(target_value) && is.finite(target_value) &&
+      target_value > 0) {
+      caps <- c(caps, NEAR_TARGET_PCT_RELATIVE * target_value)
+    }
+    return(min(caps))
+  }
+  sigma_tol
 }
 
 # Resolve target for analysis context via fallback chain.
@@ -562,7 +601,8 @@ bfh_generate_analysis <- function(x,
     stop("min_chars must be less than max_chars", call. = FALSE)
   }
 
-  # Byg struktureret analyse-objekt via bfh_analyse + bfh_render_analysis.
+  # Byg struktureret analyse-objekt (Phase 2 cut-over: bfh_analyse +
+  # bfh_render_analysis erstatter monolitisk build_fallback_analysis).
   # Public-API-signatur uaendret -- intern delegation til ny pipeline.
   spc_analysis <- bfh_analyse(x, metadata = metadata, language = language)
   baseline_analysis <- bfh_render_analysis(
@@ -697,8 +737,9 @@ bfh_generate_analysis <- function(x,
 #   has_target                            (logical, derived: target_value + centerline gyldige)
 #   outliers_for_text                     (numeric, til pluralize_da + placeholder)
 #
-# Pure: samme input -> samme output. Driver cascade-dispatch og budget-
-# allokering uden at flade detection-logikken sammen med i18n-opslag.
+# Pure: samme input -> samme output. Bruges af build_fallback_analysis() til
+# at drive cascade-dispatch og budget-allokering uden at flade detection-
+# logikken sammen med i18n-opslag.
 # Atomic Anhoej-signal-detectors. Shared mellem .detect_signal_flags()
 # (feature-extraction) og AI-path has_signals (LLM-egress gate). Holder
 # semantik konsistent paa tvaers af call-sites -- ej re-implement risiko
@@ -869,7 +910,7 @@ bfh_generate_analysis <- function(x,
 #
 # goal_met, at_target og near_target er evalueret af caller; helper er pure
 # dispatch. Prioritet i direction-aware gren: goal_met > near_target >
-# goal_not_met.
+# goal_not_met (matcher .evaluate_target_arm() priority).
 .select_action_key <- function(flags, target_direction, goal_met, at_target,
                                near_target = FALSE) {
   is_stable <- flags$is_stable
@@ -917,6 +958,335 @@ bfh_generate_analysis <- function(x,
   } else {
     if (is_stable) "stable_no_target" else "unstable_no_target"
   }
+}
+
+
+# Evaluer maalvurderings-arm af fallback-analysen.
+#
+# Returnerer named list (target_text, goal_met, at_target, near_target).
+# Bruges af orchestrator + .select_action_key().
+#
+# Tre dispatch-veje (matcher .select_action_key()'s tre cascade-grene):
+#   1. has_target + target_direction: retningsbevidst goal_met-evaluering
+#      via centerline-vs-target sammenligning + sigma-cascade for
+#      near_target naar strict-condition fejler.
+#   2. has_target uden target_direction: vaerdineutral at_target/over/under
+#      med tolerance.
+#   3. !has_target: target_text = "".
+#
+# i18n-lookup foregaar her (ikke i orchestrator) for at holde
+# orchestrator fri af cascade-strukturer.
+.evaluate_target_arm <- function(context, flags, texts, target_budget,
+                                 language = "da",
+                                 extra_placeholders = list()) {
+  result <- list(
+    target_text = "", goal_met = FALSE,
+    at_target = FALSE, near_target = FALSE
+  )
+  if (!flags$has_target) {
+    return(result)
+  }
+
+  target_value <- context$target_value
+  target_direction <- context$target_direction
+  centerline <- context$centerline
+
+  # Foretraek display-streng fra input (fx "<= 2,5"), ellers format numerisk.
+  # language threades igennem til format_target_value() saa engelsk
+  # analyse-tekst faar "1.5" og dansk faar "1,5" (cycle 01 finding E4).
+  display_target <- if (!is.null(context$target_display) &&
+    nzchar(context$target_display)) {
+    context$target_display
+  } else {
+    format_target_value(target_value,
+      y_axis_unit = context$y_axis_unit,
+      language = language
+    )
+  }
+
+  # Erstat ASCII-operatorer med Unicode-sammentrukne tegn i analyseteksten.
+  # context$target_display selv bevares uaendret (invariant fra resolve_target()).
+  display_target <- .normalize_target_operators(display_target)
+
+  # Merge target-display med globale placeholders (level_direction, level_vs_target).
+  # Target tager precedence saa specifik target-display ikke kan overskrives.
+  data <- modifyList(extra_placeholders, list(target = display_target))
+
+  y_axis_unit <- context$y_axis_unit
+  is_percent <- identical(y_axis_unit, "percent")
+
+  if (!is.null(target_direction)) {
+    # Retningsbevidst: prioritet er strikt goal_met > near_target >
+    # goal_not_met. CL paa korrekt side af target laeses altid som
+    # "opfyldt" uanset afstand; near_target reserveres for "forkert side
+    # men inden for proces-stoej" (sigma-cascade matcher path A).
+    #
+    # Percent-units: display-precision-equality check foer strikt-numeric.
+    # CL og target der afrunder til samme chart-display-vaerdi (fx 1,0%
+    # vs 1%) klassificeres som goal_met. Forhindrer "lige over"-tekst
+    # naar laeseren visuelt ser CL paa maalstregen.
+    display_equal <- is_percent &&
+      .cl_displays_at_target_pct(centerline, target_value)
+    result$goal_met <- display_equal || switch(target_direction,
+      "higher" = centerline >= target_value,
+      "lower"  = centerline <= target_value,
+      FALSE
+    )
+    if (!result$goal_met) {
+      # Strict-condition fejler -- check om delta er inden for tolerance.
+      # Samme tre-vejs cascade som value-neutral gren (sigma_hat ->
+      # sigma_data -> eksakt). Tolerance-faldet for higher/lower er
+      # symmetrisk om target; retningen kodes via {level_direction}.
+      delta <- abs(centerline - target_value)
+      tolerance <- .near_target_tolerance(
+        context$sigma_hat, context$sigma_data, is_percent,
+        target_value = target_value
+      )
+      result$near_target <- delta <= tolerance
+    }
+    key <- if (result$goal_met) {
+      "goal_met"
+    } else if (result$near_target) {
+      "near_target"
+    } else {
+      "goal_not_met"
+    }
+    result$target_text <- pick_text(texts$target[[key]],
+      data = data,
+      budget = target_budget
+    )
+  } else {
+    # Vaerdineutral: at/over/under target med processkala-tolerance.
+    # Tre-vejs cascade (se openspec change at-target-tolerance-process-variation):
+    #   1. Kontrolgraense-baseret: |CL - target| <= 3 * sigma_hat
+    #      (svarer trivielt til LCL <= target <= UCL ved konstante 3-sigma-graenser)
+    #   2. Data-sigma fallback:    |CL - target| <= sd(y)
+    #      (run charts og no_variation hvor kontrolgraenser mangler)
+    #   3. Eksakt-match:           |CL - target| < 1e-9
+    #      (degenereret: konstant y, n=1, eller begge sigma er 0)
+    # Percent-units: capped ved NEAR_TARGET_PCT_CAP saa stoejende processer
+    # ej ratiionaliserer fjern-CL som "taet paa" (parity med direction-aware).
+    delta <- abs(centerline - target_value)
+    display_equal <- is_percent &&
+      .cl_displays_at_target_pct(centerline, target_value)
+    is_at_target <- display_equal ||
+      delta <= .near_target_tolerance(
+        context$sigma_hat, context$sigma_data, is_percent,
+        target_value = target_value
+      )
+    if (is_at_target) {
+      result$target_text <- pick_text(texts$target$at_target,
+        data = data,
+        budget = target_budget
+      )
+      result$at_target <- TRUE
+    } else if (centerline > target_value) {
+      result$target_text <- pick_text(texts$target$over_target,
+        data = data,
+        budget = target_budget
+      )
+    } else {
+      result$target_text <- pick_text(texts$target$under_target,
+        data = data,
+        budget = target_budget
+      )
+    }
+  }
+
+  result
+}
+
+
+# Intern funktion: Byg komplet fallback-analysetekst.
+#
+# BACKWARD-COMPAT LAYER (post-Phase-2 cut-over):
+# Primary path for bfh_generate_analysis() er nu bfh_analyse() +
+# bfh_render_analysis() (R/spc_compose.R + R/spc_render.R).
+# build_fallback_analysis bevares som intern fallback for direct-callere
+# (test-spc_analysis.R + eventuelle eksterne :::-konsumenter) -- vil
+# blive fjernet i naeste major release efter mindst et stabilt release-
+# cycle med den nye pipeline.
+#
+# Allokerer tegnbudget til stability/target/action dele og vaelger
+# passende variant for hver del. Naar context$target_direction er
+# non-NULL (udledt fra fx "<= 2,5"), bruges retningsbevidst maal-
+# vurdering (goal_met/goal_not_met) i stedet for vaerdineutral
+# at/over/under. ensure_within_max garanterer max_chars-graensen.
+#
+# @keywords internal
+# @noRd
+build_fallback_analysis <- function(context,
+                                    max_chars = 375,
+                                    language = "da",
+                                    texts_loader = NULL) {
+  if (is.null(texts_loader)) {
+    texts_loader <- function() load_spc_texts(language)
+  }
+  spc_stats <- context$spc_stats
+  target_value <- context$target_value
+  target_direction <- context$target_direction
+  centerline <- context$centerline
+  n_points <- context$n_points
+
+  # --- Detect signaler + target-tilstand ---
+  flags <- .detect_signal_flags(context)
+  has_runs <- flags$has_runs
+  has_crossings <- flags$has_crossings
+  has_outliers <- flags$has_outliers
+  is_stable <- flags$is_stable
+  no_variation <- flags$no_variation
+  has_target <- flags$has_target
+  outliers_for_text <- flags$outliers_for_text
+
+  # --- Budget-allokering ---
+  budgets <- .allocate_text_budget(max_chars, has_target)
+  stability_budget <- budgets$stability_budget
+  target_budget <- budgets$target_budget
+  action_budget <- budgets$action_budget
+
+  if (!is.function(texts_loader)) {
+    stop("texts_loader must be a function", call. = FALSE)
+  }
+  texts <- texts_loader()
+  # outliers_actual i placeholder_data bruger recent_count-vaerdien, saa YAML-
+  # skabelonernes {outliers_actual} placeholder ogsaa foelger "seneste 6 obs"-
+  # reglen. outliers_word giver korrekt dansk ental/flertal for 1 vs n.
+  outliers_n <- if (is_valid_scalar(outliers_for_text)) outliers_for_text else 0L
+
+  # level_direction / level_vs_target: target-relative position af centerlinje.
+  # Bruges som placeholders til at sammensaette saetninger som
+  # "Niveauet {level_vs_target} ({target})" -> "Niveauet ligger under maalet (90%)".
+  # For percent-units: "paa" rendres naar CL og target afrunder til samme
+  # chart-display-vaerdi (display-precision-equality). For andre units:
+  # strikt lighedstest (delta < 1e-9). Tomme strenge naar target ikke er
+  # sat, saa placeholderne kan staa i templates uden at generere fejl,
+  # men bor kun bruges i target-/goal-specifikke varianter for at give
+  # meningsfuld tekst.
+  level_keys <- .compute_level_keys(centerline, target_value, flags$has_target,
+    y_axis_unit = context$y_axis_unit)
+  level_direction <- if (!is.null(level_keys)) {
+    i18n_lookup(paste0("labels.level_direction.", level_keys$direction_key), language)
+  } else {
+    ""
+  }
+  level_vs_target <- if (!is.null(level_keys)) {
+    i18n_lookup(paste0("labels.level_vs_target.", level_keys$vs_target_key), language)
+  } else {
+    ""
+  }
+
+  # Formateret centerline-vaerdi til {centerline}-placeholder. Bruger
+  # format_target_value() saa centerline rendres pa samme skala som y-aksen
+  # (fx 85% paa percent-charts, 3.2 paa numeric-charts). target threades
+  # gennem saa percent-CL bevarer en decimal naar |CL - target| <= 2pp --
+  # matcher chart-label-praecision (format_y_value via
+  # format_percent_contextual). Tom-fallback til "ukendt"-label naar
+  # centerline er NULL/NA (degenereret data-tilfaelde).
+  cl_fmt <- if (!is.null(centerline) && !is.na(centerline)) {
+    format_target_value(centerline,
+      y_axis_unit = context$y_axis_unit,
+      language = language,
+      target = target_value
+    )
+  } else {
+    i18n_lookup("labels.misc.ukendt", language)
+  }
+
+  placeholder_data <- list(
+    runs_actual = spc_stats$runs_actual,
+    runs_expected = spc_stats$runs_expected,
+    crossings_actual = spc_stats$crossings_actual,
+    crossings_expected = spc_stats$crossings_expected,
+    outliers_actual = outliers_for_text,
+    outliers_word = pluralize_da(
+      outliers_n,
+      i18n_lookup("labels.outliers.singular", language),
+      i18n_lookup("labels.outliers.plural", language)
+    ),
+    effective_window = spc_stats$effective_window %||% RECENT_OBS_WINDOW,
+    centerline = cl_fmt,
+    level_direction = level_direction,
+    level_vs_target = level_vs_target
+  )
+
+  # --- 1. Stabilitetstekst ---
+  # Prioritet: no_variation > majority_at_centerline > auto_mean_unstable >
+  # signal-baseret dispatch.
+  # no_variation kraever Anhoej-stats er NA (alle identiske); majority_at_cl
+  # tillader normal variation men flagger >= 50% punkter eksakt paa CL;
+  # auto_mean_unstable fyrer naar CL er auto-skiftet til gennemsnit pga
+  # majoritets-paa-median, men signaler stadig er til stede.
+  if (no_variation) {
+    stability <- pick_text(
+      texts$stability$no_variation,
+      data = list(centerline = cl_fmt),
+      budget = stability_budget
+    )
+  } else if (isTRUE(flags$majority_at_cl)) {
+    stability <- pick_text(
+      texts$stability$majority_at_centerline,
+      data = list(centerline = cl_fmt),
+      budget = stability_budget
+    )
+  } else if (isTRUE(flags$auto_mean_unstable)) {
+    stability <- pick_text(
+      texts$stability$auto_mean_unstable,
+      data = list(centerline = cl_fmt),
+      budget = stability_budget
+    )
+  } else {
+    key <- .select_stability_key(flags)
+    stability <- pick_text(texts$stability[[key]],
+      data = placeholder_data,
+      budget = stability_budget
+    )
+  }
+
+  # --- 2. Maalvurdering ---
+  # extra_placeholders giver target-templates adgang til {level_direction},
+  # {level_vs_target} og {centerline} ved siden af det allerede formaterede
+  # {target}.
+  target_eval <- .evaluate_target_arm(
+    context, flags, texts,
+    target_budget,
+    language = language,
+    extra_placeholders = list(
+      centerline = cl_fmt,
+      level_direction = level_direction,
+      level_vs_target = level_vs_target
+    )
+  )
+  target_text <- target_eval$target_text
+  goal_met <- target_eval$goal_met
+  at_target <- target_eval$at_target
+  near_target <- target_eval$near_target
+
+  # --- 3. Handlingsforslag ---
+  # action-templates faar ogsaa adgang til level_*- og centerline-placeholders
+  # saa goal_met/goal_not_met-tekster kan beskrive niveau-position i forhold
+  # til maal.
+  action_key <- .select_action_key(flags, target_direction, goal_met,
+    at_target,
+    near_target = near_target
+  )
+  action <- pick_text(texts$action[[action_key]],
+    data = list(
+      centerline = cl_fmt,
+      level_direction = level_direction,
+      level_vs_target = level_vs_target
+    ),
+    budget = action_budget
+  )
+
+  # --- Kombiner ---
+  parts <- c(stability, target_text, action)
+  parts <- parts[nchar(parts) > 0]
+  text <- paste(parts, collapse = " ")
+
+  # --- Garanter max_chars-graensen (trim ved saetnings-/klausulgraense) ---
+  text <- ensure_within_max(text, max_chars)
+
+  return(text)
 }
 
 

--- a/R/spc_analysis.R
+++ b/R/spc_analysis.R
@@ -10,9 +10,8 @@
 
 # Konverter ASCII-operatorer (>=, <=) til Unicode-sammentrukne tegn
 # (\U2265, \U2264) i target-display-strenge til klinisk prose-rendering.
-# Bruges af baade .evaluate_target_arm() (legacy) og spc_render.R
-# (struktureret pipeline). Holder operator-mappingen i en enkelt
-# autoritativ kilde.
+# Bruges af spc_render.R (struktureret pipeline). Holder operator-mappingen
+# i en enkelt autoritativ kilde.
 .normalize_target_operators <- function(x) {
   if (is.null(x) || !nzchar(x)) {
     return(x)
@@ -26,8 +25,7 @@
 # "at" | "over" | "under" -- eller NULL hvis target ej sat. Caller
 # resolverer keys via i18n_lookup(paste0("labels.level_*.", key)).
 #
-# Erstatter dual-computation i build_fallback_analysis() (linje 990-1013)
-# og struktureret spc_render.R (.compute_level_direction +
+# Shared helper for spc_render.R (.compute_level_direction +
 # .compute_level_vs_target).
 .compute_level_keys <- function(centerline, target_value, has_target,
                                 y_axis_unit = NULL) {
@@ -61,7 +59,7 @@
 #     reference for kontekstuel praecision).
 # Returnerer TRUE naar de to display-strenge repraesenterer samme tal.
 #
-# Brugt af .compute_level_keys() + .evaluate_target_arm() til at flippe
+# Brugt af .compute_level_keys() til at flippe
 # "lige over" -> "paa maalet"/"goal_met" naar visuel lighed gaelder.
 .cl_displays_at_target_pct <- function(centerline, target_value) {
   if (!is_valid_scalar(centerline) || !is_valid_scalar(target_value)) {
@@ -76,43 +74,6 @@
   }
   cl_pct_whole <- round(centerline * 100)
   isTRUE(cl_pct_whole == target_pct_whole)
-}
-
-# Beregn near_target / at_target tolerance via sigma-cascade.
-#
-# Cascade (uaendret fra original logik):
-#   1. sigma_hat tilgaengelig     -> 3*sigma_hat (kontrolgraense-bredde / 2)
-#   2. sigma_data tilgaengelig    -> sd(y)
-#   3. ingen sigma                -> 1e-9 (kraever eksakt match)
-#
-# Percent-units (is_percent=TRUE): tolerance capes ved
-#   min(3*sigma_hat, NEAR_TARGET_PCT_CAP, NEAR_TARGET_PCT_RELATIVE * target).
-# Absolut cap (3pp) haandterer noisy processes; relativ cap (25% af target)
-# haandterer smaa-target-cases hvor 3pp stadig er klinisk for stor.
-# Eksempler:
-#   target=15%, CL=19%, delta=4pp: cap=min(sigma,3pp,3.75pp)=3pp; 4pp>3pp -> NOT near
-#   target=3%,  CL=7%,  delta=4pp: cap=min(sigma,3pp,0.75pp)=0.75pp; 4pp>0.75pp -> NOT near
-#   target=90%, CL=87%, delta=3pp: cap=min(sigma,3pp,22.5pp)=3pp; 3pp<=3pp -> NEAR
-.near_target_tolerance <- function(sigma_hat, sigma_data, is_percent,
-                                   target_value = NULL) {
-  sigma_tol <- if (is_valid_scalar(sigma_hat) && is.finite(sigma_hat) &&
-    sigma_hat > 0) {
-    3 * sigma_hat
-  } else if (is_valid_scalar(sigma_data) && is.finite(sigma_data) &&
-    sigma_data > 0) {
-    sigma_data
-  } else {
-    1e-9
-  }
-  if (isTRUE(is_percent)) {
-    caps <- c(sigma_tol, NEAR_TARGET_PCT_CAP)
-    if (is_valid_scalar(target_value) && is.finite(target_value) &&
-      target_value > 0) {
-      caps <- c(caps, NEAR_TARGET_PCT_RELATIVE * target_value)
-    }
-    return(min(caps))
-  }
-  sigma_tol
 }
 
 # Resolve target for analysis context via fallback chain.
@@ -601,8 +562,7 @@ bfh_generate_analysis <- function(x,
     stop("min_chars must be less than max_chars", call. = FALSE)
   }
 
-  # Byg struktureret analyse-objekt (Phase 2 cut-over: bfh_analyse +
-  # bfh_render_analysis erstatter monolitisk build_fallback_analysis).
+  # Byg struktureret analyse-objekt via bfh_analyse + bfh_render_analysis.
   # Public-API-signatur uaendret -- intern delegation til ny pipeline.
   spc_analysis <- bfh_analyse(x, metadata = metadata, language = language)
   baseline_analysis <- bfh_render_analysis(
@@ -737,9 +697,8 @@ bfh_generate_analysis <- function(x,
 #   has_target                            (logical, derived: target_value + centerline gyldige)
 #   outliers_for_text                     (numeric, til pluralize_da + placeholder)
 #
-# Pure: samme input -> samme output. Bruges af build_fallback_analysis() til
-# at drive cascade-dispatch og budget-allokering uden at flade detection-
-# logikken sammen med i18n-opslag.
+# Pure: samme input -> samme output. Driver cascade-dispatch og budget-
+# allokering uden at flade detection-logikken sammen med i18n-opslag.
 # Atomic Anhoej-signal-detectors. Shared mellem .detect_signal_flags()
 # (feature-extraction) og AI-path has_signals (LLM-egress gate). Holder
 # semantik konsistent paa tvaers af call-sites -- ej re-implement risiko
@@ -910,7 +869,7 @@ bfh_generate_analysis <- function(x,
 #
 # goal_met, at_target og near_target er evalueret af caller; helper er pure
 # dispatch. Prioritet i direction-aware gren: goal_met > near_target >
-# goal_not_met (matcher .evaluate_target_arm() priority).
+# goal_not_met.
 .select_action_key <- function(flags, target_direction, goal_met, at_target,
                                near_target = FALSE) {
   is_stable <- flags$is_stable
@@ -958,335 +917,6 @@ bfh_generate_analysis <- function(x,
   } else {
     if (is_stable) "stable_no_target" else "unstable_no_target"
   }
-}
-
-
-# Evaluer maalvurderings-arm af fallback-analysen.
-#
-# Returnerer named list (target_text, goal_met, at_target, near_target).
-# Bruges af orchestrator + .select_action_key().
-#
-# Tre dispatch-veje (matcher .select_action_key()'s tre cascade-grene):
-#   1. has_target + target_direction: retningsbevidst goal_met-evaluering
-#      via centerline-vs-target sammenligning + sigma-cascade for
-#      near_target naar strict-condition fejler.
-#   2. has_target uden target_direction: vaerdineutral at_target/over/under
-#      med tolerance.
-#   3. !has_target: target_text = "".
-#
-# i18n-lookup foregaar her (ikke i orchestrator) for at holde
-# orchestrator fri af cascade-strukturer.
-.evaluate_target_arm <- function(context, flags, texts, target_budget,
-                                 language = "da",
-                                 extra_placeholders = list()) {
-  result <- list(
-    target_text = "", goal_met = FALSE,
-    at_target = FALSE, near_target = FALSE
-  )
-  if (!flags$has_target) {
-    return(result)
-  }
-
-  target_value <- context$target_value
-  target_direction <- context$target_direction
-  centerline <- context$centerline
-
-  # Foretraek display-streng fra input (fx "<= 2,5"), ellers format numerisk.
-  # language threades igennem til format_target_value() saa engelsk
-  # analyse-tekst faar "1.5" og dansk faar "1,5" (cycle 01 finding E4).
-  display_target <- if (!is.null(context$target_display) &&
-    nzchar(context$target_display)) {
-    context$target_display
-  } else {
-    format_target_value(target_value,
-      y_axis_unit = context$y_axis_unit,
-      language = language
-    )
-  }
-
-  # Erstat ASCII-operatorer med Unicode-sammentrukne tegn i analyseteksten.
-  # context$target_display selv bevares uaendret (invariant fra resolve_target()).
-  display_target <- .normalize_target_operators(display_target)
-
-  # Merge target-display med globale placeholders (level_direction, level_vs_target).
-  # Target tager precedence saa specifik target-display ikke kan overskrives.
-  data <- modifyList(extra_placeholders, list(target = display_target))
-
-  y_axis_unit <- context$y_axis_unit
-  is_percent <- identical(y_axis_unit, "percent")
-
-  if (!is.null(target_direction)) {
-    # Retningsbevidst: prioritet er strikt goal_met > near_target >
-    # goal_not_met. CL paa korrekt side af target laeses altid som
-    # "opfyldt" uanset afstand; near_target reserveres for "forkert side
-    # men inden for proces-stoej" (sigma-cascade matcher path A).
-    #
-    # Percent-units: display-precision-equality check foer strikt-numeric.
-    # CL og target der afrunder til samme chart-display-vaerdi (fx 1,0%
-    # vs 1%) klassificeres som goal_met. Forhindrer "lige over"-tekst
-    # naar laeseren visuelt ser CL paa maalstregen.
-    display_equal <- is_percent &&
-      .cl_displays_at_target_pct(centerline, target_value)
-    result$goal_met <- display_equal || switch(target_direction,
-      "higher" = centerline >= target_value,
-      "lower"  = centerline <= target_value,
-      FALSE
-    )
-    if (!result$goal_met) {
-      # Strict-condition fejler -- check om delta er inden for tolerance.
-      # Samme tre-vejs cascade som value-neutral gren (sigma_hat ->
-      # sigma_data -> eksakt). Tolerance-faldet for higher/lower er
-      # symmetrisk om target; retningen kodes via {level_direction}.
-      delta <- abs(centerline - target_value)
-      tolerance <- .near_target_tolerance(
-        context$sigma_hat, context$sigma_data, is_percent,
-        target_value = target_value
-      )
-      result$near_target <- delta <= tolerance
-    }
-    key <- if (result$goal_met) {
-      "goal_met"
-    } else if (result$near_target) {
-      "near_target"
-    } else {
-      "goal_not_met"
-    }
-    result$target_text <- pick_text(texts$target[[key]],
-      data = data,
-      budget = target_budget
-    )
-  } else {
-    # Vaerdineutral: at/over/under target med processkala-tolerance.
-    # Tre-vejs cascade (se openspec change at-target-tolerance-process-variation):
-    #   1. Kontrolgraense-baseret: |CL - target| <= 3 * sigma_hat
-    #      (svarer trivielt til LCL <= target <= UCL ved konstante 3-sigma-graenser)
-    #   2. Data-sigma fallback:    |CL - target| <= sd(y)
-    #      (run charts og no_variation hvor kontrolgraenser mangler)
-    #   3. Eksakt-match:           |CL - target| < 1e-9
-    #      (degenereret: konstant y, n=1, eller begge sigma er 0)
-    # Percent-units: capped ved NEAR_TARGET_PCT_CAP saa stoejende processer
-    # ej ratiionaliserer fjern-CL som "taet paa" (parity med direction-aware).
-    delta <- abs(centerline - target_value)
-    display_equal <- is_percent &&
-      .cl_displays_at_target_pct(centerline, target_value)
-    is_at_target <- display_equal ||
-      delta <= .near_target_tolerance(
-        context$sigma_hat, context$sigma_data, is_percent,
-        target_value = target_value
-      )
-    if (is_at_target) {
-      result$target_text <- pick_text(texts$target$at_target,
-        data = data,
-        budget = target_budget
-      )
-      result$at_target <- TRUE
-    } else if (centerline > target_value) {
-      result$target_text <- pick_text(texts$target$over_target,
-        data = data,
-        budget = target_budget
-      )
-    } else {
-      result$target_text <- pick_text(texts$target$under_target,
-        data = data,
-        budget = target_budget
-      )
-    }
-  }
-
-  result
-}
-
-
-# Intern funktion: Byg komplet fallback-analysetekst.
-#
-# BACKWARD-COMPAT LAYER (post-Phase-2 cut-over):
-# Primary path for bfh_generate_analysis() er nu bfh_analyse() +
-# bfh_render_analysis() (R/spc_compose.R + R/spc_render.R).
-# build_fallback_analysis bevares som intern fallback for direct-callere
-# (test-spc_analysis.R + eventuelle eksterne :::-konsumenter) -- vil
-# blive fjernet i naeste major release efter mindst et stabilt release-
-# cycle med den nye pipeline.
-#
-# Allokerer tegnbudget til stability/target/action dele og vaelger
-# passende variant for hver del. Naar context$target_direction er
-# non-NULL (udledt fra fx "<= 2,5"), bruges retningsbevidst maal-
-# vurdering (goal_met/goal_not_met) i stedet for vaerdineutral
-# at/over/under. ensure_within_max garanterer max_chars-graensen.
-#
-# @keywords internal
-# @noRd
-build_fallback_analysis <- function(context,
-                                    max_chars = 375,
-                                    language = "da",
-                                    texts_loader = NULL) {
-  if (is.null(texts_loader)) {
-    texts_loader <- function() load_spc_texts(language)
-  }
-  spc_stats <- context$spc_stats
-  target_value <- context$target_value
-  target_direction <- context$target_direction
-  centerline <- context$centerline
-  n_points <- context$n_points
-
-  # --- Detect signaler + target-tilstand ---
-  flags <- .detect_signal_flags(context)
-  has_runs <- flags$has_runs
-  has_crossings <- flags$has_crossings
-  has_outliers <- flags$has_outliers
-  is_stable <- flags$is_stable
-  no_variation <- flags$no_variation
-  has_target <- flags$has_target
-  outliers_for_text <- flags$outliers_for_text
-
-  # --- Budget-allokering ---
-  budgets <- .allocate_text_budget(max_chars, has_target)
-  stability_budget <- budgets$stability_budget
-  target_budget <- budgets$target_budget
-  action_budget <- budgets$action_budget
-
-  if (!is.function(texts_loader)) {
-    stop("texts_loader must be a function", call. = FALSE)
-  }
-  texts <- texts_loader()
-  # outliers_actual i placeholder_data bruger recent_count-vaerdien, saa YAML-
-  # skabelonernes {outliers_actual} placeholder ogsaa foelger "seneste 6 obs"-
-  # reglen. outliers_word giver korrekt dansk ental/flertal for 1 vs n.
-  outliers_n <- if (is_valid_scalar(outliers_for_text)) outliers_for_text else 0L
-
-  # level_direction / level_vs_target: target-relative position af centerlinje.
-  # Bruges som placeholders til at sammensaette saetninger som
-  # "Niveauet {level_vs_target} ({target})" -> "Niveauet ligger under maalet (90%)".
-  # For percent-units: "paa" rendres naar CL og target afrunder til samme
-  # chart-display-vaerdi (display-precision-equality). For andre units:
-  # strikt lighedstest (delta < 1e-9). Tomme strenge naar target ikke er
-  # sat, saa placeholderne kan staa i templates uden at generere fejl,
-  # men bor kun bruges i target-/goal-specifikke varianter for at give
-  # meningsfuld tekst.
-  level_keys <- .compute_level_keys(centerline, target_value, flags$has_target,
-    y_axis_unit = context$y_axis_unit)
-  level_direction <- if (!is.null(level_keys)) {
-    i18n_lookup(paste0("labels.level_direction.", level_keys$direction_key), language)
-  } else {
-    ""
-  }
-  level_vs_target <- if (!is.null(level_keys)) {
-    i18n_lookup(paste0("labels.level_vs_target.", level_keys$vs_target_key), language)
-  } else {
-    ""
-  }
-
-  # Formateret centerline-vaerdi til {centerline}-placeholder. Bruger
-  # format_target_value() saa centerline rendres pa samme skala som y-aksen
-  # (fx 85% paa percent-charts, 3.2 paa numeric-charts). target threades
-  # gennem saa percent-CL bevarer en decimal naar |CL - target| <= 2pp --
-  # matcher chart-label-praecision (format_y_value via
-  # format_percent_contextual). Tom-fallback til "ukendt"-label naar
-  # centerline er NULL/NA (degenereret data-tilfaelde).
-  cl_fmt <- if (!is.null(centerline) && !is.na(centerline)) {
-    format_target_value(centerline,
-      y_axis_unit = context$y_axis_unit,
-      language = language,
-      target = target_value
-    )
-  } else {
-    i18n_lookup("labels.misc.ukendt", language)
-  }
-
-  placeholder_data <- list(
-    runs_actual = spc_stats$runs_actual,
-    runs_expected = spc_stats$runs_expected,
-    crossings_actual = spc_stats$crossings_actual,
-    crossings_expected = spc_stats$crossings_expected,
-    outliers_actual = outliers_for_text,
-    outliers_word = pluralize_da(
-      outliers_n,
-      i18n_lookup("labels.outliers.singular", language),
-      i18n_lookup("labels.outliers.plural", language)
-    ),
-    effective_window = spc_stats$effective_window %||% RECENT_OBS_WINDOW,
-    centerline = cl_fmt,
-    level_direction = level_direction,
-    level_vs_target = level_vs_target
-  )
-
-  # --- 1. Stabilitetstekst ---
-  # Prioritet: no_variation > majority_at_centerline > auto_mean_unstable >
-  # signal-baseret dispatch.
-  # no_variation kraever Anhoej-stats er NA (alle identiske); majority_at_cl
-  # tillader normal variation men flagger >= 50% punkter eksakt paa CL;
-  # auto_mean_unstable fyrer naar CL er auto-skiftet til gennemsnit pga
-  # majoritets-paa-median, men signaler stadig er til stede.
-  if (no_variation) {
-    stability <- pick_text(
-      texts$stability$no_variation,
-      data = list(centerline = cl_fmt),
-      budget = stability_budget
-    )
-  } else if (isTRUE(flags$majority_at_cl)) {
-    stability <- pick_text(
-      texts$stability$majority_at_centerline,
-      data = list(centerline = cl_fmt),
-      budget = stability_budget
-    )
-  } else if (isTRUE(flags$auto_mean_unstable)) {
-    stability <- pick_text(
-      texts$stability$auto_mean_unstable,
-      data = list(centerline = cl_fmt),
-      budget = stability_budget
-    )
-  } else {
-    key <- .select_stability_key(flags)
-    stability <- pick_text(texts$stability[[key]],
-      data = placeholder_data,
-      budget = stability_budget
-    )
-  }
-
-  # --- 2. Maalvurdering ---
-  # extra_placeholders giver target-templates adgang til {level_direction},
-  # {level_vs_target} og {centerline} ved siden af det allerede formaterede
-  # {target}.
-  target_eval <- .evaluate_target_arm(
-    context, flags, texts,
-    target_budget,
-    language = language,
-    extra_placeholders = list(
-      centerline = cl_fmt,
-      level_direction = level_direction,
-      level_vs_target = level_vs_target
-    )
-  )
-  target_text <- target_eval$target_text
-  goal_met <- target_eval$goal_met
-  at_target <- target_eval$at_target
-  near_target <- target_eval$near_target
-
-  # --- 3. Handlingsforslag ---
-  # action-templates faar ogsaa adgang til level_*- og centerline-placeholders
-  # saa goal_met/goal_not_met-tekster kan beskrive niveau-position i forhold
-  # til maal.
-  action_key <- .select_action_key(flags, target_direction, goal_met,
-    at_target,
-    near_target = near_target
-  )
-  action <- pick_text(texts$action[[action_key]],
-    data = list(
-      centerline = cl_fmt,
-      level_direction = level_direction,
-      level_vs_target = level_vs_target
-    ),
-    budget = action_budget
-  )
-
-  # --- Kombiner ---
-  parts <- c(stability, target_text, action)
-  parts <- parts[nchar(parts) > 0]
-  text <- paste(parts, collapse = " ")
-
-  # --- Garanter max_chars-graensen (trim ved saetnings-/klausulgraense) ---
-  text <- ensure_within_max(text, max_chars)
-
-  return(text)
 }
 
 

--- a/R/utils_qic_summary.R
+++ b/R/utils_qic_summary.R
@@ -170,8 +170,8 @@ format_qic_summary <- function(qic_data, y_axis_unit = "count") {
   )
 
   # Add Anhoej rules statistics
-  formatted[["l\u00e6ngste_l\u00f8b"]] <- as.integer(raw_summary$longest.run)
-  formatted[["l\u00e6ngste_l\u00f8b_max"]] <- as.integer(raw_summary$longest.run.max)
+  formatted[["laengste_loeb"]] <- as.integer(raw_summary$longest.run)
+  formatted[["laengste_loeb_max"]] <- as.integer(raw_summary$longest.run.max)
   formatted$antal_kryds <- as.integer(raw_summary$n.crossings)
   formatted$antal_kryds_min <- as.integer(raw_summary$n.crossings.min)
 
@@ -182,8 +182,8 @@ format_qic_summary <- function(qic_data, y_axis_unit = "count") {
   # clarity; both are pure derivations from already-formatted columns and inherit
   # NA from their inputs (degenerate phases where qicharts2 cannot compute).
   formatted$anhoej_signal <- as.logical(raw_summary$runs.signal)
-  formatted$runs_signal <- formatted[["l\u00e6ngste_l\u00f8b"]] >
-    formatted[["l\u00e6ngste_l\u00f8b_max"]]
+  formatted$runs_signal <- formatted[["laengste_loeb"]] >
+    formatted[["laengste_loeb_max"]]
   formatted$crossings_signal <- formatted$antal_kryds < formatted$antal_kryds_min
   formatted$sigma_signal <- as.logical(raw_summary$sigma.signal)
 
@@ -242,24 +242,24 @@ format_qic_summary <- function(qic_data, y_axis_unit = "count") {
     alle_konstante <- all(part_konstant)
 
     # Tilfoej per-row flag
-    formatted[["kontrolgr\u00e6nser_konstante"]] <- part_konstant
+    formatted[["kontrolgraenser_konstante"]] <- part_konstant
 
     if (alle_konstante) {
       # Backward-compat: bevar skalare kolonner (\u00e9n vaerdi per fase) i raa precision
-      formatted[["nedre_kontrolgr\u00e6nse"]] <- raw_summary$lcl
-      formatted[["\u00f8vre_kontrolgr\u00e6nse"]] <- raw_summary$ucl
+      formatted[["nedre_kontrolgraense"]] <- raw_summary$lcl
+      formatted[["oevre_kontrolgraense"]] <- raw_summary$ucl
     } else {
       # Variable graenser: eksponer min/max per fase i raa precision
-      formatted[["nedre_kontrolgr\u00e6nse_min"]] <- vapply(part_key, function(p) {
+      formatted[["nedre_kontrolgraense_min"]] <- vapply(part_key, function(p) {
         min(lcl_split[[p]], na.rm = TRUE)
       }, numeric(1))
-      formatted[["nedre_kontrolgr\u00e6nse_max"]] <- vapply(part_key, function(p) {
+      formatted[["nedre_kontrolgraense_max"]] <- vapply(part_key, function(p) {
         max(lcl_split[[p]], na.rm = TRUE)
       }, numeric(1))
-      formatted[["\u00f8vre_kontrolgr\u00e6nse_min"]] <- vapply(part_key, function(p) {
+      formatted[["oevre_kontrolgraense_min"]] <- vapply(part_key, function(p) {
         min(ucl_split[[p]], na.rm = TRUE)
       }, numeric(1))
-      formatted[["\u00f8vre_kontrolgr\u00e6nse_max"]] <- vapply(part_key, function(p) {
+      formatted[["oevre_kontrolgraense_max"]] <- vapply(part_key, function(p) {
         max(ucl_split[[p]], na.rm = TRUE)
       }, numeric(1))
     }
@@ -267,8 +267,8 @@ format_qic_summary <- function(qic_data, y_axis_unit = "count") {
 
   # Optionally add 95% limits if present (raa precision)
   if ("lcl.95" %in% names(raw_summary) && "ucl.95" %in% names(raw_summary)) {
-    formatted[["nedre_kontrolgr\u00e6nse_95"]] <- raw_summary$lcl.95
-    formatted[["\u00f8vre_kontrolgr\u00e6nse_95"]] <- raw_summary$ucl.95
+    formatted[["nedre_kontrolgraense_95"]] <- raw_summary$lcl.95
+    formatted[["oevre_kontrolgraense_95"]] <- raw_summary$ucl.95
   }
 
   # Add facet columns if present

--- a/R/utils_spc_stats.R
+++ b/R/utils_spc_stats.R
@@ -101,11 +101,11 @@ bfh_extract_spc_stats.data.frame <- function(x) {
 
   row <- x[nrow(x), ]
 
-  if ("l\u00e6ngste_l\u00f8b_max" %in% names(row)) {
-    stats$runs_expected <- clean_spc_value(row[["l\u00e6ngste_l\u00f8b_max"]])
+  if ("laengste_loeb_max" %in% names(row)) {
+    stats$runs_expected <- clean_spc_value(row[["laengste_loeb_max"]])
   }
-  if ("l\u00e6ngste_l\u00f8b" %in% names(row)) {
-    stats$runs_actual <- clean_spc_value(row[["l\u00e6ngste_l\u00f8b"]])
+  if ("laengste_loeb" %in% names(row)) {
+    stats$runs_actual <- clean_spc_value(row[["laengste_loeb"]])
   }
   if ("antal_kryds_min" %in% names(row)) {
     stats$crossings_expected <- clean_spc_value(row$antal_kryds_min)

--- a/openspec/specs/public-api/spec.md
+++ b/openspec/specs/public-api/spec.md
@@ -26,8 +26,8 @@ The package SHALL provide a public API function for extracting SPC statistics fr
 **Test Cases:**
 ```r
 summary <- data.frame(
-  længste_løb_max = 8,
-  længste_løb = 6,
+  laengste_loeb_max = 8,
+  laengste_loeb = 6,
   antal_kryds_min = 10,
   antal_kryds = 12
 )
@@ -69,7 +69,7 @@ bfh_extract_spc_stats(data.frame())
 
 **Test Cases:**
 ```r
-summary <- data.frame(længste_løb = 6)  # Missing other columns
+summary <- data.frame(laengste_loeb = 6)  # Missing other columns
 
 stats <- bfh_extract_spc_stats(summary)
 # Returns:
@@ -377,7 +377,7 @@ When control limits vary across observations within a part (typical for P-charts
 
 **Contract:**
 
-| Limit constancy in part | `kontrolgrænser_konstante` | `nedre_/øvre_kontrolgrænse` (scalar) | `*_min`/`*_max` columns |
+| Limit constancy in part | `kontrolgraenser_konstante` | `nedre_/oevre_kontrolgraense` (scalar) | `*_min`/`*_max` columns |
 |---|---|---|---|
 | Constant | `TRUE` | populated with single value | absent or NA |
 | Variable | `FALSE` | absent or NA | populated with min/max across part |
@@ -386,23 +386,23 @@ When control limits vary across observations within a part (typical for P-charts
 
 - **GIVEN** an i-chart with constant control limits within a single part
 - **WHEN** `format_qic_summary(...)` is called
-- **THEN** the summary SHALL contain `nedre_kontrolgrænse` and `øvre_kontrolgrænse` as scalar columns
-- **AND** `kontrolgrænser_konstante` SHALL be `TRUE`
+- **THEN** the summary SHALL contain `nedre_kontrolgraense` and `oevre_kontrolgraense` as scalar columns
+- **AND** `kontrolgraenser_konstante` SHALL be `TRUE`
 
 ```r
 data <- data.frame(period = 1:10, value = c(10, 11, 10, 11, 10, 11, 10, 11, 10, 11))
 result <- bfh_qic(data, x = period, y = value, chart_type = "i")
-expect_true(result$summary$kontrolgrænser_konstante[1])
-expect_true("nedre_kontrolgrænse" %in% names(result$summary))
-expect_false(is.na(result$summary$nedre_kontrolgrænse[1]))
+expect_true(result$summary$kontrolgraenser_konstante[1])
+expect_true("nedre_kontrolgraense" %in% names(result$summary))
+expect_false(is.na(result$summary$nedre_kontrolgraense[1]))
 ```
 
 #### Scenario: variable limits expose min/max columns and FALSE flag
 
 - **GIVEN** a P-chart with varying denominators within a part (e.g., `n = c(100, 200, 50)`)
 - **WHEN** `format_qic_summary(...)` is called
-- **THEN** the summary SHALL contain `nedre_kontrolgrænse_min`, `nedre_kontrolgrænse_max`, `øvre_kontrolgrænse_min`, `øvre_kontrolgrænse_max` columns
-- **AND** `kontrolgrænser_konstante` SHALL be `FALSE`
+- **THEN** the summary SHALL contain `nedre_kontrolgraense_min`, `nedre_kontrolgraense_max`, `oevre_kontrolgraense_min`, `oevre_kontrolgraense_max` columns
+- **AND** `kontrolgraenser_konstante` SHALL be `FALSE`
 - **AND** the min ≤ max relationship SHALL hold
 
 ```r
@@ -413,15 +413,15 @@ data <- data.frame(
 )
 result <- bfh_qic(data, x = period, y = events, n = total,
                   chart_type = "p", y_axis_unit = "percent")
-expect_false(result$summary$kontrolgrænser_konstante[1])
-expect_true("nedre_kontrolgrænse_min" %in% names(result$summary))
-expect_lte(result$summary$nedre_kontrolgrænse_min[1],
-           result$summary$nedre_kontrolgrænse_max[1])
+expect_false(result$summary$kontrolgraenser_konstante[1])
+expect_true("nedre_kontrolgraense_min" %in% names(result$summary))
+expect_lte(result$summary$nedre_kontrolgraense_min[1],
+           result$summary$nedre_kontrolgraense_max[1])
 ```
 
 #### Scenario: backward-compatible reads on constant-limit summaries
 
-- **GIVEN** existing downstream code that reads `summary$nedre_kontrolgrænse` for a constant-limit chart
+- **GIVEN** existing downstream code that reads `summary$nedre_kontrolgraense` for a constant-limit chart
 - **WHEN** `format_qic_summary(...)` is called
 - **THEN** the column SHALL be present and populated as before
 - **AND** existing tests SHALL pass without modification
@@ -430,7 +430,7 @@ expect_lte(result$summary$nedre_kontrolgrænse_min[1],
 
 - **GIVEN** a multi-part chart where part 1 has constant limits and part 2 has variable limits
 - **WHEN** `format_qic_summary(...)` is called
-- **THEN** `kontrolgrænser_konstante` SHALL be `TRUE` for part 1 and `FALSE` for part 2
+- **THEN** `kontrolgraenser_konstante` SHALL be `TRUE` for part 1 and `FALSE` for part 2
 - **AND** scalar columns SHALL be populated for part 1 (NA or absent for part 2)
 - **AND** min/max columns SHALL be populated for part 2 (NA for part 1)
 
@@ -813,7 +813,7 @@ Cross-references SHALL be expressed as prose ("See spc-analysis-api Requirement:
 The summary returned by `bfh_qic()$summary` SHALL expose three logical columns describing the Anhoej rule outcome per phase:
 
 - `anhoej_signal` — combined Anhoej signal, sourced directly from `qicharts2::runs.signal`. TRUE when EITHER the runs-rule OR the crossings-rule is violated for the phase. This matches `qicharts2`'s `crsignal()` model exactly.
-- `runs_signal` — runs-rule outcome alone. TRUE when `længste_løb > længste_løb_max` for the phase. Derived per-phase from existing summary columns.
+- `runs_signal` — runs-rule outcome alone. TRUE when `laengste_loeb > laengste_loeb_max` for the phase. Derived per-phase from existing summary columns.
 - `crossings_signal` — crossings-rule outcome alone. TRUE when `antal_kryds < antal_kryds_min` for the phase. Derived per-phase from existing summary columns.
 
 **Rationale:**
@@ -822,7 +822,7 @@ The summary returned by `bfh_qic()$summary` SHALL expose three logical columns d
 - Derivation is purely arithmetic from already-present summary columns — no new statistical computation.
 
 **NA semantics:**
-- When `længste_løb` or `antal_kryds` is NA for a phase (degenerate phase: all-equal values, single-observation phase), the derived `runs_signal` / `crossings_signal` SHALL also be NA. `anhoej_signal` follows `qicharts2::runs.signal`'s NA semantics (typically NA when the Anhoej rules cannot be evaluated).
+- When `laengste_loeb` or `antal_kryds` is NA for a phase (degenerate phase: all-equal values, single-observation phase), the derived `runs_signal` / `crossings_signal` SHALL also be NA. `anhoej_signal` follows `qicharts2::runs.signal`'s NA semantics (typically NA when the Anhoej rules cannot be evaluated).
 
 #### Scenario: Combined and decomposed signals present for all chart types
 
@@ -914,7 +914,7 @@ expect_false(result$summary$anhoej_signal[1])
 
 ### Requirement: Summary numeric columns SHALL preserve raw qicharts2 precision
 
-The summary returned by `bfh_qic()$summary` SHALL carry numeric values at the precision returned by `qicharts2::qic()`. Specifically, `centerlinje`, `nedre_kontrolgrænse`, `øvre_kontrolgrænse`, `nedre_kontrolgrænse_min`, `nedre_kontrolgrænse_max`, `øvre_kontrolgrænse_min`, `øvre_kontrolgrænse_max`, `nedre_kontrolgrænse_95`, and `øvre_kontrolgrænse_95` SHALL NOT be rounded by `format_qic_summary()`.
+The summary returned by `bfh_qic()$summary` SHALL carry numeric values at the precision returned by `qicharts2::qic()`. Specifically, `centerlinje`, `nedre_kontrolgraense`, `oevre_kontrolgraense`, `nedre_kontrolgraense_min`, `nedre_kontrolgraense_max`, `oevre_kontrolgraense_min`, `oevre_kontrolgraense_max`, `nedre_kontrolgraense_95`, and `oevre_kontrolgraense_95` SHALL NOT be rounded by `format_qic_summary()`.
 
 **Rationale:**
 - Downstream consumers performing logical comparisons (`target >= centerlinje`, statistical further-analysis) need full precision. Pre-change rounding to 1-2 decimals introduced clinically wrong answers near round-off boundaries (verified via biSPCharts #470).
@@ -922,7 +922,7 @@ The summary returned by `bfh_qic()$summary` SHALL carry numeric values at the pr
 - Single source of truth eliminates the previous `summary$centerlinje` (rounded) vs `qic_data$cl` (raw) split that confused downstream usage.
 
 **Internal logic preserved:**
-- The `kontrolgrænser_konstante` constancy flag continues to use `round_prec = decimal_places + 2` to absorb floating-point drift in qicharts2's per-row limit values. That logic operates on raw `qic_data$lcl/ucl` columns and is unchanged.
+- The `kontrolgraenser_konstante` constancy flag continues to use `round_prec = decimal_places + 2` to absorb floating-point drift in qicharts2's per-row limit values. That logic operates on raw `qic_data$lcl/ucl` columns and is unchanged.
 
 #### Scenario: centerlinje matches raw qic_data$cl
 
@@ -945,23 +945,23 @@ expect_identical(result$summary$centerlinje[1], result$qic_data$cl[1])
 
 - **GIVEN** any non-run chart with constant limits within a phase
 - **WHEN** `bfh_qic(..., return.data = TRUE)` is called
-- **THEN** `summary$nedre_kontrolgrænse[p]` SHALL equal `qic_data$lcl[part == p][1]` exactly
-- **AND** `summary$øvre_kontrolgrænse[p]` SHALL equal `qic_data$ucl[part == p][1]` exactly
+- **THEN** `summary$nedre_kontrolgraense[p]` SHALL equal `qic_data$lcl[part == p][1]` exactly
+- **AND** `summary$oevre_kontrolgraense[p]` SHALL equal `qic_data$ucl[part == p][1]` exactly
 
 #### Scenario: Variable limit min/max preserve raw precision
 
 - **GIVEN** a P-chart with varying denominators within a phase
 - **WHEN** `bfh_qic(..., return.data = TRUE)` is called
-- **THEN** `summary$nedre_kontrolgrænse_min[p]` SHALL equal `min(qic_data$lcl[part == p], na.rm = TRUE)` exactly
-- **AND** `summary$nedre_kontrolgrænse_max[p]` SHALL equal `max(qic_data$lcl[part == p], na.rm = TRUE)` exactly
-- **AND** the same SHALL hold for `øvre_kontrolgrænse_min/max` against `qic_data$ucl`
+- **THEN** `summary$nedre_kontrolgraense_min[p]` SHALL equal `min(qic_data$lcl[part == p], na.rm = TRUE)` exactly
+- **AND** `summary$nedre_kontrolgraense_max[p]` SHALL equal `max(qic_data$lcl[part == p], na.rm = TRUE)` exactly
+- **AND** the same SHALL hold for `oevre_kontrolgraense_min/max` against `qic_data$ucl`
 
-#### Scenario: kontrolgrænser_konstante still uses tolerance
+#### Scenario: kontrolgraenser_konstante still uses tolerance
 
 - **GIVEN** a phase where `qic_data$lcl` values vary only in the 4th decimal (typical qicharts2 floating-point drift for "constant" limits)
 - **WHEN** `format_qic_summary(..., y_axis_unit = "percent")` is called (`decimal_places + 2 = 4` precision)
-- **THEN** `summary$kontrolgrænser_konstante[p]` SHALL be `TRUE`
-- **AND** scalar columns `nedre_kontrolgrænse` / `øvre_kontrolgrænse` SHALL be populated with raw (unrounded) values
+- **THEN** `summary$kontrolgraenser_konstante[p]` SHALL be `TRUE`
+- **AND** scalar columns `nedre_kontrolgraense` / `oevre_kontrolgraense` SHALL be populated with raw (unrounded) values
 
 <!--
 REMOVED block dropped: legacy `loebelaengde_signal` requirement was never

--- a/openspec/specs/test-infrastructure/spec.md
+++ b/openspec/specs/test-infrastructure/spec.md
@@ -239,7 +239,7 @@ Control limit and centerline calculations SHALL be verified against hand-compute
 - **GIVEN** a constructed dataset with 9 consecutive points above median
 - **WHEN** `bfh_qic(..., chart_type = "run")` is called
 - **THEN** `anhoej.signal` SHALL be `TRUE` for those 9 points
-- **AND** the summary SHALL report `længste_løb` equal to 9 or higher
+- **AND** the summary SHALL report `laengste_loeb` equal to 9 or higher
 
 #### Scenario: Outlier counts distinguish total vs. recent
 

--- a/tests/testthat/helper-fixtures.R
+++ b/tests/testthat/helper-fixtures.R
@@ -233,7 +233,7 @@ fixture_test_chart <- function(title = "Test", n = 12, lambda = 15) {
 # Analysis context (spc_analysis tests)
 # ----------------------------------------------------------------------------
 
-#' Minimal analyse-context (synthetic list matching bfh_build_analysis_context output)
+#' Minimal analyse-context til build_fallback_analysis() tests
 #'
 #' Konsoliderer `make_ctx()` fra test-spc_analysis.R.
 #'

--- a/tests/testthat/helper-fixtures.R
+++ b/tests/testthat/helper-fixtures.R
@@ -186,8 +186,8 @@ fixture_bfh_qic_result <- function(sigma_signal,
   if (!is.null(part)) qic_data$part <- part
 
   default_summary <- data.frame(
-    længste_løb = 3L,
-    længste_løb_max = 7L,
+    laengste_loeb = 3L,
+    laengste_loeb_max = 7L,
     antal_kryds = 6L,
     antal_kryds_min = 4L,
     centerlinje = 0

--- a/tests/testthat/helper-fixtures.R
+++ b/tests/testthat/helper-fixtures.R
@@ -233,7 +233,7 @@ fixture_test_chart <- function(title = "Test", n = 12, lambda = 15) {
 # Analysis context (spc_analysis tests)
 # ----------------------------------------------------------------------------
 
-#' Minimal analyse-context til build_fallback_analysis() tests
+#' Minimal analyse-context (synthetic list matching bfh_build_analysis_context output)
 #'
 #' Konsoliderer `make_ctx()` fra test-spc_analysis.R.
 #'

--- a/tests/testthat/test-anhoej-decomposed-signals.R
+++ b/tests/testthat/test-anhoej-decomposed-signals.R
@@ -87,8 +87,8 @@ test_that("runs_signal og crossings_signal er korrekt deriveret per fase", {
   )
   result <- bfh_qic(d, x = month, y = value, chart_type = "i", part = c(12))
 
-  loeb_col <- grep("ngste_løb$", names(result$summary), value = TRUE)[1]
-  loeb_max_col <- grep("ngste_løb_max$", names(result$summary), value = TRUE)[1]
+  loeb_col <- grep("ngste_loeb$", names(result$summary), value = TRUE)[1]
+  loeb_max_col <- grep("ngste_loeb_max$", names(result$summary), value = TRUE)[1]
 
   for (i in seq_len(nrow(result$summary))) {
     expected_runs <- isTRUE(

--- a/tests/testthat/test-anhoej-precision.R
+++ b/tests/testthat/test-anhoej-precision.R
@@ -41,9 +41,9 @@ test_that("run-længde-signal fires ved 10+ konsekutive punkter på én side (n=
     info = "10+14 run-længde for n=24 burde trigger signal"
   )
 
-  # Summary skal indeholde længste_løb ≥ 10
-  expect_gte(result$summary$længste_løb[1], 10,
-    label = "længste_løb i summary"
+  # Summary skal indeholde laengste_loeb ≥ 10
+  expect_gte(result$summary$laengste_loeb[1], 10,
+    label = "laengste_loeb i summary"
   )
 })
 
@@ -65,9 +65,9 @@ test_that("run-længde-signal fires IKKE ved korte runs (n=24)", {
     info = "Korte runs (alternerende) skal ikke trigger signal"
   )
 
-  # Summary skal have lille længste_løb
-  expect_lte(result$summary$længste_løb[1], 5,
-    label = "længste_løb ≤ 5 for alternerende data"
+  # Summary skal have lille laengste_loeb
+  expect_lte(result$summary$laengste_loeb[1], 5,
+    label = "laengste_loeb ≤ 5 for alternerende data"
   )
 })
 
@@ -150,7 +150,7 @@ test_that("stabile data med blandede mønstre giver ingen Anhøj-signal", {
   )
 
   # Sanity: max run < 5 og mange crossings
-  expect_lte(result$summary$længste_løb[1], 4)
+  expect_lte(result$summary$laengste_loeb[1], 4)
   expect_gte(result$summary$antal_kryds[1], 8)
 })
 
@@ -269,7 +269,7 @@ test_that("summary indeholder Anhøj-kolonner for run-chart", {
 
   # Anhøj-stat-kolonner
   required_cols <- c(
-    "længste_løb", "længste_løb_max",
+    "laengste_loeb", "laengste_loeb_max",
     "antal_kryds", "antal_kryds_min",
     "anhoej_signal", "runs_signal", "crossings_signal"
   )
@@ -283,8 +283,8 @@ test_that("summary indeholder Anhøj-kolonner for run-chart", {
   )
 })
 
-test_that("længste_løb_max = round(log2(n)) + 3 for run-chart", {
-  # For n=24 skal længste_løb_max = round(log2(24))+3 = 5+3 = 8
+test_that("laengste_loeb_max = round(log2(n)) + 3 for run-chart", {
+  # For n=24 skal laengste_loeb_max = round(log2(24))+3 = 5+3 = 8
   data <- data.frame(
     period = 1:24,
     value = c(rep(60, 10), rep(40, 14))
@@ -293,10 +293,10 @@ test_that("længste_løb_max = round(log2(n)) + 3 for run-chart", {
   result <- bfh_qic(data, x = period, y = value, chart_type = "run")
 
   expected_max <- round(log2(24)) + 3
-  expect_equal(result$summary$længste_løb_max[1], expected_max,
+  expect_equal(result$summary$laengste_loeb_max[1], expected_max,
     tolerance = 1, # qicharts2 kan runde lidt anderledes
     label = paste0(
-      "længste_løb_max for n=24 = round(log2(24))+3 = ",
+      "laengste_loeb_max for n=24 = round(log2(24))+3 = ",
       expected_max
     )
   )

--- a/tests/testthat/test-cl-user-supplied.R
+++ b/tests/testthat/test-cl-user-supplied.R
@@ -151,7 +151,7 @@ test_that("bfh_extract_spc_stats.data.frame surfaces cl_user_supplied", {
 test_that("bfh_extract_spc_stats.data.frame returns FALSE for plain data.frame", {
   # No attr set -> NULL attr -> isTRUE(NULL) = FALSE. Defensive sanity check.
   df <- data.frame(
-    "længste_løb_max" = 5L,
+    "laengste_loeb_max" = 5L,
     antal_kryds = 3L, check.names = FALSE
   )
   stats <- BFHcharts::bfh_extract_spc_stats(df)

--- a/tests/testthat/test-export_pdf-content.R
+++ b/tests/testthat/test-export_pdf-content.R
@@ -244,7 +244,7 @@ test_that("PDF indeholder Anhoej-statistik (runs og kryds)", {
   temp_file <- withr::local_tempfile(fileext = ".pdf")
   bfh_export_pdf(result, temp_file)
 
-  # Tabel skal indeholde rubrik for længste_løb og antal_kryds
+  # Tabel skal indeholde rubrik for laengste_loeb og antal_kryds
   # (label-teksten varierer — matcher flere plausible former)
   text <- pdftools::pdf_text(temp_file)
   combined <- paste(text, collapse = " ")

--- a/tests/testthat/test-export_pdf.R
+++ b/tests/testthat/test-export_pdf.R
@@ -306,7 +306,7 @@ test_that("bfh_extract_spc_stats handles missing columns gracefully (public API)
 
   # Summary with some columns
   summary <- data.frame(
-    længste_løb = 8,
+    laengste_loeb = 8,
     antal_kryds = 5
   )
   stats <- bfh_extract_spc_stats(summary)
@@ -448,8 +448,8 @@ test_that("build_typst_content passes data_definition with preserved newlines", 
 test_that("bfh_extract_spc_stats extracts statistics from valid summary", {
   # Create valid summary data frame
   summary <- data.frame(
-    længste_løb_max = 8,
-    længste_løb = 6,
+    laengste_loeb_max = 8,
+    laengste_loeb = 6,
     antal_kryds_min = 10,
     antal_kryds = 12
   )
@@ -475,8 +475,8 @@ test_that("bfh_extract_spc_stats extracts statistics from valid summary", {
 
 test_that("bfh_extract_spc_stats extracts outliers from summary when present", {
   summary <- data.frame(
-    længste_løb_max = 8,
-    længste_løb = 6,
+    laengste_loeb_max = 8,
+    laengste_loeb = 6,
     antal_kryds_min = 10,
     antal_kryds = 12,
     forventede_outliers = 0,
@@ -516,7 +516,7 @@ test_that("bfh_extract_spc_stats handles empty data frame gracefully", {
 test_that("bfh_extract_spc_stats handles missing columns gracefully", {
   # Summary with only some columns
   summary <- data.frame(
-    længste_løb = 6,
+    laengste_loeb = 6,
     antal_kryds = 12
   )
 

--- a/tests/testthat/test-extract-spc-stats-dispatch.R
+++ b/tests/testthat/test-extract-spc-stats-dispatch.R
@@ -16,8 +16,8 @@
 
 test_that("bfh_extract_spc_stats.data.frame preserves backward-compatible behavior", {
   summary <- data.frame(
-    længste_løb = 5L,
-    længste_løb_max = 7L,
+    laengste_loeb = 5L,
+    laengste_loeb_max = 7L,
     antal_kryds = 6L,
     antal_kryds_min = 4L
   )
@@ -55,9 +55,9 @@ test_that("bfh_extract_spc_stats(bfh_qic_result) returns TOTAL outliers in lates
   # Efter fix: outliers_actual == 3 (total i seneste part).
   sigma_signal <- c(
     rep(FALSE, 5),
-    TRUE,                 # outlier på position 6 (udenfor seneste 6 obs)
+    TRUE, # outlier på position 6 (udenfor seneste 6 obs)
     rep(FALSE, 13),
-    TRUE, TRUE            # 2 outliers på position 20 og 21 (inden for seneste 6)
+    TRUE, TRUE # 2 outliers på position 20 og 21 (inden for seneste 6)
   )
   # 21 obs total: seneste 6 = positioner 16-21 => kun 2 outliers i vinduet
   result <- fixture_bfh_qic_result(sigma_signal)
@@ -85,9 +85,9 @@ test_that("bfh_extract_spc_stats only counts outliers in latest part when phases
 test_that("bfh_extract_spc_stats(bfh_qic_result) exposes outliers_recent_count for last 6 obs", {
   sigma_signal <- c(
     rep(FALSE, 5),
-    TRUE,                 # udenfor vinduet
+    TRUE, # udenfor vinduet
     rep(FALSE, 13),
-    TRUE, TRUE            # i vinduet (seneste 6 obs)
+    TRUE, TRUE # i vinduet (seneste 6 obs)
   )
   result <- fixture_bfh_qic_result(sigma_signal)
 

--- a/tests/testthat/test-generate_details.R
+++ b/tests/testthat/test-generate_details.R
@@ -99,8 +99,8 @@ make_result_with_x <- function(x_col) {
     list(
       plot = ggplot2::ggplot(),
       summary = data.frame(
-        længste_løb = 3L,
-        længste_løb_max = 7L,
+        laengste_loeb = 3L,
+        laengste_loeb_max = 7L,
         antal_kryds = 6L,
         antal_kryds_min = 4L,
         centerlinje = 0

--- a/tests/testthat/test-return-data-summary.R
+++ b/tests/testthat/test-return-data-summary.R
@@ -115,9 +115,9 @@ test_that("summary has correct Danish column names", {
 
   expected_cols <- c(
     "fase", "antal_observationer", "anvendelige_observationer",
-    "længste_løb", "længste_løb_max", "antal_kryds", "antal_kryds_min",
+    "laengste_loeb", "laengste_loeb_max", "antal_kryds", "antal_kryds_min",
     "anhoej_signal", "runs_signal", "crossings_signal", "sigma_signal", "centerlinje",
-    "nedre_kontrolgrænse", "øvre_kontrolgrænse"
+    "nedre_kontrolgraense", "oevre_kontrolgraense"
   )
 
   expect_true(all(expected_cols %in% names(result$summary)))
@@ -140,12 +140,12 @@ test_that("summary works with run charts (no control limits)", {
 
   # Run charts have control limit columns but they contain NA values
   expect_true("centerlinje" %in% names(result$summary))
-  expect_true("nedre_kontrolgrænse" %in% names(result$summary))
-  expect_true("øvre_kontrolgrænse" %in% names(result$summary))
+  expect_true("nedre_kontrolgraense" %in% names(result$summary))
+  expect_true("oevre_kontrolgraense" %in% names(result$summary))
 
   # Values should be NA for run charts
-  expect_true(is.na(result$summary$nedre_kontrolgrænse[1]))
-  expect_true(is.na(result$summary$øvre_kontrolgrænse[1]))
+  expect_true(is.na(result$summary$nedre_kontrolgraense[1]))
+  expect_true(is.na(result$summary$oevre_kontrolgraense[1]))
 })
 
 test_that("summary works with p-charts", {
@@ -168,8 +168,8 @@ test_that("summary works with p-charts", {
   expect_s3_class(result$summary, "data.frame")
   expect_true("centerlinje" %in% names(result$summary))
   # P-charts have variable control limits, so they should NOT be in summary
-  expect_false("nedre_kontrolgrænse" %in% names(result$summary))
-  expect_false("øvre_kontrolgrænse" %in% names(result$summary))
+  expect_false("nedre_kontrolgraense" %in% names(result$summary))
+  expect_false("oevre_kontrolgraense" %in% names(result$summary))
 })
 
 test_that("summary works with c-charts", {
@@ -211,8 +211,8 @@ test_that("summary works with u-charts", {
   expect_s3_class(result$summary, "data.frame")
   expect_true("centerlinje" %in% names(result$summary))
   # U-charts have variable control limits, so they should NOT be in summary
-  expect_false("nedre_kontrolgrænse" %in% names(result$summary))
-  expect_false("øvre_kontrolgrænse" %in% names(result$summary))
+  expect_false("nedre_kontrolgraense" %in% names(result$summary))
+  expect_false("oevre_kontrolgraense" %in% names(result$summary))
 })
 
 test_that("summary handles multiple phases correctly", {
@@ -336,8 +336,8 @@ test_that("Anhøj statistics are included in summary", {
   )
 
   # Check Anhøj rule statistics
-  expect_true("længste_løb" %in% names(result$summary))
-  expect_true("længste_løb_max" %in% names(result$summary))
+  expect_true("laengste_loeb" %in% names(result$summary))
+  expect_true("laengste_loeb_max" %in% names(result$summary))
   expect_true("antal_kryds" %in% names(result$summary))
   expect_true("antal_kryds_min" %in% names(result$summary))
   expect_true("anhoej_signal" %in% names(result$summary))
@@ -413,10 +413,10 @@ test_that("i-charts and c-charts have constant control limits in summary", {
     y_axis_unit = "count"
   )
 
-  expect_true("nedre_kontrolgrænse" %in% names(result_i$summary))
-  expect_true("øvre_kontrolgrænse" %in% names(result_i$summary))
-  expect_type(result_i$summary$nedre_kontrolgrænse, "double")
-  expect_type(result_i$summary$øvre_kontrolgrænse, "double")
+  expect_true("nedre_kontrolgraense" %in% names(result_i$summary))
+  expect_true("oevre_kontrolgraense" %in% names(result_i$summary))
+  expect_type(result_i$summary$nedre_kontrolgraense, "double")
+  expect_type(result_i$summary$oevre_kontrolgraense, "double")
 
   # C-chart should also have control limits
   result_c <- bfh_qic(
@@ -427,6 +427,6 @@ test_that("i-charts and c-charts have constant control limits in summary", {
     y_axis_unit = "count"
   )
 
-  expect_true("nedre_kontrolgrænse" %in% names(result_c$summary))
-  expect_true("øvre_kontrolgrænse" %in% names(result_c$summary))
+  expect_true("nedre_kontrolgraense" %in% names(result_c$summary))
+  expect_true("oevre_kontrolgraense" %in% names(result_c$summary))
 })

--- a/tests/testthat/test-row-order-invariance.R
+++ b/tests/testthat/test-row-order-invariance.R
@@ -20,8 +20,8 @@ make_result_with_x <- function(x_vals, sigma_vals, chart_type = "i") {
   )
 
   summary_df <- data.frame(
-    `længste_løb` = 3L,
-    `længste_løb_max` = 7L,
+    `laengste_loeb` = 3L,
+    `laengste_loeb_max` = 7L,
     antal_kryds = 6L,
     antal_kryds_min = 4L,
     centerlinje = 0,

--- a/tests/testthat/test-signal_interpretation.R
+++ b/tests/testthat/test-signal_interpretation.R
@@ -69,8 +69,8 @@ test_that("signal-kolonner er tilgængelige i summary", {
   result <- bfh_qic(data, x = date, y = value, chart_type = "i")
 
   # Summary skal have Anhøj-relaterede kolonner
-  expect_true("længste_løb" %in% names(result$summary))
-  expect_true("længste_løb_max" %in% names(result$summary))
+  expect_true("laengste_loeb" %in% names(result$summary))
+  expect_true("laengste_loeb_max" %in% names(result$summary))
   expect_true("antal_kryds" %in% names(result$summary))
   expect_true("antal_kryds_min" %in% names(result$summary))
   expect_true("anhoej_signal" %in% names(result$summary))

--- a/tests/testthat/test-spc_analysis.R
+++ b/tests/testthat/test-spc_analysis.R
@@ -280,6 +280,13 @@ test_that("bfh_generate_analysis threads texts_loader to fallback pipeline", {
   expect_match(analysis, "CUSTOM_ACTION")
 })
 
+test_that("build_fallback_analysis validates texts_loader", {
+  expect_error(
+    BFHcharts:::build_fallback_analysis(list(), texts_loader = "bad"),
+    "texts_loader must be a function"
+  )
+})
+
 # ==============================================================================
 # pick_text() tests (intern funktion)
 # ==============================================================================
@@ -545,156 +552,107 @@ test_that("bfh_build_analysis_context bevarer numerisk target uden retning", {
 
 
 # ==============================================================================
-# bfh_render_analysis() — goal_met/goal_not_met + constraints
-# (ported from legacy build_fallback_analysis tests per ADR-004)
+# build_fallback_analysis() — goal_met/goal_not_met + constraints
 # ==============================================================================
 
-test_that("bfh_render_analysis overstiger aldrig max_chars", {
-  # Lower-direction: CL (45) <= target (50) -> goal_met. Stable data.
-  withr::with_seed(71L, {
-    d <- data.frame(
-      date  = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
-      value = round(rnorm(24, 45, 2), 1)
-    )
-  })
-  result <- bfh_qic(d,
-    x = date, y = value, chart_type = "i",
-    target_text = "<= 50"
-  )
-  analysis <- bfh_analyse(result)
+# Hjælpefunktion: fixture_analysis_context() er tilgængelig via helper-fixtures.R.
+
+test_that("build_fallback_analysis overstiger aldrig max_chars", {
   for (mx in c(200L, 275L, 375L, 500L)) {
-    txt <- bfh_render_analysis(analysis, max_chars = mx)
+    ctx <- fixture_analysis_context(target_value = 50, target_direction = "lower", centerline = 45)
+    txt <- BFHcharts:::build_fallback_analysis(ctx, max_chars = mx)
     expect_lte(nchar(txt), mx,
       label = sprintf("max_chars=%d giver %d tegn", mx, nchar(txt))
     )
   }
 })
 
-test_that("bfh_render_analysis bruger goal_met-tekst naar target_direction er 'lower' og CL <= target", {
-  # Lower-direction: steady process at mean=2.0, target="<= 2.5" -> goal_met.
-  withr::with_seed(72L, {
-    d <- data.frame(
-      date  = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
-      value = round(rnorm(24, 2.0, 0.1), 2)
-    )
-  })
-  result <- bfh_qic(d,
-    x = date, y = value, chart_type = "i",
-    target_text = "<= 2.5"
+test_that("build_fallback_analysis bruger goal_met-tekst når target_direction er 'lower' og CL <= target", {
+  ctx <- fixture_analysis_context(
+    target_value = 2.5, target_direction = "lower", centerline = 2.0,
+    target_display = "<= 2,5"
   )
-  analysis <- bfh_analyse(result)
-  txt <- bfh_render_analysis(analysis)
-  # Skal INDEHOLDE "opfylder malet" eller "malet ... naet"
+  txt <- BFHcharts:::build_fallback_analysis(ctx)
+  # Skal INDEHOLDE "opfylder målet" eller "målet ... nået"
   expect_true(grepl("opfylder (udviklings)?målet|målet.*nået", txt),
     info = paste("Forventede goal_met-sprog, fik:", txt)
   )
-  # Ma IKKE indeholde den vaerdineutrale "ligger under maalet"
+  # Må IKKE indeholde den værdineutrale "ligger under målet"
   expect_false(grepl("ligger under målet", txt))
 })
 
-test_that("bfh_render_analysis bruger goal_not_met naar CL overstiger 'lower'-target", {
-  # Lower-direction: steady process at mean=4.0, target="<= 2.5" -> goal_not_met.
-  withr::with_seed(73L, {
-    d <- data.frame(
-      date  = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
-      value = round(rnorm(24, 4.0, 0.1), 2)
-    )
-  })
-  result <- bfh_qic(d,
-    x = date, y = value, chart_type = "i",
-    target_text = "<= 2.5"
+test_that("build_fallback_analysis bruger goal_not_met når CL overstiger 'lower'-target", {
+  ctx <- fixture_analysis_context(
+    target_value = 2.5, target_direction = "lower", centerline = 4.0,
+    target_display = "<= 2,5"
   )
-  analysis <- bfh_analyse(result)
-  txt <- bfh_render_analysis(analysis)
-  # goal_not_met-tekster: "opfylder (endnu )?ikke maalet", "endnu ikke naet",
-  # "er ikke naet", "naar ikke (udviklings)?maalet".
-  expect_true(
-    grepl("opfylder (endnu )?ikke (udviklings)?målet|endnu ikke nået|er ikke nået|når ikke (udviklings)?målet", txt),
+  txt <- BFHcharts:::build_fallback_analysis(ctx)
+  # goal_not_met-tekster udtrykker negation paa flere maader afhaengigt af
+  # variant: "opfylder (endnu )?ikke maalet", "endnu ikke naaet", "er ikke
+  # naaet", "naar ikke (udviklings)?maalet". Daekker alle nuvaerende formuleringer.
+  expect_true(grepl("opfylder (endnu )?ikke (udviklings)?målet|endnu ikke nået|er ikke nået|når ikke (udviklings)?målet", txt),
     info = paste("Forventede goal_not_met-sprog, fik:", txt)
   )
 })
 
-test_that("bfh_render_analysis bruger goal_met for 'higher'-target naar CL >= target", {
-  # Higher-direction: steady process at mean=95, target=">= 90" -> goal_met.
-  withr::with_seed(74L, {
-    d <- data.frame(
-      date  = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
-      value = round(rnorm(24, 95, 1), 1)
-    )
-  })
-  result <- bfh_qic(d,
-    x = date, y = value, chart_type = "i",
-    target_text = ">= 90"
+test_that("build_fallback_analysis bruger goal_met for 'higher'-target når CL >= target", {
+  ctx <- fixture_analysis_context(
+    target_value = 90, target_direction = "higher", centerline = 95,
+    target_display = ">= 90"
   )
-  analysis <- bfh_analyse(result)
-  txt <- bfh_render_analysis(analysis)
+  txt <- BFHcharts:::build_fallback_analysis(ctx)
   expect_true(grepl("opfylder (udviklings)?målet|målet.*nået", txt),
     info = paste("Forventede goal_met, fik:", txt)
   )
 })
 
-test_that("bfh_render_analysis bruger vaerdineutral tekst naar target_direction er NULL", {
-  # Numeric target (no direction operator): CL ~3.0 vs target=2.5 -> over_target.
-  withr::with_seed(75L, {
-    d <- data.frame(
-      date  = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
-      value = round(rnorm(24, 3.0, 0.1), 2)
-    )
-  })
-  result <- bfh_qic(d,
-    x = date, y = value, chart_type = "i",
-    target_value = 2.5
-  )
-  analysis <- bfh_analyse(result)
-  txt <- bfh_render_analysis(analysis)
-  # Vaerdineutral sti: "over" / "under" / "taet paa"
+test_that("build_fallback_analysis bruger værdineutral tekst når target_direction er NULL", {
+  ctx <- fixture_analysis_context(target_value = 2.5, target_direction = NULL, centerline = 3.0)
+  txt <- BFHcharts:::build_fallback_analysis(ctx)
+  # Den værdineutrale sti bruger "over" / "under" / "tæt på"
   expect_true(grepl("over|under|tæt på", txt))
 })
 
-test_that("bfh_render_analysis reallokerer budget naar target mangler", {
-  # No target -> stability+action fylder meste af max_chars.
-  d <- fixture_phase_stable()
-  result <- bfh_qic(d, x = date, y = value, chart_type = "i")
-  analysis <- bfh_analyse(result)
-  txt <- bfh_render_analysis(analysis, max_chars = 400)
-  # Floor justeret 250 -> 240 efter text-stramninger 2026-05 (cycle 06).
+test_that("build_fallback_analysis reallokerer budget når target mangler", {
+  ctx_no_target <- fixture_analysis_context(target_value = NA_real_, target_direction = NULL)
+  txt <- BFHcharts:::build_fallback_analysis(ctx_no_target, max_chars = 400)
+  # Uden target skal stability+action fylde meste af max_chars.
+  # Floor justeret 250 -> 240 efter text-stramninger 2026-05 (cycle 06):
+  # stability.no_signals.detailed og action.stable_no_target.detailed
+  # blev forkortet -- ren tekst-justering, ej budget-allokerings-bug.
   expect_gte(nchar(txt), 240)
   expect_lte(nchar(txt), 400)
 })
 
-test_that("bfh_render_analysis bruger ental ved 1 outlier", {
-  # Data med en enkelt outlier: 23 obs taet paa 50 + 1 obs >> UCL.
-  withr::with_seed(76L, {
-    vals <- round(rnorm(23, 50, 2), 1)
-  })
-  vals <- c(vals, 80) # klar outlier (langt over UCL)
-  d <- data.frame(
-    date  = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
-    value = vals
+test_that("build_fallback_analysis bruger ental ved 1 outlier", {
+  stats <- list(
+    runs_actual = 5, runs_expected = 7,
+    crossings_actual = 8, crossings_expected = 5,
+    outliers_recent_count = 1
   )
-  result <- bfh_qic(d, x = date, y = value, chart_type = "i")
-  analysis <- bfh_analyse(result)
-  txt <- bfh_render_analysis(analysis)
-  # Enten "1 observation" (direkte) eller "1 af de seneste [N] observationer"
+  ctx <- fixture_analysis_context(spc_stats = stats)
+  txt <- BFHcharts:::build_fallback_analysis(ctx)
+  # Grammatisk korrekt dansk: enten "1 observation ligger" (direkte) eller
+  # "1 af de seneste [N] observationer ligger" (flertal i "af de seneste"-konstruktion,
+  # muligvis med et vinduesantal indskudt).
   expect_match(txt, "1 observation\\b|1 af de seneste \\d* ?observationer")
+  # Må ikke indeholde "1 observationer" som direkte konstruktion
   expect_false(grepl("\\b1 observationer\\b", txt))
 })
 
-test_that("bfh_render_analysis bruger flertal ved 3 outliers", {
-  # Data med 3 outliers: 21 obs taet paa 50 + 3 obs >> UCL.
-  withr::with_seed(77L, {
-    vals <- round(rnorm(21, 50, 2), 1)
-  })
-  vals <- c(vals, 80, 82, 85) # 3 klare outliers
-  d <- data.frame(
-    date  = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
-    value = vals
+test_that("build_fallback_analysis bruger flertal ved 3 outliers", {
+  stats <- list(
+    runs_actual = 5, runs_expected = 7,
+    crossings_actual = 8, crossings_expected = 5,
+    outliers_recent_count = 3
   )
-  result <- bfh_qic(d, x = date, y = value, chart_type = "i")
-  analysis <- bfh_analyse(result)
-  txt <- bfh_render_analysis(analysis)
-  # Enten "3 observationer" (direkte) eller "3 af de seneste [N] observationer"
+  ctx <- fixture_analysis_context(spc_stats = stats)
+  txt <- BFHcharts:::build_fallback_analysis(ctx)
+  # Grammatisk korrekt dansk: enten "3 observationer" (direkte) eller
+  # "3 af de seneste [N] observationer" (flertal i "af de seneste"-konstruktion,
+  # muligvis med et vinduesantal indskudt).
   expect_match(txt, "3 observationer|3 af de seneste \\d* ?observationer")
+  # Må aldrig bruge ental efter tal > 1
   expect_false(grepl("\\b3 observation\\b", txt))
 })
 
@@ -816,29 +774,26 @@ test_that("REGRESSION: bfh_build_analysis_context normaliserer '>= 90%' til 0.90
   expect_equal(ctx$target_direction, "higher")
 })
 
-test_that("REGRESSION: bfh_render_analysis producerer 'opfylder maalet' for 91% vs >= 90%", {
-  # Direkte klinisk konsekvens-test: normaliseret target (0.90) og CL (0.91)
-  # skal give goal_met = TRUE (bug: target var 90 -> goal_met = FALSE).
-  set.seed(78L)
-  p_data <- data.frame(
-    date   = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
-    n      = rep(100L, 24),
-    events = rep(91L, 24) # 91% -> CL ~0.91
+test_that("REGRESSION: build_fallback_analysis producerer 'opfylder målet' for 91% vs >= 90%", {
+  # Dette er den direkte kliniske konsekvens-test:
+  # Med normaliseret target (0.90) og centerline (0.91) skal goal_met = TRUE
+  ctx <- fixture_analysis_context(
+    chart_type = "p",
+    y_axis_unit = "percent",
+    centerline = 0.91,
+    target_value = 0.90, # normaliseret (bug: var 90 -> FALSE)
+    target_direction = "higher",
+    target_display = ">= 90%"
   )
-  result <- bfh_qic(p_data,
-    x = date, y = events, n = n,
-    chart_type = "p", y_axis_unit = "percent"
-  )
-  analysis <- bfh_analyse(result, metadata = list(target = ">= 90%"))
-  txt <- bfh_render_analysis(analysis)
+  txt <- BFHcharts:::build_fallback_analysis(ctx)
 
-  # Teksten skal bekraefte at maalet er naet
+  # Teksten bør bekræfte at målet er nået
   expect_match(txt, "opfylder (udviklings)?målet|målet.*opfyldt|målet.*nået",
-    label = "Skal indeholde positivt maalbekraeftelse"
+    label = "Skal indeholde positivt målbekræftelse"
   )
   # Og IKKE den fejlagtige negative tekst
   expect_false(grepl("endnu ikke nået|opfylder ikke", txt),
-    label = "Ma ikke indeholde fejlagtig negation"
+    label = "Må ikke indeholde fejlagtig negation"
   )
 })
 
@@ -862,10 +817,9 @@ test_that("REGRESSION: lower-direction 3% vs '<= 5%' -> goal_met via normaliseri
   )
   expect_equal(ctx$target_direction, "lower")
 
-  analysis <- bfh_analyse(result, metadata = list(target = "<= 5%"))
-  txt <- bfh_render_analysis(analysis)
+  txt <- BFHcharts:::build_fallback_analysis(ctx)
   expect_match(txt, "opfylder (udviklings)?målet|målet.*opfyldt",
-    label = "3% opfylder <= 5% maal"
+    label = "3% opfylder <= 5% mål"
   )
 })
 
@@ -1050,96 +1004,126 @@ test_that("Target fallback: no target anywhere yields NA target_value", {
 })
 
 # ==============================================================================
-# Process-variation-based at_target classification via .within_sigma_tolerance
+# Process-variation-based at_target classification
 # (openspec change: at-target-tolerance-process-variation)
-# Tests ported to .within_sigma_tolerance() (spc_features.R live implementation)
 # ==============================================================================
 
-test_that(".within_sigma_tolerance: tight process with small target -> NOT within", {
-  # Bug reproducer: target=0.01, delta=0.009, sigma_hat=0.01/6 ~=0.0017,
-  # 3*sigma_hat ~=0.005 -> delta (0.009) > tolerance (0.005) -> FALSE.
-  # Under the old rule max(0.01*0.05, 0.01)=0.01 dominated -> at_target (wrong).
-  sigma_hat <- 0.01 / 6
-  delta <- abs(0.019 - 0.01) # 0.009
-  expect_false(
-    BFHcharts:::.within_sigma_tolerance(delta, sigma_hat,
-      sigma_data = 0.002,
-      sigma_multiplier_hat = 3, is_percent = FALSE
-    ),
-    label = "delta=0.009 exceeds 3*sigma_hat=0.005 -> not within"
+test_that("at_target classifies CORRECTLY for tight process with small target (bug reproducer)", {
+  # Bug rapporteret af maintainer: target = "<1%" (proportionsskala: 0.01),
+  # centerline = 0.019, smalle kontrolgraenser (UCL-LCL ~= 0.01).
+  # Under den gamle regel: tolerance = max(0.01*0.05, 0.01) = 0.01 dominerer ->
+  # |0.019-0.01| = 0.009 <= 0.01 -> at_target = TRUE (forkert).
+  # Under den nye regel: sigma_hat = 0.01/6 ~= 0.0017, 3*sigma_hat ~= 0.005 ->
+  # 0.009 > 0.005 -> at_target = FALSE (korrekt).
+  # NB: target_direction = NULL, ellers rammer vi goal_not_met-grenen.
+  ctx <- fixture_analysis_context(
+    target_value = 0.01,
+    target_direction = NULL,
+    centerline = 0.019,
+    sigma_hat = 0.01 / 6, # half-width = 3*sigma => sigma = (UCL-LCL)/6
+    sigma_data = 0.002,
+    target_display = "0.01"
+  )
+  txt <- BFHcharts:::build_fallback_analysis(ctx)
+  expect_true(grepl("over (udviklings)?m.let|over (udviklings)?malet", txt),
+    info = paste("Forventede over_target, fik:", txt)
+  )
+  expect_false(grepl("t.t p. (udviklings)?m.let|naer (udviklings)?m.let", txt))
+})
+
+test_that("at_target classifies CORRECTLY when target is inside wide control limits", {
+  # Vid process: UCL=12, LCL=2 -> sigma_hat = 10/6 ~= 1.67, 3*sigma_hat = 5.
+  # target=5, centerline=7 -> |7-5|=2 <= 5 -> at_target = TRUE.
+  ctx <- fixture_analysis_context(
+    target_value = 5,
+    target_direction = NULL,
+    centerline = 7,
+    sigma_hat = 10 / 6,
+    target_display = "5"
+  )
+  txt <- BFHcharts:::build_fallback_analysis(ctx)
+  expect_true(grepl("t.t p. (udviklings)?m.let", txt),
+    info = paste("Forventede at_target, fik:", txt)
   )
 })
 
-test_that(".within_sigma_tolerance: wide control limits -> within", {
-  # Vid process: UCL=12, LCL=2 -> sigma_hat=10/6~=1.67, 3*sigma_hat=5.
-  # delta=|7-5|=2 <= 5 -> TRUE.
-  sigma_hat <- 10 / 6
-  delta <- abs(7 - 5) # 2
-  expect_true(
-    BFHcharts:::.within_sigma_tolerance(delta, sigma_hat,
-      sigma_data = NA_real_,
-      sigma_multiplier_hat = 3, is_percent = FALSE
-    ),
-    label = "delta=2 <= 3*sigma_hat=5 -> within"
+test_that("at_target falls back to sd(y) when sigma_hat is NA (run chart)", {
+  # Run chart har ingen UCL/LCL -> sigma_hat = NA, men sigma_data = sd(y).
+  # target=10, centerline=11, sd(y)=2 -> |11-10|=1 <= 2 -> at_target = TRUE.
+  ctx <- fixture_analysis_context(
+    target_value = 10,
+    target_direction = NULL,
+    centerline = 11,
+    sigma_hat = NA_real_,
+    sigma_data = 2,
+    target_display = "10"
+  )
+  txt <- BFHcharts:::build_fallback_analysis(ctx)
+  expect_true(grepl("t.t p. (udviklings)?m.let", txt),
+    info = paste("Forventede at_target via sd-fallback, fik:", txt)
   )
 })
 
-test_that(".within_sigma_tolerance: sd(y) fallback when sigma_hat is NA (run chart)", {
-  # sigma_hat=NA, sigma_data=2 -> tolerance=2. delta=|11-10|=1 <= 2 -> TRUE.
-  delta <- abs(11 - 10) # 1
-  expect_true(
-    BFHcharts:::.within_sigma_tolerance(delta,
-      sigma_hat = NA_real_,
-      sigma_data = 2, sigma_multiplier_hat = 3, is_percent = FALSE
-    ),
-    label = "delta=1 <= sigma_data=2 -> within via sd-fallback"
+test_that("at_target falls back to sd(y) and classifies over_target when delta exceeds sd", {
+  # Run chart hvor target ligger uden for sd-baeltet.
+  ctx <- fixture_analysis_context(
+    target_value = 10,
+    target_direction = NULL,
+    centerline = 15,
+    sigma_hat = NA_real_,
+    sigma_data = 2,
+    target_display = "10"
+  )
+  txt <- BFHcharts:::build_fallback_analysis(ctx)
+  expect_true(grepl("over (udviklings)?m.let", txt),
+    info = paste("Forventede over_target, fik:", txt)
   )
 })
 
-test_that(".within_sigma_tolerance: sd(y) fallback -> NOT within when delta exceeds sd", {
-  # sigma_hat=NA, sigma_data=2. delta=|15-10|=5 > 2 -> FALSE.
-  delta <- abs(15 - 10) # 5
-  expect_false(
-    BFHcharts:::.within_sigma_tolerance(delta,
-      sigma_hat = NA_real_,
-      sigma_data = 2, sigma_multiplier_hat = 3, is_percent = FALSE
-    ),
-    label = "delta=5 > sigma_data=2 -> not within"
+test_that("at_target uses exact-match when both sigma_hat and sigma_data are zero/NA", {
+  # Degenereret case: konstant y, ingen variation. CL == target -> at_target.
+  ctx <- fixture_analysis_context(
+    target_value = 5,
+    target_direction = NULL,
+    centerline = 5,
+    sigma_hat = 0,
+    sigma_data = 0,
+    target_display = "5"
+  )
+  txt <- BFHcharts:::build_fallback_analysis(ctx)
+  expect_true(grepl("t.t p. (udviklings)?m.let", txt),
+    info = paste("Forventede at_target via eksakt-match, fik:", txt)
   )
 })
 
-test_that(".within_sigma_tolerance: exact-match (sigma=0) -> TRUE when delta=0", {
-  # Degenereret case: konstant y, sigma=0. CL==target -> delta=0 <= 1e-9 -> TRUE.
-  expect_true(
-    BFHcharts:::.within_sigma_tolerance(0,
-      sigma_hat = 0, sigma_data = 0,
-      sigma_multiplier_hat = 3, is_percent = FALSE
-    ),
-    label = "delta=0 <= 1e-9 tolerance -> within (exact match)"
+test_that("at_target eksakt-match: lille forskel klassificeres som over/under", {
+  # CL er minimalt over target med ingen variation -> over_target.
+  ctx <- fixture_analysis_context(
+    target_value = 5,
+    target_direction = NULL,
+    centerline = 5.001,
+    sigma_hat = 0,
+    sigma_data = 0,
+    target_display = "5"
   )
+  txt <- BFHcharts:::build_fallback_analysis(ctx)
+  expect_true(grepl("over (udviklings)?m.let", txt))
 })
 
-test_that(".within_sigma_tolerance: exact-match (sigma=0) -> FALSE when delta > 0", {
-  # CL minimalt over target, ingen variation -> delta=0.001 > 1e-9 -> FALSE.
-  expect_false(
-    BFHcharts:::.within_sigma_tolerance(0.001,
-      sigma_hat = 0, sigma_data = 0,
-      sigma_multiplier_hat = 3, is_percent = FALSE
-    ),
-    label = "delta=0.001 > 1e-9 tolerance -> not within"
-  )
-})
-
-test_that(".within_sigma_tolerance: inclusive at the 3*sigma_hat boundary", {
-  # Boundary: |CL - target| = 3*sigma_hat exactly. <=konvention -> TRUE.
+test_that("at_target classifies inclusively at the 3*sigma_hat boundary", {
+  # Boundary case: |CL - target| = 3*sigma_hat exactly.
+  # Forventning: <=-konvention inkluderer graensen -> at_target.
   sigma <- 1
-  delta <- 3 * sigma # exactly at boundary
-  expect_true(
-    BFHcharts:::.within_sigma_tolerance(delta,
-      sigma_hat = sigma,
-      sigma_data = NA_real_, sigma_multiplier_hat = 3, is_percent = FALSE
-    ),
-    label = "delta = 3*sigma exactly -> within (inclusive boundary)"
+  ctx <- fixture_analysis_context(
+    target_value = 8,
+    target_direction = NULL,
+    centerline = 5,
+    sigma_hat = sigma, # 3*sigma = 3; |5-8| = 3 = 3 -> at_target
+    target_display = "8"
+  )
+  txt <- BFHcharts:::build_fallback_analysis(ctx)
+  expect_true(grepl("t.t p. (udviklings)?m.let", txt),
+    info = paste("Forventede at_target ved <=-graense, fik:", txt)
   )
 })
 

--- a/tests/testthat/test-spc_analysis.R
+++ b/tests/testthat/test-spc_analysis.R
@@ -280,13 +280,6 @@ test_that("bfh_generate_analysis threads texts_loader to fallback pipeline", {
   expect_match(analysis, "CUSTOM_ACTION")
 })
 
-test_that("build_fallback_analysis validates texts_loader", {
-  expect_error(
-    BFHcharts:::build_fallback_analysis(list(), texts_loader = "bad"),
-    "texts_loader must be a function"
-  )
-})
-
 # ==============================================================================
 # pick_text() tests (intern funktion)
 # ==============================================================================
@@ -552,107 +545,156 @@ test_that("bfh_build_analysis_context bevarer numerisk target uden retning", {
 
 
 # ==============================================================================
-# build_fallback_analysis() — goal_met/goal_not_met + constraints
+# bfh_render_analysis() — goal_met/goal_not_met + constraints
+# (ported from legacy build_fallback_analysis tests per ADR-004)
 # ==============================================================================
 
-# Hjælpefunktion: fixture_analysis_context() er tilgængelig via helper-fixtures.R.
-
-test_that("build_fallback_analysis overstiger aldrig max_chars", {
+test_that("bfh_render_analysis overstiger aldrig max_chars", {
+  # Lower-direction: CL (45) <= target (50) -> goal_met. Stable data.
+  withr::with_seed(71L, {
+    d <- data.frame(
+      date  = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
+      value = round(rnorm(24, 45, 2), 1)
+    )
+  })
+  result <- bfh_qic(d,
+    x = date, y = value, chart_type = "i",
+    target_text = "<= 50"
+  )
+  analysis <- bfh_analyse(result)
   for (mx in c(200L, 275L, 375L, 500L)) {
-    ctx <- fixture_analysis_context(target_value = 50, target_direction = "lower", centerline = 45)
-    txt <- BFHcharts:::build_fallback_analysis(ctx, max_chars = mx)
+    txt <- bfh_render_analysis(analysis, max_chars = mx)
     expect_lte(nchar(txt), mx,
       label = sprintf("max_chars=%d giver %d tegn", mx, nchar(txt))
     )
   }
 })
 
-test_that("build_fallback_analysis bruger goal_met-tekst når target_direction er 'lower' og CL <= target", {
-  ctx <- fixture_analysis_context(
-    target_value = 2.5, target_direction = "lower", centerline = 2.0,
-    target_display = "<= 2,5"
+test_that("bfh_render_analysis bruger goal_met-tekst naar target_direction er 'lower' og CL <= target", {
+  # Lower-direction: steady process at mean=2.0, target="<= 2.5" -> goal_met.
+  withr::with_seed(72L, {
+    d <- data.frame(
+      date  = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
+      value = round(rnorm(24, 2.0, 0.1), 2)
+    )
+  })
+  result <- bfh_qic(d,
+    x = date, y = value, chart_type = "i",
+    target_text = "<= 2.5"
   )
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  # Skal INDEHOLDE "opfylder målet" eller "målet ... nået"
+  analysis <- bfh_analyse(result)
+  txt <- bfh_render_analysis(analysis)
+  # Skal INDEHOLDE "opfylder malet" eller "malet ... naet"
   expect_true(grepl("opfylder (udviklings)?målet|målet.*nået", txt),
     info = paste("Forventede goal_met-sprog, fik:", txt)
   )
-  # Må IKKE indeholde den værdineutrale "ligger under målet"
+  # Ma IKKE indeholde den vaerdineutrale "ligger under maalet"
   expect_false(grepl("ligger under målet", txt))
 })
 
-test_that("build_fallback_analysis bruger goal_not_met når CL overstiger 'lower'-target", {
-  ctx <- fixture_analysis_context(
-    target_value = 2.5, target_direction = "lower", centerline = 4.0,
-    target_display = "<= 2,5"
+test_that("bfh_render_analysis bruger goal_not_met naar CL overstiger 'lower'-target", {
+  # Lower-direction: steady process at mean=4.0, target="<= 2.5" -> goal_not_met.
+  withr::with_seed(73L, {
+    d <- data.frame(
+      date  = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
+      value = round(rnorm(24, 4.0, 0.1), 2)
+    )
+  })
+  result <- bfh_qic(d,
+    x = date, y = value, chart_type = "i",
+    target_text = "<= 2.5"
   )
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  # goal_not_met-tekster udtrykker negation paa flere maader afhaengigt af
-  # variant: "opfylder (endnu )?ikke maalet", "endnu ikke naaet", "er ikke
-  # naaet", "naar ikke (udviklings)?maalet". Daekker alle nuvaerende formuleringer.
-  expect_true(grepl("opfylder (endnu )?ikke (udviklings)?målet|endnu ikke nået|er ikke nået|når ikke (udviklings)?målet", txt),
+  analysis <- bfh_analyse(result)
+  txt <- bfh_render_analysis(analysis)
+  # goal_not_met-tekster: "opfylder (endnu )?ikke maalet", "endnu ikke naet",
+  # "er ikke naet", "naar ikke (udviklings)?maalet".
+  expect_true(
+    grepl("opfylder (endnu )?ikke (udviklings)?målet|endnu ikke nået|er ikke nået|når ikke (udviklings)?målet", txt),
     info = paste("Forventede goal_not_met-sprog, fik:", txt)
   )
 })
 
-test_that("build_fallback_analysis bruger goal_met for 'higher'-target når CL >= target", {
-  ctx <- fixture_analysis_context(
-    target_value = 90, target_direction = "higher", centerline = 95,
-    target_display = ">= 90"
+test_that("bfh_render_analysis bruger goal_met for 'higher'-target naar CL >= target", {
+  # Higher-direction: steady process at mean=95, target=">= 90" -> goal_met.
+  withr::with_seed(74L, {
+    d <- data.frame(
+      date  = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
+      value = round(rnorm(24, 95, 1), 1)
+    )
+  })
+  result <- bfh_qic(d,
+    x = date, y = value, chart_type = "i",
+    target_text = ">= 90"
   )
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
+  analysis <- bfh_analyse(result)
+  txt <- bfh_render_analysis(analysis)
   expect_true(grepl("opfylder (udviklings)?målet|målet.*nået", txt),
     info = paste("Forventede goal_met, fik:", txt)
   )
 })
 
-test_that("build_fallback_analysis bruger værdineutral tekst når target_direction er NULL", {
-  ctx <- fixture_analysis_context(target_value = 2.5, target_direction = NULL, centerline = 3.0)
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  # Den værdineutrale sti bruger "over" / "under" / "tæt på"
+test_that("bfh_render_analysis bruger vaerdineutral tekst naar target_direction er NULL", {
+  # Numeric target (no direction operator): CL ~3.0 vs target=2.5 -> over_target.
+  withr::with_seed(75L, {
+    d <- data.frame(
+      date  = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
+      value = round(rnorm(24, 3.0, 0.1), 2)
+    )
+  })
+  result <- bfh_qic(d,
+    x = date, y = value, chart_type = "i",
+    target_value = 2.5
+  )
+  analysis <- bfh_analyse(result)
+  txt <- bfh_render_analysis(analysis)
+  # Vaerdineutral sti: "over" / "under" / "taet paa"
   expect_true(grepl("over|under|tæt på", txt))
 })
 
-test_that("build_fallback_analysis reallokerer budget når target mangler", {
-  ctx_no_target <- fixture_analysis_context(target_value = NA_real_, target_direction = NULL)
-  txt <- BFHcharts:::build_fallback_analysis(ctx_no_target, max_chars = 400)
-  # Uden target skal stability+action fylde meste af max_chars.
-  # Floor justeret 250 -> 240 efter text-stramninger 2026-05 (cycle 06):
-  # stability.no_signals.detailed og action.stable_no_target.detailed
-  # blev forkortet -- ren tekst-justering, ej budget-allokerings-bug.
+test_that("bfh_render_analysis reallokerer budget naar target mangler", {
+  # No target -> stability+action fylder meste af max_chars.
+  d <- fixture_phase_stable()
+  result <- bfh_qic(d, x = date, y = value, chart_type = "i")
+  analysis <- bfh_analyse(result)
+  txt <- bfh_render_analysis(analysis, max_chars = 400)
+  # Floor justeret 250 -> 240 efter text-stramninger 2026-05 (cycle 06).
   expect_gte(nchar(txt), 240)
   expect_lte(nchar(txt), 400)
 })
 
-test_that("build_fallback_analysis bruger ental ved 1 outlier", {
-  stats <- list(
-    runs_actual = 5, runs_expected = 7,
-    crossings_actual = 8, crossings_expected = 5,
-    outliers_recent_count = 1
+test_that("bfh_render_analysis bruger ental ved 1 outlier", {
+  # Data med en enkelt outlier: 23 obs taet paa 50 + 1 obs >> UCL.
+  withr::with_seed(76L, {
+    vals <- round(rnorm(23, 50, 2), 1)
+  })
+  vals <- c(vals, 80) # klar outlier (langt over UCL)
+  d <- data.frame(
+    date  = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
+    value = vals
   )
-  ctx <- fixture_analysis_context(spc_stats = stats)
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  # Grammatisk korrekt dansk: enten "1 observation ligger" (direkte) eller
-  # "1 af de seneste [N] observationer ligger" (flertal i "af de seneste"-konstruktion,
-  # muligvis med et vinduesantal indskudt).
+  result <- bfh_qic(d, x = date, y = value, chart_type = "i")
+  analysis <- bfh_analyse(result)
+  txt <- bfh_render_analysis(analysis)
+  # Enten "1 observation" (direkte) eller "1 af de seneste [N] observationer"
   expect_match(txt, "1 observation\\b|1 af de seneste \\d* ?observationer")
-  # Må ikke indeholde "1 observationer" som direkte konstruktion
   expect_false(grepl("\\b1 observationer\\b", txt))
 })
 
-test_that("build_fallback_analysis bruger flertal ved 3 outliers", {
-  stats <- list(
-    runs_actual = 5, runs_expected = 7,
-    crossings_actual = 8, crossings_expected = 5,
-    outliers_recent_count = 3
+test_that("bfh_render_analysis bruger flertal ved 3 outliers", {
+  # Data med 3 outliers: 21 obs taet paa 50 + 3 obs >> UCL.
+  withr::with_seed(77L, {
+    vals <- round(rnorm(21, 50, 2), 1)
+  })
+  vals <- c(vals, 80, 82, 85) # 3 klare outliers
+  d <- data.frame(
+    date  = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
+    value = vals
   )
-  ctx <- fixture_analysis_context(spc_stats = stats)
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  # Grammatisk korrekt dansk: enten "3 observationer" (direkte) eller
-  # "3 af de seneste [N] observationer" (flertal i "af de seneste"-konstruktion,
-  # muligvis med et vinduesantal indskudt).
+  result <- bfh_qic(d, x = date, y = value, chart_type = "i")
+  analysis <- bfh_analyse(result)
+  txt <- bfh_render_analysis(analysis)
+  # Enten "3 observationer" (direkte) eller "3 af de seneste [N] observationer"
   expect_match(txt, "3 observationer|3 af de seneste \\d* ?observationer")
-  # Må aldrig bruge ental efter tal > 1
   expect_false(grepl("\\b3 observation\\b", txt))
 })
 
@@ -774,26 +816,29 @@ test_that("REGRESSION: bfh_build_analysis_context normaliserer '>= 90%' til 0.90
   expect_equal(ctx$target_direction, "higher")
 })
 
-test_that("REGRESSION: build_fallback_analysis producerer 'opfylder målet' for 91% vs >= 90%", {
-  # Dette er den direkte kliniske konsekvens-test:
-  # Med normaliseret target (0.90) og centerline (0.91) skal goal_met = TRUE
-  ctx <- fixture_analysis_context(
-    chart_type = "p",
-    y_axis_unit = "percent",
-    centerline = 0.91,
-    target_value = 0.90, # normaliseret (bug: var 90 -> FALSE)
-    target_direction = "higher",
-    target_display = ">= 90%"
+test_that("REGRESSION: bfh_render_analysis producerer 'opfylder maalet' for 91% vs >= 90%", {
+  # Direkte klinisk konsekvens-test: normaliseret target (0.90) og CL (0.91)
+  # skal give goal_met = TRUE (bug: target var 90 -> goal_met = FALSE).
+  set.seed(78L)
+  p_data <- data.frame(
+    date   = seq.Date(as.Date("2024-01-01"), by = "month", length.out = 24),
+    n      = rep(100L, 24),
+    events = rep(91L, 24) # 91% -> CL ~0.91
   )
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
+  result <- bfh_qic(p_data,
+    x = date, y = events, n = n,
+    chart_type = "p", y_axis_unit = "percent"
+  )
+  analysis <- bfh_analyse(result, metadata = list(target = ">= 90%"))
+  txt <- bfh_render_analysis(analysis)
 
-  # Teksten bør bekræfte at målet er nået
+  # Teksten skal bekraefte at maalet er naet
   expect_match(txt, "opfylder (udviklings)?målet|målet.*opfyldt|målet.*nået",
-    label = "Skal indeholde positivt målbekræftelse"
+    label = "Skal indeholde positivt maalbekraeftelse"
   )
   # Og IKKE den fejlagtige negative tekst
   expect_false(grepl("endnu ikke nået|opfylder ikke", txt),
-    label = "Må ikke indeholde fejlagtig negation"
+    label = "Ma ikke indeholde fejlagtig negation"
   )
 })
 
@@ -817,9 +862,10 @@ test_that("REGRESSION: lower-direction 3% vs '<= 5%' -> goal_met via normaliseri
   )
   expect_equal(ctx$target_direction, "lower")
 
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
+  analysis <- bfh_analyse(result, metadata = list(target = "<= 5%"))
+  txt <- bfh_render_analysis(analysis)
   expect_match(txt, "opfylder (udviklings)?målet|målet.*opfyldt",
-    label = "3% opfylder <= 5% mål"
+    label = "3% opfylder <= 5% maal"
   )
 })
 
@@ -1004,126 +1050,96 @@ test_that("Target fallback: no target anywhere yields NA target_value", {
 })
 
 # ==============================================================================
-# Process-variation-based at_target classification
+# Process-variation-based at_target classification via .within_sigma_tolerance
 # (openspec change: at-target-tolerance-process-variation)
+# Tests ported to .within_sigma_tolerance() (spc_features.R live implementation)
 # ==============================================================================
 
-test_that("at_target classifies CORRECTLY for tight process with small target (bug reproducer)", {
-  # Bug rapporteret af maintainer: target = "<1%" (proportionsskala: 0.01),
-  # centerline = 0.019, smalle kontrolgraenser (UCL-LCL ~= 0.01).
-  # Under den gamle regel: tolerance = max(0.01*0.05, 0.01) = 0.01 dominerer ->
-  # |0.019-0.01| = 0.009 <= 0.01 -> at_target = TRUE (forkert).
-  # Under den nye regel: sigma_hat = 0.01/6 ~= 0.0017, 3*sigma_hat ~= 0.005 ->
-  # 0.009 > 0.005 -> at_target = FALSE (korrekt).
-  # NB: target_direction = NULL, ellers rammer vi goal_not_met-grenen.
-  ctx <- fixture_analysis_context(
-    target_value = 0.01,
-    target_direction = NULL,
-    centerline = 0.019,
-    sigma_hat = 0.01 / 6, # half-width = 3*sigma => sigma = (UCL-LCL)/6
-    sigma_data = 0.002,
-    target_display = "0.01"
-  )
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  expect_true(grepl("over (udviklings)?m.let|over (udviklings)?malet", txt),
-    info = paste("Forventede over_target, fik:", txt)
-  )
-  expect_false(grepl("t.t p. (udviklings)?m.let|naer (udviklings)?m.let", txt))
-})
-
-test_that("at_target classifies CORRECTLY when target is inside wide control limits", {
-  # Vid process: UCL=12, LCL=2 -> sigma_hat = 10/6 ~= 1.67, 3*sigma_hat = 5.
-  # target=5, centerline=7 -> |7-5|=2 <= 5 -> at_target = TRUE.
-  ctx <- fixture_analysis_context(
-    target_value = 5,
-    target_direction = NULL,
-    centerline = 7,
-    sigma_hat = 10 / 6,
-    target_display = "5"
-  )
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  expect_true(grepl("t.t p. (udviklings)?m.let", txt),
-    info = paste("Forventede at_target, fik:", txt)
+test_that(".within_sigma_tolerance: tight process with small target -> NOT within", {
+  # Bug reproducer: target=0.01, delta=0.009, sigma_hat=0.01/6 ~=0.0017,
+  # 3*sigma_hat ~=0.005 -> delta (0.009) > tolerance (0.005) -> FALSE.
+  # Under the old rule max(0.01*0.05, 0.01)=0.01 dominated -> at_target (wrong).
+  sigma_hat <- 0.01 / 6
+  delta <- abs(0.019 - 0.01) # 0.009
+  expect_false(
+    BFHcharts:::.within_sigma_tolerance(delta, sigma_hat,
+      sigma_data = 0.002,
+      sigma_multiplier_hat = 3, is_percent = FALSE
+    ),
+    label = "delta=0.009 exceeds 3*sigma_hat=0.005 -> not within"
   )
 })
 
-test_that("at_target falls back to sd(y) when sigma_hat is NA (run chart)", {
-  # Run chart har ingen UCL/LCL -> sigma_hat = NA, men sigma_data = sd(y).
-  # target=10, centerline=11, sd(y)=2 -> |11-10|=1 <= 2 -> at_target = TRUE.
-  ctx <- fixture_analysis_context(
-    target_value = 10,
-    target_direction = NULL,
-    centerline = 11,
-    sigma_hat = NA_real_,
-    sigma_data = 2,
-    target_display = "10"
-  )
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  expect_true(grepl("t.t p. (udviklings)?m.let", txt),
-    info = paste("Forventede at_target via sd-fallback, fik:", txt)
+test_that(".within_sigma_tolerance: wide control limits -> within", {
+  # Vid process: UCL=12, LCL=2 -> sigma_hat=10/6~=1.67, 3*sigma_hat=5.
+  # delta=|7-5|=2 <= 5 -> TRUE.
+  sigma_hat <- 10 / 6
+  delta <- abs(7 - 5) # 2
+  expect_true(
+    BFHcharts:::.within_sigma_tolerance(delta, sigma_hat,
+      sigma_data = NA_real_,
+      sigma_multiplier_hat = 3, is_percent = FALSE
+    ),
+    label = "delta=2 <= 3*sigma_hat=5 -> within"
   )
 })
 
-test_that("at_target falls back to sd(y) and classifies over_target when delta exceeds sd", {
-  # Run chart hvor target ligger uden for sd-baeltet.
-  ctx <- fixture_analysis_context(
-    target_value = 10,
-    target_direction = NULL,
-    centerline = 15,
-    sigma_hat = NA_real_,
-    sigma_data = 2,
-    target_display = "10"
-  )
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  expect_true(grepl("over (udviklings)?m.let", txt),
-    info = paste("Forventede over_target, fik:", txt)
+test_that(".within_sigma_tolerance: sd(y) fallback when sigma_hat is NA (run chart)", {
+  # sigma_hat=NA, sigma_data=2 -> tolerance=2. delta=|11-10|=1 <= 2 -> TRUE.
+  delta <- abs(11 - 10) # 1
+  expect_true(
+    BFHcharts:::.within_sigma_tolerance(delta,
+      sigma_hat = NA_real_,
+      sigma_data = 2, sigma_multiplier_hat = 3, is_percent = FALSE
+    ),
+    label = "delta=1 <= sigma_data=2 -> within via sd-fallback"
   )
 })
 
-test_that("at_target uses exact-match when both sigma_hat and sigma_data are zero/NA", {
-  # Degenereret case: konstant y, ingen variation. CL == target -> at_target.
-  ctx <- fixture_analysis_context(
-    target_value = 5,
-    target_direction = NULL,
-    centerline = 5,
-    sigma_hat = 0,
-    sigma_data = 0,
-    target_display = "5"
-  )
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  expect_true(grepl("t.t p. (udviklings)?m.let", txt),
-    info = paste("Forventede at_target via eksakt-match, fik:", txt)
+test_that(".within_sigma_tolerance: sd(y) fallback -> NOT within when delta exceeds sd", {
+  # sigma_hat=NA, sigma_data=2. delta=|15-10|=5 > 2 -> FALSE.
+  delta <- abs(15 - 10) # 5
+  expect_false(
+    BFHcharts:::.within_sigma_tolerance(delta,
+      sigma_hat = NA_real_,
+      sigma_data = 2, sigma_multiplier_hat = 3, is_percent = FALSE
+    ),
+    label = "delta=5 > sigma_data=2 -> not within"
   )
 })
 
-test_that("at_target eksakt-match: lille forskel klassificeres som over/under", {
-  # CL er minimalt over target med ingen variation -> over_target.
-  ctx <- fixture_analysis_context(
-    target_value = 5,
-    target_direction = NULL,
-    centerline = 5.001,
-    sigma_hat = 0,
-    sigma_data = 0,
-    target_display = "5"
+test_that(".within_sigma_tolerance: exact-match (sigma=0) -> TRUE when delta=0", {
+  # Degenereret case: konstant y, sigma=0. CL==target -> delta=0 <= 1e-9 -> TRUE.
+  expect_true(
+    BFHcharts:::.within_sigma_tolerance(0,
+      sigma_hat = 0, sigma_data = 0,
+      sigma_multiplier_hat = 3, is_percent = FALSE
+    ),
+    label = "delta=0 <= 1e-9 tolerance -> within (exact match)"
   )
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  expect_true(grepl("over (udviklings)?m.let", txt))
 })
 
-test_that("at_target classifies inclusively at the 3*sigma_hat boundary", {
-  # Boundary case: |CL - target| = 3*sigma_hat exactly.
-  # Forventning: <=-konvention inkluderer graensen -> at_target.
+test_that(".within_sigma_tolerance: exact-match (sigma=0) -> FALSE when delta > 0", {
+  # CL minimalt over target, ingen variation -> delta=0.001 > 1e-9 -> FALSE.
+  expect_false(
+    BFHcharts:::.within_sigma_tolerance(0.001,
+      sigma_hat = 0, sigma_data = 0,
+      sigma_multiplier_hat = 3, is_percent = FALSE
+    ),
+    label = "delta=0.001 > 1e-9 tolerance -> not within"
+  )
+})
+
+test_that(".within_sigma_tolerance: inclusive at the 3*sigma_hat boundary", {
+  # Boundary: |CL - target| = 3*sigma_hat exactly. <=konvention -> TRUE.
   sigma <- 1
-  ctx <- fixture_analysis_context(
-    target_value = 8,
-    target_direction = NULL,
-    centerline = 5,
-    sigma_hat = sigma, # 3*sigma = 3; |5-8| = 3 = 3 -> at_target
-    target_display = "8"
-  )
-  txt <- BFHcharts:::build_fallback_analysis(ctx)
-  expect_true(grepl("t.t p. (udviklings)?m.let", txt),
-    info = paste("Forventede at_target ved <=-graense, fik:", txt)
+  delta <- 3 * sigma # exactly at boundary
+  expect_true(
+    BFHcharts:::.within_sigma_tolerance(delta,
+      sigma_hat = sigma,
+      sigma_data = NA_real_, sigma_multiplier_hat = 3, is_percent = FALSE
+    ),
+    label = "delta = 3*sigma exactly -> within (inclusive boundary)"
   )
 })
 

--- a/tests/testthat/test-summary-anhoej-consistency.R
+++ b/tests/testthat/test-summary-anhoej-consistency.R
@@ -31,7 +31,7 @@ check_anhoej_consistency <- function(result) {
   summary <- result$summary
   qic_data <- result$qic_data
 
-  loeb_col <- grep("ngste_løb$", names(summary), value = TRUE)[1]
+  loeb_col <- grep("ngste_loeb$", names(summary), value = TRUE)[1]
   sig_col <- if ("anhoej_signal" %in% names(summary)) "anhoej_signal" else NA_character_
 
   n_phases <- nrow(summary)
@@ -80,7 +80,7 @@ check_anhoej_consistency <- function(result) {
 
     # --- runs_signal (decomposed: laengste_loeb > laengste_loeb_max) ---
     if ("runs_signal" %in% names(summary)) {
-      loeb_max_col <- grep("ngste_løb_max$", names(summary), value = TRUE)[1]
+      loeb_max_col <- grep("ngste_loeb_max$", names(summary), value = TRUE)[1]
       s_run_sig <- as.logical(summary$runs_signal[i])
       expected_run_sig <- isTRUE(summary[[loeb_col]][i] > summary[[loeb_max_col]][i])
       if (!is.na(s_run_sig) && !isTRUE(s_run_sig == expected_run_sig)) {
@@ -136,7 +136,7 @@ test_that("summary Anhoej-stats matcher qic_data per fase - I-chart 2 faser", {
   expect_true(length(divs) == 0L, info = paste("Divergenser:", paste(divs, collapse = "; ")))
 
   # Eksplicitte fase-assertions (spec scenario 1)
-  loeb_col <- grep("ngste_løb$", names(result$summary), value = TRUE)[1]
+  loeb_col <- grep("ngste_loeb$", names(result$summary), value = TRUE)[1]
   for (i in 1:2) {
     phase_rows <- result$qic_data[result$qic_data$part == i, ]
     expect_equal(
@@ -183,7 +183,7 @@ test_that("summary Anhoej-stats matcher qic_data - enkelt fase (ingen part)", {
   expect_true(length(divs) == 0L, info = paste("Divergenser:", paste(divs, collapse = "; ")))
 
   # Global aggregering skal matche enkelt-fase summary
-  loeb_col <- grep("ngste_løb$", names(result$summary), value = TRUE)[1]
+  loeb_col <- grep("ngste_loeb$", names(result$summary), value = TRUE)[1]
   expect_equal(
     as.integer(result$summary[1, loeb_col]),
     max(result$qic_data$longest.run, na.rm = TRUE)
@@ -354,7 +354,7 @@ test_that("bfh_extract_spc_stats(result) matcher result$summary vaerdier", {
   stats <- bfh_extract_spc_stats(result)
 
   # stats er baseret paa seneste fase (fase 2)
-  loeb_col <- grep("ngste_løb$", names(result$summary), value = TRUE)[1]
+  loeb_col <- grep("ngste_loeb$", names(result$summary), value = TRUE)[1]
   latest_row <- result$summary[nrow(result$summary), ]
 
   expect_equal(stats$runs_actual, as.integer(latest_row[[loeb_col]]))

--- a/tests/testthat/test-summary-precision.R
+++ b/tests/testthat/test-summary-precision.R
@@ -68,13 +68,13 @@ test_that("scalar nedre/oevre_kontrolgraense matcher qic_data raat", {
   result <- bfh_qic(d, x = month, y = value, chart_type = "i")
 
   # I-chart skal have konstante graenser -> scalar kolonner
-  expect_true(result$summary$kontrolgrænser_konstante[1])
+  expect_true(result$summary$kontrolgraenser_konstante[1])
   expect_identical(
-    result$summary$nedre_kontrolgrænse[1],
+    result$summary$nedre_kontrolgraense[1],
     result$qic_data$lcl[1]
   )
   expect_identical(
-    result$summary$øvre_kontrolgrænse[1],
+    result$summary$oevre_kontrolgraense[1],
     result$qic_data$ucl[1]
   )
 })
@@ -94,21 +94,21 @@ test_that("variable kontrolgraenser min/max matcher qic_data$lcl/ucl raat", {
     chart_type = "p", y_axis_unit = "percent"
   )
 
-  expect_false(result$summary$kontrolgrænser_konstante[1])
+  expect_false(result$summary$kontrolgraenser_konstante[1])
   expect_identical(
-    result$summary$nedre_kontrolgrænse_min[1],
+    result$summary$nedre_kontrolgraense_min[1],
     min(result$qic_data$lcl, na.rm = TRUE)
   )
   expect_identical(
-    result$summary$nedre_kontrolgrænse_max[1],
+    result$summary$nedre_kontrolgraense_max[1],
     max(result$qic_data$lcl, na.rm = TRUE)
   )
   expect_identical(
-    result$summary$øvre_kontrolgrænse_min[1],
+    result$summary$oevre_kontrolgraense_min[1],
     min(result$qic_data$ucl, na.rm = TRUE)
   )
   expect_identical(
-    result$summary$øvre_kontrolgrænse_max[1],
+    result$summary$oevre_kontrolgraense_max[1],
     max(result$qic_data$ucl, na.rm = TRUE)
   )
 })
@@ -137,14 +137,14 @@ test_that("kontrolgraenser_konstante haandterer floating-point drift via toleran
 
   result <- format_qic_summary(qic_data, y_axis_unit = "count")
 
-  expect_true(result$kontrolgrænser_konstante[1],
+  expect_true(result$kontrolgraenser_konstante[1],
     info = "Drift under tolerance skal stadig detekteres som konstant"
   )
-  expect_true("nedre_kontrolgrænse" %in% names(result),
+  expect_true("nedre_kontrolgraense" %in% names(result),
     info = "Konstans -> scalar kolonner"
   )
   # Den scalar vaerdi skal vaere RAA (ikke afrundet)
-  expect_equal(result$nedre_kontrolgrænse[1], 40.00001, tolerance = 1e-6)
+  expect_equal(result$nedre_kontrolgraense[1], 40.00001, tolerance = 1e-6)
 })
 
 # -----------------------------------------------------------------------------

--- a/tests/testthat/test-utils_qic_summary.R
+++ b/tests/testthat/test-utils_qic_summary.R
@@ -15,8 +15,8 @@ test_that("format_qic_summary returnerer data frame med danske kolonnenavne", {
   expect_true("fase" %in% names(result))
   expect_true("antal_observationer" %in% names(result))
   expect_true("anvendelige_observationer" %in% names(result))
-  expect_true("længste_løb" %in% names(result))
-  expect_true("længste_løb_max" %in% names(result))
+  expect_true("laengste_loeb" %in% names(result))
+  expect_true("laengste_loeb_max" %in% names(result))
   expect_true("antal_kryds" %in% names(result))
   expect_true("antal_kryds_min" %in% names(result))
   expect_true("anhoej_signal" %in% names(result))
@@ -31,7 +31,7 @@ test_that("format_qic_summary returnerer korrekte typer", {
 
   expect_type(result$fase, "integer")
   expect_type(result$antal_observationer, "integer")
-  expect_type(result$længste_løb, "integer")
+  expect_type(result$laengste_loeb, "integer")
   expect_type(result$anhoej_signal, "logical")
   expect_type(result$runs_signal, "logical")
   expect_type(result$crossings_signal, "logical")
@@ -72,8 +72,8 @@ test_that("format_qic_summary aggregerer Anhøj-stats per part", {
   result <- format_qic_summary(qic_data, y_axis_unit = "count")
 
   # safe_max per part — skal give max per fase
-  expect_equal(result$længste_løb[1], 3L)
-  expect_equal(result$længste_løb[2], 7L)
+  expect_equal(result$laengste_loeb[1], 3L)
+  expect_equal(result$laengste_loeb[2], 7L)
 })
 
 test_that("format_qic_summary kombinerer signals korrekt med any()", {
@@ -138,16 +138,16 @@ test_that("format_qic_summary inkluderer skalare kontrolgrænser ved konstante g
   result <- format_qic_summary(qic_data, y_axis_unit = "count")
 
   # Backward-compat: skalare kolonner til stede
-  expect_true("nedre_kontrolgrænse" %in% names(result))
-  expect_true("øvre_kontrolgrænse" %in% names(result))
+  expect_true("nedre_kontrolgraense" %in% names(result))
+  expect_true("oevre_kontrolgraense" %in% names(result))
   # Flag sættes til TRUE
-  expect_true("kontrolgrænser_konstante" %in% names(result))
-  expect_true(all(result$kontrolgrænser_konstante))
+  expect_true("kontrolgraenser_konstante" %in% names(result))
+  expect_true(all(result$kontrolgraenser_konstante))
   # Min/max kolonner fraværende ved konstante grænser
-  expect_false("nedre_kontrolgrænse_min" %in% names(result))
-  expect_false("nedre_kontrolgrænse_max" %in% names(result))
-  expect_false("øvre_kontrolgrænse_min" %in% names(result))
-  expect_false("øvre_kontrolgrænse_max" %in% names(result))
+  expect_false("nedre_kontrolgraense_min" %in% names(result))
+  expect_false("nedre_kontrolgraense_max" %in% names(result))
+  expect_false("oevre_kontrolgraense_min" %in% names(result))
+  expect_false("oevre_kontrolgraense_max" %in% names(result))
 })
 
 test_that("format_qic_summary eksponerer min/max ved variable grænser", {
@@ -159,19 +159,19 @@ test_that("format_qic_summary eksponerer min/max ved variable grænser", {
   result <- format_qic_summary(qic_data, y_axis_unit = "percent")
 
   # Flag sættes til FALSE
-  expect_true("kontrolgrænser_konstante" %in% names(result))
-  expect_false(any(result$kontrolgrænser_konstante))
+  expect_true("kontrolgraenser_konstante" %in% names(result))
+  expect_false(any(result$kontrolgraenser_konstante))
   # Min/max kolonner tilstede
-  expect_true("nedre_kontrolgrænse_min" %in% names(result))
-  expect_true("nedre_kontrolgrænse_max" %in% names(result))
-  expect_true("øvre_kontrolgrænse_min" %in% names(result))
-  expect_true("øvre_kontrolgrænse_max" %in% names(result))
+  expect_true("nedre_kontrolgraense_min" %in% names(result))
+  expect_true("nedre_kontrolgraense_max" %in% names(result))
+  expect_true("oevre_kontrolgraense_min" %in% names(result))
+  expect_true("oevre_kontrolgraense_max" %in% names(result))
   # Skalare kolonner fraværende (misvisende at vise én værdi)
-  expect_false("nedre_kontrolgrænse" %in% names(result))
-  expect_false("øvre_kontrolgrænse" %in% names(result))
+  expect_false("nedre_kontrolgraense" %in% names(result))
+  expect_false("oevre_kontrolgraense" %in% names(result))
   # Min < max (grænser varierer)
-  expect_lt(result$nedre_kontrolgrænse_min, result$nedre_kontrolgrænse_max)
-  expect_lt(result$øvre_kontrolgrænse_min, result$øvre_kontrolgrænse_max)
+  expect_lt(result$nedre_kontrolgraense_min, result$nedre_kontrolgraense_max)
+  expect_lt(result$oevre_kontrolgraense_min, result$oevre_kontrolgraense_max)
 })
 
 test_that("format_qic_summary: variable grænser giver korrekte min/max-værdier", {
@@ -183,10 +183,10 @@ test_that("format_qic_summary: variable grænser giver korrekte min/max-værdier
   result <- format_qic_summary(qic_data, y_axis_unit = "percent")
 
   # Slice C: raa precision -- min/max matcher faktisk min/max uden afrunding
-  expect_equal(result$nedre_kontrolgrænse_min, 30)
-  expect_equal(result$nedre_kontrolgrænse_max, 40)
-  expect_equal(result$øvre_kontrolgrænse_min, 60)
-  expect_equal(result$øvre_kontrolgrænse_max, 70)
+  expect_equal(result$nedre_kontrolgraense_min, 30)
+  expect_equal(result$nedre_kontrolgraense_max, 40)
+  expect_equal(result$oevre_kontrolgraense_min, 60)
+  expect_equal(result$oevre_kontrolgraense_max, 70)
 })
 
 test_that("format_qic_summary: p-chart med konstant n → konstante grænser", {
@@ -195,9 +195,9 @@ test_that("format_qic_summary: p-chart med konstant n → konstante grænser", {
   # lcl/ucl er allerede konstante i fixture (rep(35,n) og rep(65,n))
   result <- format_qic_summary(qic_data, y_axis_unit = "percent")
 
-  expect_true(all(result$kontrolgrænser_konstante))
-  expect_true("nedre_kontrolgrænse" %in% names(result))
-  expect_true("øvre_kontrolgrænse" %in% names(result))
+  expect_true(all(result$kontrolgraenser_konstante))
+  expect_true("nedre_kontrolgraense" %in% names(result))
+  expect_true("oevre_kontrolgraense" %in% names(result))
 })
 
 test_that("format_qic_summary: multi-fase med variable grænser → flag per row korrekt", {
@@ -211,16 +211,16 @@ test_that("format_qic_summary: multi-fase med variable grænser → flag per row
 
   expect_equal(nrow(result), 2)
   # Fase 1 er konstant, fase 2 er variabel
-  expect_true(result$kontrolgrænser_konstante[1])
-  expect_false(result$kontrolgrænser_konstante[2])
+  expect_true(result$kontrolgraenser_konstante[1])
+  expect_false(result$kontrolgraenser_konstante[2])
   # Global beslutning: mindst én variabel → min/max kolonner for alle
-  expect_true("nedre_kontrolgrænse_min" %in% names(result))
-  expect_true("nedre_kontrolgrænse_max" %in% names(result))
-  expect_false("nedre_kontrolgrænse" %in% names(result))
+  expect_true("nedre_kontrolgraense_min" %in% names(result))
+  expect_true("nedre_kontrolgraense_max" %in% names(result))
+  expect_false("nedre_kontrolgraense" %in% names(result))
   # Fase 1 (konstant) → min == max
-  expect_equal(result$nedre_kontrolgrænse_min[1], result$nedre_kontrolgrænse_max[1])
+  expect_equal(result$nedre_kontrolgraense_min[1], result$nedre_kontrolgraense_max[1])
   # Fase 2 (variabel) → min < max
-  expect_lt(result$nedre_kontrolgrænse_min[2], result$nedre_kontrolgrænse_max[2])
+  expect_lt(result$nedre_kontrolgraense_min[2], result$nedre_kontrolgraense_max[2])
 })
 
 # =============================================================================
@@ -234,8 +234,8 @@ test_that("format_qic_summary håndterer run chart uden lcl/ucl", {
 
   result <- format_qic_summary(qic_data, y_axis_unit = "count")
 
-  expect_false("nedre_kontrolgrænse" %in% names(result))
-  expect_false("øvre_kontrolgrænse" %in% names(result))
+  expect_false("nedre_kontrolgraense" %in% names(result))
+  expect_false("oevre_kontrolgraense" %in% names(result))
   # Men centerlinje skal stadig være der
   expect_true("centerlinje" %in% names(result))
 })
@@ -252,7 +252,7 @@ test_that("format_qic_summary håndterer NA i Anhøj-stats", {
   result <- format_qic_summary(qic_data, y_axis_unit = "count")
 
   # safe_max af alle NAs → NA_real_, som as.integer → NA_integer_
-  expect_true(is.na(result$længste_løb))
+  expect_true(is.na(result$laengste_loeb))
   expect_true(is.na(result$antal_kryds))
 })
 


### PR DESCRIPTION
## Summary

- Renames all UTF-8 Danish column names in `result$summary` to ASCII transliterations
- A user following the documented ASCII names would silently get NULL — runtime now matches docs
- `utils_spc_stats.R` (consumer) updated in lockstep with `utils_qic_summary.R` (creator)

## Renamed columns

| Old (UTF-8, broken) | New (ASCII, matches docs) |
|---|---|
| `laengste_loeb` (with UTF-8 ae/oe) | `laengste_loeb` |
| `laengste_loeb_max` (with UTF-8 ae/oe) | `laengste_loeb_max` |
| `nedre_kontrolgraense` (with UTF-8 ae) | `nedre_kontrolgraense` |
| `nedre_kontrolgraense_min/max` | `nedre_kontrolgraense_min/max` |
| `nedre_kontrolgraense_95` | `nedre_kontrolgraense_95` |
| `oevre_kontrolgraense` (with UTF-8 oe/ae) | `oevre_kontrolgraense` |
| `oevre_kontrolgraense_min/max` | `oevre_kontrolgraense_min/max` |
| `oevre_kontrolgraense_95` | `oevre_kontrolgraense_95` |
| `kontrolgraenser_konstante` (with UTF-8 ae) | `kontrolgraenser_konstante` |

## Breaking change

This is a breaking change. Downstream consumers using `result$summary$laengste_loeb` (UTF-8 column) will need to update to `result$summary$laengste_loeb` (ASCII). biSPCharts update tracked separately.

## Test plan

- [x] ASCII compliance test (`test-source-ascii.R`) passes
- [x] Full pre-push suite: 5698 pass, 0 fail, 70 skip
- [ ] Verify `result$summary$laengste_loeb` works on a sample run