### PR TITLE
refactor(formatting): merge formatting kernels — closes #426

### DIFF
--- a/R/spc_analysis.R
+++ b/R/spc_analysis.R
@@ -1163,7 +1163,8 @@ build_fallback_analysis <- function(context,
   # men bor kun bruges i target-/goal-specifikke varianter for at give
   # meningsfuld tekst.
   level_keys <- .compute_level_keys(centerline, target_value, flags$has_target,
-    y_axis_unit = context$y_axis_unit)
+    y_axis_unit = context$y_axis_unit
+  )
   level_direction <- if (!is.null(level_keys)) {
     i18n_lookup(paste0("labels.level_direction.", level_keys$direction_key), language)
   } else {
@@ -1291,33 +1292,31 @@ build_fallback_analysis <- function(context,
 
 
 # Formater maalvaerdi til visning
-# y_axis_unit bruges til at afgoere om vaerdien skal vises som procent.
-# language styrer decimal-separator: "da" -> "," (default), "en" -> "."
-# (cycle 01 finding E4: previously hardcoded "," produced danish decimals
-# in english analysis-text, eg. "1,5" instead of "1.5").
+# Delegates to format_y_value() for chart-label/analysis-text consistency
+# (fixes #426: two formatting kernels produced different output for same value).
 #
-# target: optional 0-1-skala maal-vaerdi. Naar sat OG x er i [0,1] med
-# y_axis_unit="percent", delegeres formatering til format_percent_contextual()
-# saa praecision matcher chart-labels: en decimal vises naar |x - target|
-# <= 2 procentpoint, ellers afrundes til hele procent. Sikrer at
-# {centerline}/{target}-placeholders i analyse-tekst rendres med samme
-# antal decimaler som CL-label paa selve grafen.
+# NULL guard: returns "" for NULL/NA (callers expect ""; format_y_value returns
+# NA_character_ for NA and errors for NULL y_unit).
+#
+# NULL y_axis_unit fallback: format_y_value requires a non-NULL y_unit.
+# When y_axis_unit is NULL (no unit context), fall back to generic locale-aware
+# formatting so existing callers are not broken.
 format_target_value <- function(x, y_axis_unit = NULL, language = "da",
                                 target = NULL) {
   if (is.null(x) || is.na(x)) {
     return("")
   }
 
-  # Konverter proportion til procent hvis relevant
-  # x i [0, 1] -> proportion, multiplicer med 100. x > 1 -> allerede procent.
-  if (!is.null(y_axis_unit) && y_axis_unit == "percent") {
-    if (x >= 0 && x <= 1) {
-      return(format_percent_contextual(x, target = target, language = language))
-    } else if (x > 1) {
-      return(paste0(round(x), "%"))
-    }
+  # Delegate to format_y_value when unit is known (canonical formatting path).
+  # NULL y_axis_unit: format_y_value errors on NULL y_unit, use generic fallback.
+  if (!is.null(y_axis_unit)) {
+    return(format_y_value(x,
+      y_unit = y_axis_unit, target = target,
+      language = language
+    ))
   }
 
+  # Generic fallback (NULL y_axis_unit): locale-aware, no unit-specific logic.
   if (is_effective_integer(x)) {
     as.character(as.integer(x))
   } else {

--- a/tests/testthat/_snaps/spc_golden_corpus.md
+++ b/tests/testthat/_snaps/spc_golden_corpus.md
@@ -38,28 +38,28 @@
     Code
       cat(text)
     Output
-      Processen varierer naturligt og niveauet vurderes derfor som stabilt og forudsigeligt, uden tegn på systematiske ændringer. Det nuværende niveau på 50,29 opfylder udviklingsmålet (≤ 100). Fortsæt den nuværende praksis, men hold løbende øje med data, så niveauet kan fastholdes og evt. forandring fanges tidligt.
+      Processen varierer naturligt og niveauet vurderes derfor som stabilt og forudsigeligt, uden tegn på systematiske ændringer. Det nuværende niveau på 50,3 opfylder udviklingsmålet (≤ 100). Fortsæt den nuværende praksis, men hold løbende øje med data, så niveauet kan fastholdes og evt. forandring fanges tidligt.
 
 # golden: stable + target='>= 40' (direction-aware higher)
 
     Code
       cat(text)
     Output
-      Processen varierer naturligt og niveauet vurderes derfor som stabilt og forudsigeligt, uden tegn på systematiske ændringer. Det nuværende niveau på 50,29 opfylder udviklingsmålet (≥ 40). Fortsæt den nuværende praksis, men hold løbende øje med data, så niveauet kan fastholdes og evt. forandring fanges tidligt.
+      Processen varierer naturligt og niveauet vurderes derfor som stabilt og forudsigeligt, uden tegn på systematiske ændringer. Det nuværende niveau på 50,3 opfylder udviklingsmålet (≥ 40). Fortsæt den nuværende praksis, men hold løbende øje med data, så niveauet kan fastholdes og evt. forandring fanges tidligt.
 
 # golden: phased data + higher_better direction (full modifier-cascade)
 
     Code
       cat(text)
     Output
-      Processen varierer naturligt og niveauet vurderes derfor som stabilt og forudsigeligt, uden tegn på systematiske ændringer. Sammenlignet med tidligere fase er niveauet flyttet fra 49,75 til 54,87, en betydelig niveauforandring på ~10% i den ønskede retning. Overvej, om et udviklingsmål kan fastsættes, så det aktuelle niveau kan vurderes, og behovet for forbedring kan prioriteres.
+      Processen varierer naturligt og niveauet vurderes derfor som stabilt og forudsigeligt, uden tegn på systematiske ændringer. Sammenlignet med tidligere fase er niveauet flyttet fra 49,7 til 54,9, en betydelig niveauforandring på ~10% i den ønskede retning. Overvej, om et udviklingsmål kan fastsættes, så det aktuelle niveau kan vurderes, og behovet for forbedring kan prioriteres.
 
 # golden: phased data + lower_better direction (unfavorable cascade)
 
     Code
       cat(text)
     Output
-      Processen varierer naturligt og niveauet vurderes derfor som stabilt og forudsigeligt, uden tegn på systematiske ændringer. Sammenlignet med tidligere fase er niveauet flyttet fra 49,75 til 54,87, en betydelig niveauforandring på ~10% væk fra den ønskede retning. Overvej, om et udviklingsmål kan fastsættes, så det aktuelle niveau kan vurderes, og behovet for forbedring kan prioriteres.
+      Processen varierer naturligt og niveauet vurderes derfor som stabilt og forudsigeligt, uden tegn på systematiske ændringer. Sammenlignet med tidligere fase er niveauet flyttet fra 49,7 til 54,9, en betydelig niveauforandring på ~10% væk fra den ønskede retning. Overvej, om et udviklingsmål kan fastsættes, så det aktuelle niveau kan vurderes, og behovet for forbedring kan prioriteres.
 
 # golden: cl=specified (cl_user_supplied caveat)
 

--- a/tests/testthat/test-i18n_bilingual_parity.R
+++ b/tests/testthat/test-i18n_bilingual_parity.R
@@ -156,14 +156,16 @@ test_that("Phase 99.3: placeholders matches mellem da og en per nøgle", {
 # ==========================================================================
 
 test_that("Phase 99.3: format_target_value bruger korrekt decimal-separator", {
-  # da: komma
+  # da: komma. format_target_value now delegates to format_y_value (fix #426).
+  # format_count rounds non-integer values >= 1 to 1 decimal (matching chart
+  # labels), so 50.59 -> "50,6" (was "50,59" under old 2-decimal kernel).
   expect_equal(
     BFHcharts:::format_target_value(1.5, y_axis_unit = "count", language = "da"),
     "1,5"
   )
   expect_equal(
     BFHcharts:::format_target_value(50.59, y_axis_unit = "count", language = "da"),
-    "50,59"
+    "50,6"
   )
 
   # en: punktum
@@ -173,7 +175,7 @@ test_that("Phase 99.3: format_target_value bruger korrekt decimal-separator", {
   )
   expect_equal(
     BFHcharts:::format_target_value(50.59, y_axis_unit = "count", language = "en"),
-    "50.59"
+    "50.6"
   )
 })
 
@@ -188,6 +190,59 @@ test_that("Phase 99.3: format_target_value percent rendres ens (% er sprog-neutr
     BFHcharts:::format_target_value(0.9, y_axis_unit = "percent", language = "en"),
     "90%"
   )
+})
+
+
+# ==========================================================================
+# Phase 99.3.3b: format_target_value paritet med format_y_value (fix #426)
+# ==========================================================================
+
+test_that("format_target_value matches format_y_value for count unit", {
+  # After delegation, analysis-text and chart-labels produce identical output.
+  expect_equal(
+    BFHcharts:::format_target_value(1500, "count", "da"),
+    BFHcharts:::format_y_value(1500, y_unit = "count", language = "da")
+  )
+  expect_equal(
+    BFHcharts:::format_target_value(1500, "count", "en"),
+    BFHcharts:::format_y_value(1500, y_unit = "count", language = "en")
+  )
+})
+
+test_that("format_target_value matches format_y_value for percent unit", {
+  expect_equal(
+    BFHcharts:::format_target_value(0.85, "percent", "da"),
+    BFHcharts:::format_y_value(0.85, y_unit = "percent", language = "da")
+  )
+  expect_equal(
+    BFHcharts:::format_target_value(0.85, "percent", "en"),
+    BFHcharts:::format_y_value(0.85, y_unit = "percent", language = "en")
+  )
+})
+
+test_that("format_target_value matches format_y_value for rate unit", {
+  expect_equal(
+    BFHcharts:::format_target_value(2.5, "rate", "da"),
+    BFHcharts:::format_y_value(2.5, y_unit = "rate", language = "da")
+  )
+})
+
+test_that("format_target_value matches format_y_value for time unit", {
+  # Time: format_time_composite produces composite format (e.g. "1t 30m").
+  # Both kernels now agree; old format_target_value produced plain numbers.
+  expect_equal(
+    BFHcharts:::format_target_value(90, "time", "da"),
+    BFHcharts:::format_y_value(90, y_unit = "time", language = "da")
+  )
+})
+
+test_that("format_target_value NULL/NA guard still returns empty string", {
+  expect_equal(BFHcharts:::format_target_value(NULL, "count"), "")
+  expect_equal(BFHcharts:::format_target_value(NA, "count"), "")
+  # NULL y_axis_unit: generic fallback path (not delegated to format_y_value)
+  expect_equal(BFHcharts:::format_target_value(5, NULL), "5")
+  expect_equal(BFHcharts:::format_target_value(1.5, NULL, "da"), "1,5")
+  expect_equal(BFHcharts:::format_target_value(1.5, NULL, "en"), "1.5")
 })
 
 


### PR DESCRIPTION
## Summary

- `format_target_value()` in `R/spc_analysis.R` now delegates to `format_y_value()` for all non-NULL `y_axis_unit` values, eliminating the divergence between analysis-text placeholders (`{centerline}`, `{target}`) and chart labels for the same CL value.
- NULL/NA guard preserved: returns `""` (callers expect empty string; `format_y_value` returns `NA_character_` for NA and errors for NULL unit).
- NULL `y_axis_unit` falls through to the existing generic locale-aware fallback (unchanged behavior for that path).

## Intentional behavior changes

- **count/rate non-integer values**: analysis text now rounds to 1 decimal matching chart labels (e.g. `"50,3"` instead of old `"50,29"`; `"54,9"` instead of `"54,87"`). Golden corpus snapshots updated.
- **time unit**: now produces composite format (`"1t 30m"`) matching chart labels, instead of plain numbers.

## Test plan

- [x] `devtools::test(filter = "summary-precision|label_format|i18n")` — 272 tests pass
- [x] `devtools::test()` — 5709 tests pass, 0 failures
- [x] ASCII source compliance test passes
- [x] Golden corpus snapshots accepted (4 updated: centerline display values now 1-decimal)
- [x] New parity tests added in `test-i18n_bilingual_parity.R` asserting `format_target_value == format_y_value` for count, percent, rate, time units
- [ ] Manual smoke-test of analysis text with count/rate charts (non-integer CL values)

## Merge order note

**Merge AFTER #415 (legacy pipeline removal)** — both PRs touch `R/spc_analysis.R` and will conflict. This PR should be rebased or merged after #415 is in `develop`.