### PR TITLE
refactor(spc): extract CL/target extraction to shared helpers (closes #425)

### DIFF
--- a/R/fct_add_spc_labels.R
+++ b/R/fct_add_spc_labels.R
@@ -159,30 +159,13 @@ add_spc_labels <- function(
     NULL
   }
 
-  # Ekstraher CL vaerdi fra seneste part ----
-  # INTENTIONEL ASYMMETRI: CL hentes fra seneste part (centerlinjen aendres ved
-  # faseovergange), mens target hentes som foerste non-NA (target er typisk
-  # konstant og sat af brugeren uafhaengigt af faser).
-  cl_value <- NA_real_
-  if (!is.null(qic_data$cl) && any(!is.na(qic_data$cl))) {
-    if ("part" %in% names(qic_data)) {
-      latest_part <- max(qic_data$part, na.rm = TRUE)
-      part_data <- qic_data[qic_data$part == latest_part & !is.na(qic_data$part), ]
-
-      if (nrow(part_data) > 0) {
-        last_row <- part_data[nrow(part_data), ]
-        cl_value <- last_row$cl
-      }
-    } else {
-      cl_value <- tail(stats::na.omit(qic_data$cl), 1)
-    }
-  }
-
-  # Ekstraher Target vaerdi ----
-  target_value <- NA_real_
-  if (!is.null(qic_data$target) && any(!is.na(qic_data$target))) {
-    target_value <- qic_data$target[!is.na(qic_data$target)][1]
-  }
+  # Extract CL and target from latest phase via shared helpers ----
+  # INTENTIONAL ASYMMETRY: CL is taken from the last row of the latest phase
+  # (centerline changes at phase transitions), while target is the first non-NA
+  # value (target is typically constant and user-supplied independently of
+  # phases).
+  cl_value <- extract_latest_cl(qic_data)
+  target_value <- extract_first_target(qic_data)
 
   # Valider at vi har mindst en vaerdi ----
   if (is.na(cl_value) && is.na(target_value)) {

--- a/R/plot_core.R
+++ b/R/plot_core.R
@@ -259,13 +259,7 @@ bfh_spc_plot <- function(qic_data,
 
   # Collect line positions for note label placement ----
   line_positions <- c(
-    cl = if (!is.null(qic_data$cl)) {
-      latest_part <- max(qic_data$part, na.rm = TRUE)
-      part_cl <- qic_data$cl[qic_data$part == latest_part & !is.na(qic_data$part)]
-      if (length(part_cl) > 0 && !all(is.na(part_cl))) part_cl[!is.na(part_cl)][1] else NA_real_
-    } else {
-      NA_real_
-    },
+    cl = extract_latest_cl(qic_data),
     ucl = if (!is.null(qic_data$ucl) && any(!is.na(qic_data$ucl))) {
       stats::median(qic_data$ucl, na.rm = TRUE)
     } else {
@@ -276,11 +270,7 @@ bfh_spc_plot <- function(qic_data,
     } else {
       NA_real_
     },
-    target = if (!is.null(qic_data$target) && any(!is.na(qic_data$target))) {
-      qic_data$target[!is.na(qic_data$target)][1]
-    } else {
-      NA_real_
-    }
+    target = extract_first_target(qic_data)
   )
 
   # Add plot enhancements (extended lines, comments) ----

--- a/R/plot_enhancements.R
+++ b/R/plot_enhancements.R
@@ -70,12 +70,13 @@ add_plot_enhancements <- function(plot,
 
   # Centerline extension (only for latest part)
   if (!is.null(qic_data$cl) && any(!is.na(qic_data$cl))) {
-    latest_part <- max(qic_data$part, na.rm = TRUE)
-    part_data <- qic_data[qic_data$part == latest_part & !is.na(qic_data$part), ]
+    last_row <- extract_latest_phase_row(qic_data)
 
-    if (nrow(part_data) > 0) {
-      last_row <- part_data[nrow(part_data), ]
-      last_part_x <- max(part_data$x, na.rm = TRUE)
+    if (!is.null(last_row)) {
+      # max(x) across the whole latest phase; last_row$x may differ if the
+      # last observation has NA x, so we recompute from the full phase.
+      phase_data <- filter_qic_to_last_phase(qic_data)
+      last_part_x <- max(phase_data$x, na.rm = TRUE)
       if (inherits(last_part_x, "Date")) {
         last_part_x <- as.POSIXct(last_part_x)
       }
@@ -100,15 +101,16 @@ add_plot_enhancements <- function(plot,
   }
 
   # Target extension (only if not suppressed)
-  if (!suppress_targetline && !is.null(qic_data$target) && any(!is.na(qic_data$target))) {
-    target_value <- qic_data$target[!is.na(qic_data$target)][1]
-
-    extended_lines_list$target <- tibble::tibble(
-      x = c(last_x, extended_x),
-      y = c(target_value, target_value),
-      type = "target",
-      linetype = "42"
-    )
+  if (!suppress_targetline) {
+    target_value <- extract_first_target(qic_data)
+    if (!is.na(target_value)) {
+      extended_lines_list$target <- tibble::tibble(
+        x = c(last_x, extended_x),
+        y = c(target_value, target_value),
+        type = "target",
+        linetype = "42"
+      )
+    }
   }
 
   # Single bind operation - much more efficient

--- a/R/utils_spc_stats.R
+++ b/R/utils_spc_stats.R
@@ -214,6 +214,43 @@ filter_qic_to_last_phase <- function(qic_data) {
   qic_data[qic_data$part == max(qic_data$part, na.rm = TRUE), , drop = FALSE]
 }
 
+# Returns the last row of the latest phase as a 1-row data frame, or NULL if
+# qic_data is NULL/empty.  Composes filter_qic_to_last_phase() so the
+# max(part) logic stays in one place.
+extract_latest_phase_row <- function(qic_data) {
+  phase <- filter_qic_to_last_phase(qic_data)
+  if (is.null(phase) || nrow(phase) == 0L) {
+    return(NULL)
+  }
+  phase[nrow(phase), , drop = FALSE]
+}
+
+# Returns the scalar CL value from the last row of the latest phase.
+# Falls back to the last non-NA CL across all rows when the part column is
+# absent (matches the defensive fallback in fct_add_spc_labels.R).
+# Returns NA_real_ if no CL is available.
+extract_latest_cl <- function(qic_data) {
+  if (is.null(qic_data$cl) || !any(!is.na(qic_data$cl))) {
+    return(NA_real_)
+  }
+  if ("part" %in% names(qic_data)) {
+    row <- extract_latest_phase_row(qic_data)
+    if (!is.null(row)) {
+      return(row$cl)
+    }
+  }
+  # No part column: fall back to last non-NA CL value.
+  tail(stats::na.omit(qic_data$cl), 1)
+}
+
+# Returns the first non-NA target value, or NA_real_ if none.
+extract_first_target <- function(qic_data) {
+  if (is.null(qic_data$target) || !any(!is.na(qic_data$target))) {
+    return(NA_real_)
+  }
+  qic_data$target[!is.na(qic_data$target)][1]
+}
+
 empty_spc_stats <- function() {
   list(
     runs_expected = NULL,


### PR DESCRIPTION
## Summary

- Adds `extract_latest_cl()`, `extract_latest_phase_row()`, and `extract_first_target()` to `R/utils_spc_stats.R`, eliminating triplication of the latest-phase CL/target lookup pattern
- Replaces inline `max(part)`/`last_row$cl` blocks in `fct_add_spc_labels.R`, `plot_enhancements.R`, and `plot_core.R` with calls to the shared helpers
- All three helpers compose `filter_qic_to_last_phase()` so the `max(part)` logic remains in a single place
- `extract_latest_cl()` preserves the no-part fallback (`tail(na.omit(cl), 1)`) from `fct_add_spc_labels.R`
- `export_details.R:145` intentionally left untouched: it uses the last row of the whole series (not the latest phase) for the "seneste" display value

## Test plan

- [x] `devtools::test(filter = "spc_labels|plot|integration")` passes
- [x] Full pre-push test suite passes (5560+ tests, 0 failures)
- [x] ASCII compliance (`source-ascii` test passes)