### PR TITLE
fix(validation): migration hint for deprecated i-prime chart type (closes #430)

### DIFF
--- a/R/utils_bfh_qic_helpers.R
+++ b/R/utils_bfh_qic_helpers.R
@@ -605,6 +605,16 @@ validate_bfh_qic_inputs <- function(data,
     }
   }
 
+  # Migration hint: "i'" was the old name for the individuals chart; renamed
+  # to "ip" in BFHcharts 0.25.0 for consistency with the rest of the API.
+  if (identical(chart_type, "i'")) {
+    stop(
+      "chart_type \"i'\" was renamed to \"ip\" in BFHcharts 0.25.0",
+      " -- use chart_type = \"ip\"",
+      call. = FALSE
+    )
+  }
+
   if (!chart_type %in% CHART_TYPES_EN) {
     stop(sprintf(
       "chart_type must be one of: %s",

--- a/tests/testthat/test-bfh_qic_helpers.R
+++ b/tests/testthat/test-bfh_qic_helpers.R
@@ -213,6 +213,14 @@ test_that("validate_bfh_qic_inputs fejler ved ugyldig chart_type", {
   expect_error(call_validate(chart_type = "xyz"), "chart_type must be one of")
 })
 
+test_that("validate_bfh_qic_inputs gives migration hint for deprecated i-prime chart_type", {
+  expect_error(
+    call_validate(chart_type = "i'"),
+    regexp = "renamed to \"ip\" in BFHcharts 0\\.25\\.0",
+    fixed = FALSE
+  )
+})
+
 test_that("validate_bfh_qic_inputs fejler ved ugyldig y_axis_unit", {
   expect_error(call_validate(y_axis_unit = "liters"), "y_axis_unit must be one of")
 })


### PR DESCRIPTION
## Summary

- Adds a targeted `stop()` before the generic `chart_type` validator in `validate_bfh_qic_inputs()` so callers still using `chart_type = "i'"` (the old name from before 0.25.0) receive an actionable message instead of the generic "must be one of" error
- Error message: `chart_type "i'" was renamed to "ip" in BFHcharts 0.25.0 -- use chart_type = "ip"`
- Adds one unit test verifying the migration hint error is raised with the correct message

## Test plan

- [x] `test-bfh_qic_helpers.R` — new test `validate_bfh_qic_inputs gives migration hint for deprecated i-prime chart_type` passes
- [x] Full test suite passed in pre-push hook (no failures, only expected skips/warnings)
- [x] ASCII-clean: `R/utils_bfh_qic_helpers.R` contains only ASCII bytes (verified)