### PR TITLE
docs: fix test README -- BFHCHARTS_TEST_RENDER not set in R-CMD-check (closes #434)

### DIFF
--- a/tests/testthat/README.md
+++ b/tests/testthat/README.md
@@ -34,14 +34,21 @@ testthat::test_file("tests/testthat/test-spc_analysis.R")
 
 ### CI (GitHub Actions)
 
-CI kører automatisk med begge miljøvariabler sat til `"true"` og installerer Quarto + åbne fallback-fonts (DejaVu, Liberation, Noto).
+Workflows og hvilke miljøvariabler de sætter:
 
-Workflows:
-- `.github/workflows/R-CMD-check.yaml` — R CMD check + testthat (PR-blocking)
-- `.github/workflows/pdf-smoke.yaml` — PDF smoke render via Quarto/Typst (PR-blocking)
-- `.github/workflows/render-tests.yaml` — Ugentlig live render-test suite (cron)
-- `.github/workflows/test-coverage.yml` — covr::codecov() rapportering
-- `.github/workflows/lint.yaml` — lintr (advisory)
+| Workflow | `BFHCHARTS_TEST_FULL` | `BFHCHARTS_TEST_RENDER` | Formål |
+|----------|-----------------------|-------------------------|--------|
+| `R-CMD-check.yaml` | `"true"` | **ikke sat** | R CMD check + testthat (PR-blocking) |
+| `pdf-smoke.yaml` | `"true"` | `"true"` | PDF smoke render via Quarto/Typst (PR-blocking) |
+| `render-tests.yaml` | `"true"` | `"true"` | Ugentlig live render-test suite (cron) |
+| `test-coverage.yml` | ikke sat | ikke sat | covr::codecov() rapportering |
+| `lint.yaml` | ikke sat | ikke sat | lintr (advisory) |
+
+`BFHCHARTS_TEST_RENDER` er bevidst **ikke sat** i `R-CMD-check.yaml`: production-template render
+kræver Mari-fonts (proprietære, kun tilgængelige via BFHchartsAssets). Render-dækning håndteres
+af `pdf-smoke.yaml` med åbne fallback-fonts (DejaVu/Liberation).
+
+`pdf-smoke.yaml` installerer Quarto + åbne fallback-fonts (DejaVu, Liberation, Noto).
 
 #### CI Font-fallback strategi
 
@@ -78,7 +85,7 @@ CI anvender to komplementære strategier:
 | `BFHCHARTS_TEST_FULL` | ikke sat | Kører integration-tests ud over unit-tests |
 | `BFHCHARTS_TEST_RENDER` | ikke sat | Kører live render-tests (Quarto, PDF, PNG) |
 
-**Status (2026-04-24):** Alle render/PDF-tests er migreret til de kanoniske helpers (`skip_if_not_render_test()` + `skip_if_no_quarto()`). Nye helpers `skip_if_no_quarto()` og `skip_if_no_mari_font()` tilføjet til `helper-skips.R`. Miljøvariablerne er sat i CI.
+**Status (2026-04-24):** Alle render/PDF-tests er migreret til de kanoniske helpers (`skip_if_not_render_test()` + `skip_if_no_quarto()`). Nye helpers `skip_if_no_quarto()` og `skip_if_no_mari_font()` tilføjet til `helper-skips.R`. Se CI-tabellen ovenfor for hvilke workflows der sætter hvilke variabler.
 
 ---
 
@@ -216,4 +223,4 @@ Genuine warnings propageres stadig — kun den specifikke PostScript-lookup-adva
 - `openspec/changes/strengthen-test-infrastructure/design.md` — tekniske beslutninger (D1-D10)
 - `openspec/changes/strengthen-test-infrastructure/tasks.md` — opgaver og status
 
-**Sidst opdateret:** 2026-04-27
+**Sidst opdateret:** 2026-06-12


### PR DESCRIPTION
## Summary
- Fixes incorrect claim that `BFHCHARTS_TEST_RENDER=true` is set on all CI runs
- Replaces prose list with accurate table: which workflow sets which env vars
- Documents why `BFHCHARTS_TEST_RENDER` is intentionally absent from R-CMD-check

## Test plan
- [ ] Docs-only change — no code changed