### PR TITLE
refactor(labels): extract pref_pos computation from add_spc_labels (closes #427)

### DIFF
--- a/R/fct_add_spc_labels.R
+++ b/R/fct_add_spc_labels.R
@@ -28,6 +28,83 @@ compute_label_size_for_viewport <- function(viewport_width_inches,
 }
 
 
+#' Compute preferred label positions based on boundary proximity
+#'
+#' Determines whether each label should prefer to appear "under" or "over"
+#' its reference line. When both lines are near the same edge the labels
+#' are spread (one under, one over). When only one line is near an edge that
+#' line is pushed toward the edge (into the expansion zone) while the other
+#' is pushed the opposite way.
+#'
+#' @param yA Numeric data-coordinate of the first reference line (A = CL).
+#'   May be NA, in which case defaults are returned without NPC conversion.
+#' @param yB Numeric data-coordinate of the second reference line (B = target).
+#'   May be NA, in which case defaults are returned without NPC conversion.
+#' @param y_to_npc Function that converts a data-coordinate to NPC [0, 1].
+#'   Typically \code{shared_mapper$y_to_npc}.
+#' @param boundary_threshold Numeric fraction from 0 or 1 at which a line is
+#'   considered "near" an edge. Default 0.30.
+#' @return Character vector of length 2: \code{c(pref_A, pref_B)}, each
+#'   element either \code{"under"} or \code{"over"}.
+#'
+#' @keywords internal
+#' @noRd
+.compute_pref_pos <- function(yA, yB, y_to_npc, boundary_threshold = 0.30) {
+  pref_A <- "under"
+  pref_B <- "under"
+
+  if (!is.na(yA) && !is.na(yB)) {
+    npc_A <- y_to_npc(yA)
+    npc_B <- y_to_npc(yB)
+
+    if (!is.null(npc_A) && !is.na(npc_A) &&
+      !is.null(npc_B) && !is.na(npc_B)) {
+      both_near_bottom <- npc_A < boundary_threshold && npc_B < boundary_threshold
+      both_near_top <- npc_A > (1 - boundary_threshold) && npc_B > (1 - boundary_threshold)
+
+      if (both_near_bottom) {
+        # Spread: lower label under its line, upper label over its line
+        if (npc_A <= npc_B) {
+          pref_A <- "under"
+          pref_B <- "over"
+        } else {
+          pref_A <- "over"
+          pref_B <- "under"
+        }
+      } else if (both_near_top) {
+        # Spread: upper label over its line, lower label under its line
+        if (npc_A >= npc_B) {
+          pref_A <- "over"
+          pref_B <- "under"
+        } else {
+          pref_A <- "under"
+          pref_B <- "over"
+        }
+      } else {
+        # One line near edge: push it toward the edge (into expansion zone),
+        # push the other line the opposite way to maximise spread.
+        if (npc_A < boundary_threshold) {
+          pref_A <- "under" # CL near bottom -> under (into expansion)
+          pref_B <- "over" # Target -> over (away from CL)
+        } else if (npc_B < boundary_threshold) {
+          pref_B <- "under"
+          pref_A <- "over"
+        }
+        if (npc_A > (1 - boundary_threshold)) {
+          pref_A <- "over" # CL near top -> over (into expansion)
+          pref_B <- "under" # Target -> under (away from CL)
+        } else if (npc_B > (1 - boundary_threshold)) {
+          pref_B <- "over"
+          pref_A <- "under"
+        }
+      }
+    }
+  }
+
+  c(pref_A, pref_B)
+}
+
+
 #' Add SPC labels to plot using advanced placement system
 #'
 #' Wrapper funktion der tilfoejer CL og Target labels til SPC plot
@@ -288,66 +365,12 @@ add_spc_labels <- function(
   }
 
   # Placer labels med advanced placement system ----
-
-  # Boundary-aware pref_pos: Naar begge linjer er naer bund/top af plottet,
-  # spred labels ved at placere den nederste "under" og den oeverste "over".
-  # Naar kun en linje er naer kanten, foretruk den side med mest plads.
-  boundary_threshold <- 0.30
-  pref_A <- "under"
-  pref_B <- "under"
-
-  if (!is.na(yA) && !is.na(yB)) {
-    npc_A <- shared_mapper$y_to_npc(yA)
-    npc_B <- shared_mapper$y_to_npc(yB)
-
-    if (!is.null(npc_A) && !is.na(npc_A) &&
-      !is.null(npc_B) && !is.na(npc_B)) {
-      both_near_bottom <- npc_A < boundary_threshold && npc_B < boundary_threshold
-      both_near_top <- npc_A > (1 - boundary_threshold) && npc_B > (1 - boundary_threshold)
-
-      if (both_near_bottom) {
-        # Spred: nederste label under sin linje, oeverste over sin linje
-        if (npc_A <= npc_B) {
-          pref_A <- "under"
-          pref_B <- "over"
-        } else {
-          pref_A <- "over"
-          pref_B <- "under"
-        }
-      } else if (both_near_top) {
-        # Spred: oeverste label over sin linje, nederste under sin linje
-        if (npc_A >= npc_B) {
-          pref_A <- "over"
-          pref_B <- "under"
-        } else {
-          pref_A <- "under"
-          pref_B <- "over"
-        }
-      } else {
-        # En linje naer kanten: send den mod kanten (ind i expansion-zonen),
-        # og den anden linje den modsatte vej - det spreder labels maksimalt.
-        if (npc_A < boundary_threshold) {
-          pref_A <- "under" # CL n\u00e6r bund -> under (ind i expansion)
-          pref_B <- "over" # Target -> over (v\u00e6k fra CL)
-        } else if (npc_B < boundary_threshold) {
-          pref_B <- "under"
-          pref_A <- "over"
-        }
-        if (npc_A > (1 - boundary_threshold)) {
-          pref_A <- "over" # CL n\u00e6r top -> over (ind i expansion)
-          pref_B <- "under" # Target -> under (v\u00e6k fra CL)
-        } else if (npc_B > (1 - boundary_threshold)) {
-          pref_B <- "over"
-          pref_A <- "under"
-        }
-      }
-    }
-  }
+  pref_pos <- .compute_pref_pos(yA, yB, shared_mapper$y_to_npc)
 
   label_params <- list(
     pad_top = 0.01,
     pad_bot = 0.01,
-    pref_pos = c(pref_A, pref_B),
+    pref_pos = pref_pos,
     priority = "A"
   )
   if (has_arrow) label_params$gap_labels <- 0

--- a/tests/testthat/test-label-placement.R
+++ b/tests/testthat/test-label-placement.R
@@ -1,0 +1,121 @@
+# test-label-placement.R
+# Unit tests for .compute_pref_pos()
+# Refs: #427
+
+# Use identity as y_to_npc so NPC == y, making branches deterministic.
+identity_npc <- function(y) y
+
+# ==============================================================================
+# .compute_pref_pos: NA inputs
+# ==============================================================================
+
+test_that(".compute_pref_pos returns defaults when yA is NA", {
+  result <- .compute_pref_pos(NA_real_, 0.5, identity_npc)
+  expect_equal(result, c("under", "under"))
+})
+
+test_that(".compute_pref_pos returns defaults when yB is NA", {
+  result <- .compute_pref_pos(0.5, NA_real_, identity_npc)
+  expect_equal(result, c("under", "under"))
+})
+
+test_that(".compute_pref_pos returns defaults when both are NA", {
+  result <- .compute_pref_pos(NA_real_, NA_real_, identity_npc)
+  expect_equal(result, c("under", "under"))
+})
+
+# ==============================================================================
+# .compute_pref_pos: both lines mid-range (no boundary trigger)
+# ==============================================================================
+
+test_that(".compute_pref_pos defaults to under/under when both mid-range", {
+  result <- .compute_pref_pos(0.5, 0.55, identity_npc)
+  expect_equal(result, c("under", "under"))
+})
+
+# ==============================================================================
+# .compute_pref_pos: both lines near bottom
+# ==============================================================================
+
+test_that(".compute_pref_pos spreads labels when both near bottom, A below B", {
+  # npc_A=0.1 <= npc_B=0.2 -> pref_A="under", pref_B="over"
+  result <- .compute_pref_pos(0.1, 0.2, identity_npc)
+  expect_equal(result, c("under", "over"))
+})
+
+test_that(".compute_pref_pos spreads labels when both near bottom, A above B", {
+  # npc_A=0.2 > npc_B=0.1 -> pref_A="over", pref_B="under"
+  result <- .compute_pref_pos(0.2, 0.1, identity_npc)
+  expect_equal(result, c("over", "under"))
+})
+
+# ==============================================================================
+# .compute_pref_pos: both lines near top
+# ==============================================================================
+
+test_that(".compute_pref_pos spreads labels when both near top, A above B", {
+  # npc_A=0.9 >= npc_B=0.8 -> pref_A="over", pref_B="under"
+  result <- .compute_pref_pos(0.9, 0.8, identity_npc)
+  expect_equal(result, c("over", "under"))
+})
+
+test_that(".compute_pref_pos spreads labels when both near top, A below B", {
+  # npc_A=0.8 < npc_B=0.9 -> pref_A="under", pref_B="over"
+  result <- .compute_pref_pos(0.8, 0.9, identity_npc)
+  expect_equal(result, c("under", "over"))
+})
+
+# ==============================================================================
+# .compute_pref_pos: one line near bottom, one mid-range
+# ==============================================================================
+
+test_that(".compute_pref_pos: A near bottom, B mid-range -> A under, B over", {
+  # npc_A=0.1 < 0.30 triggers: pref_A="under", pref_B="over"
+  result <- .compute_pref_pos(0.1, 0.5, identity_npc)
+  expect_equal(result, c("under", "over"))
+})
+
+test_that(".compute_pref_pos: B near bottom, A mid-range -> B under, A over", {
+  # npc_B=0.1 < 0.30 triggers: pref_B="under", pref_A="over"
+  result <- .compute_pref_pos(0.5, 0.1, identity_npc)
+  expect_equal(result, c("over", "under"))
+})
+
+# ==============================================================================
+# .compute_pref_pos: one line near top, one mid-range
+# ==============================================================================
+
+test_that(".compute_pref_pos: A near top, B mid-range -> A over, B under", {
+  # npc_A=0.9 > 0.70 triggers: pref_A="over", pref_B="under"
+  result <- .compute_pref_pos(0.9, 0.5, identity_npc)
+  expect_equal(result, c("over", "under"))
+})
+
+test_that(".compute_pref_pos: B near top, A mid-range -> B over, A under", {
+  # npc_B=0.9 > 0.70 triggers: pref_B="over", pref_A="under"
+  result <- .compute_pref_pos(0.5, 0.9, identity_npc)
+  expect_equal(result, c("under", "over"))
+})
+
+# ==============================================================================
+# .compute_pref_pos: custom boundary_threshold
+# ==============================================================================
+
+test_that(".compute_pref_pos respects custom boundary_threshold", {
+  # With threshold=0.60: npc_A=0.5 < 0.60 -> treated as near bottom
+  # B at 0.55 also < 0.60 -> both_near_bottom, A<=B -> pref_A="under", pref_B="over"
+  result <- .compute_pref_pos(0.5, 0.55, identity_npc, boundary_threshold = 0.60)
+  expect_equal(result, c("under", "over"))
+})
+
+# ==============================================================================
+# .compute_pref_pos: non-identity mapping (scale test)
+# ==============================================================================
+
+test_that(".compute_pref_pos works with a non-identity NPC mapper", {
+  # Mapper that scales [0, 100] data to [0, 1] NPC
+  npc_100 <- function(y) y / 100
+  # yA=5, yB=15 -> npc_A=0.05, npc_B=0.15, both < 0.30, A<=B
+  result <- .compute_pref_pos(5, 15, npc_100)
+  expect_equal(result, c("under", "over"))
+})


### PR DESCRIPTION
## Summary

- Extracts the boundary-aware preferred-label-position logic (lines 292-345 in the `develop` version of `fct_add_spc_labels.R`) into a focused internal helper `.compute_pref_pos(yA, yB, y_to_npc, boundary_threshold = 0.30)`.
- `add_spc_labels()` delegates to the helper; all behaviour is identical — the two-sequential-`if` structure in the else branch is preserved verbatim.
- Note on signature: the issue's illustrative `(data, chart_type, ...)` signature does not match the real dependencies. The actual inputs are the two data-coordinates (`yA`, `yB`) and the NPC mapper function. The helper uses those directly, which makes it testable without constructing ggplot objects or qic data.
- 14 direct unit tests added in `tests/testthat/test-label-placement.R` covering: NA short-circuit, mid-range defaults, both-near-bottom (A≤B and A>B), both-near-top (A≥B and A<B), one-near-bottom and one-near-top single-trigger cases, custom `boundary_threshold`, and a non-identity NPC mapper.
- All 25 existing `test-fct_add_spc_labels.R` tests continue to pass. Full pre-push test suite passed (mode=full, ~288s).

## Test plan

- [x] `.compute_pref_pos()` unit tests cover all branch paths (14 tests)
- [x] Existing `add_spc_labels()` integration tests pass unchanged (25 tests)
- [x] ASCII source compliance test passes
- [x] Full pre-push test suite passed