### PR TITLE
feat(api): add snake_case aliases agg_fun/return_data for dot.case params (closes #429)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,7 @@
 # Claude Instructions – BFHcharts
 
 @~/.claude/rules/CLAUDE_BOOTSTRAP_WORKFLOW.md
+@~/.claude/rules-profiles/r/R_STANDARDS.md
 
 ---
 
@@ -431,11 +432,10 @@ warning("Kontrolgrænser er statistisk usikre")  # æ trigger CRAN warning
 ## 📚 Global Standards Reference
 
 **Dette projekt følger:**
-- **R Development:** `~/.claude/rules/R_STANDARDS.md`
-- **Architecture Patterns:** `~/.claude/rules/ARCHITECTURE_PATTERNS.md`
+- **R Development:** `~/.claude/rules-profiles/r/R_STANDARDS.md`
+- **Architecture Patterns:** `~/.claude/rules-profiles/shiny/ARCHITECTURE_PATTERNS.md`
 - **Git Workflow:** `~/.claude/rules/GIT_WORKFLOW.md`
 - **Development Philosophy:** `~/.claude/rules/DEVELOPMENT_PHILOSOPHY.md`
-- **Troubleshooting:** `~/.claude/rules/TROUBLESHOOTING_GUIDE.md`
 
 **Globale agents:** tidyverse-code-reviewer, performance-optimizer, security-reviewer, test-coverage-analyzer, refactoring-advisor, legacy-code-detector
 

--- a/R/bfh_qic.R
+++ b/R/bfh_qic.R
@@ -68,7 +68,9 @@ NULL
 #'   chart simply zooms to the requested window. If `min >= max` (both
 #'   non-`NA`) the limit is ignored with a warning.
 #' @param multiply Numeric multiplier for y-axis values, e.g. 100 to convert proportions to percentages (default: 1)
-#' @param agg.fun Aggregation function for run/I charts with multiple observations per subgroup: "mean" (default), "median", "sum", "sd"
+#' @param agg_fun Aggregation function for run/I charts with multiple observations per subgroup:
+#'   "mean" (default), "median", "sum", "sd". Preferred snake_case alias for the legacy `agg.fun`.
+#' @param agg.fun Deprecated. Use `agg_fun` instead. Kept for backwards compatibility.
 #' @param base_size Base font size in points (default: auto-calculated from width/height if provided, otherwise 14)
 #' @param width Plot width (optional). Supports smart unit detection or explicit units parameter. See Details.
 #' @param height Plot height (optional). Supports smart unit detection or explicit units parameter. See Details.
@@ -79,7 +81,10 @@ NULL
 #' @param xlab X-axis label (default: "" for blank)
 #' @param subtitle Plot subtitle text (default: NULL for no subtitle)
 #' @param caption Plot caption text (default: NULL for no caption)
-#' @param return.data Logical. If TRUE, return the raw qic data frame instead of bfh_qic_result object. If FALSE (default), return bfh_qic_result S3 object. Legacy parameter maintained for backwards compatibility.
+#' @param return_data Logical. If TRUE, return the raw qic data frame instead of bfh_qic_result
+#'   object. If FALSE (default), return bfh_qic_result S3 object. Preferred snake_case alias for
+#'   the legacy `return.data`.
+#' @param return.data Deprecated. Use `return_data` instead. Kept for backwards compatibility.
 #' @param language Character string specifying output language. One of
 #'   \code{"da"} (Danish, default) or \code{"en"} (English). Controls
 #'   three independent aspects of output (since v0.12.0):
@@ -95,14 +100,14 @@ NULL
 #'   Default \code{"da"} preserves backward compatibility for Danish users.
 #'
 #' @return
-#' - Default (return.data = FALSE): \code{bfh_qic_result} S3 object with components:
+#' - Default (return_data = FALSE): \code{bfh_qic_result} S3 object with components:
 #'   \itemize{
 #'     \item \code{$plot}: ggplot2 object with the SPC chart
 #'     \item \code{$summary}: data.frame with SPC statistics
 #'     \item \code{$qic_data}: data.frame with raw qicharts2 calculations
 #'     \item \code{$config}: list with original function parameters
 #'   }
-#' - return.data = TRUE: data.frame with qic calculations (legacy behavior)
+#' - return_data = TRUE: data.frame with qic calculations (legacy behavior)
 #'
 #' @details
 #' **Helper map (internal orchestration functions):**
@@ -364,7 +369,7 @@ NULL
 #'   chart_type = "i",
 #'   y_axis_unit = "count",
 #'   chart_title = "I-Chart Using Median",
-#'   agg.fun = "median"
+#'   agg_fun = "median"
 #' )
 #'
 #' # Example 8: Multiply y-values for unit conversion
@@ -515,7 +520,7 @@ NULL
 #'   y = infections,
 #'   chart_type = "i",
 #'   y_axis_unit = "count",
-#'   return.data = TRUE # Return data.frame instead of plot
+#'   return_data = TRUE # Return data.frame instead of plot
 #' )
 #'
 #' # Now you can access all qic calculations
@@ -662,6 +667,7 @@ bfh_qic <- function(data,
                     ylim = NULL,
                     multiply = 1,
                     agg.fun = c("mean", "median", "sum", "sd"),
+                    agg_fun = NULL,
                     base_size = 14,
                     width = NULL,
                     height = NULL,
@@ -673,11 +679,54 @@ bfh_qic <- function(data,
                     subtitle = NULL,
                     caption = NULL,
                     return.data = FALSE,
+                    return_data = NULL,
                     language = "da") {
   # ---- NSE + missing() flags kapteres FOERST i bfh_qic()-scopet ----
   # substitute(), missing() og parent.frame() er scope-sensitive:
   # de SKAL evalueres her, ikke inde i helpers.
-  agg_fun_supplied <- !missing(agg.fun)
+
+  # ---- Snake_case alias resolution ----
+  # agg_fun / return_data are the new preferred names;
+  # agg.fun / return.data are kept for backwards compatibility.
+  # Capture missing() BEFORE any reassignment.
+  dot_agg_fun_supplied <- !missing(agg.fun)
+  snake_agg_fun_supplied <- !is.null(agg_fun)
+
+  if (dot_agg_fun_supplied && snake_agg_fun_supplied) {
+    stop(
+      "Supply only one of 'agg_fun' or 'agg.fun', not both.",
+      call. = FALSE
+    )
+  }
+  if (dot_agg_fun_supplied) {
+    warning(
+      "'agg.fun' is deprecated. Use 'agg_fun' instead.",
+      call. = FALSE
+    )
+  }
+  if (snake_agg_fun_supplied) {
+    agg.fun <- agg_fun
+  }
+  agg_fun_supplied <- dot_agg_fun_supplied || snake_agg_fun_supplied
+
+  dot_return_data_supplied <- !missing(return.data)
+  snake_return_data_supplied <- !is.null(return_data)
+
+  if (dot_return_data_supplied && snake_return_data_supplied) {
+    stop(
+      "Supply only one of 'return_data' or 'return.data', not both.",
+      call. = FALSE
+    )
+  }
+  if (dot_return_data_supplied) {
+    warning(
+      "'return.data' is deprecated. Use 'return_data' instead.",
+      call. = FALSE
+    )
+  }
+  if (snake_return_data_supplied) {
+    return.data <- return_data
+  }
   base_size_supplied <- !missing(base_size)
   qic_envir <- parent.frame()
 

--- a/tests/testthat/test-snake-case-aliases.R
+++ b/tests/testthat/test-snake-case-aliases.R
@@ -1,0 +1,118 @@
+# ============================================================================
+# Tests for snake_case param aliases: agg_fun / return_data
+# Closes #429
+# ============================================================================
+
+# Shared minimal fixture
+make_alias_data <- function() {
+  data.frame(
+    month = seq(as.Date("2024-01-01"), by = "month", length.out = 12),
+    value = c(10, 12, 11, 13, 10, 14, 11, 12, 13, 10, 11, 12)
+  )
+}
+
+# ----------------------------------------------------------------------------
+# return_data alias
+# ----------------------------------------------------------------------------
+
+test_that("return_data = TRUE returns a data.frame", {
+  d <- make_alias_data()
+  result <- bfh_qic(d,
+    x = month, y = value, chart_type = "i",
+    return_data = TRUE
+  )
+  expect_s3_class(result, "data.frame")
+})
+
+test_that("return_data = FALSE returns bfh_qic_result", {
+  d <- make_alias_data()
+  result <- bfh_qic(d,
+    x = month, y = value, chart_type = "i",
+    return_data = FALSE
+  )
+  expect_s3_class(result, "bfh_qic_result")
+})
+
+test_that("return.data = TRUE still works with deprecation warning", {
+  d <- make_alias_data()
+  expect_warning(
+    {
+      result <- bfh_qic(d,
+        x = month, y = value, chart_type = "i",
+        return.data = TRUE
+      )
+    },
+    regexp = "return\\.data.*deprecated",
+    fixed = FALSE
+  )
+  expect_s3_class(result, "data.frame")
+})
+
+test_that("supplying both return_data and return.data errors", {
+  d <- make_alias_data()
+  expect_error(
+    bfh_qic(d,
+      x = month, y = value, chart_type = "i",
+      return.data = TRUE, return_data = TRUE
+    ),
+    regexp = "Supply only one of",
+    fixed = FALSE
+  )
+})
+
+# ----------------------------------------------------------------------------
+# agg_fun alias
+# ----------------------------------------------------------------------------
+
+test_that("agg_fun = 'median' is accepted and returns bfh_qic_result", {
+  d <- make_alias_data()
+  result <- bfh_qic(d,
+    x = month, y = value, chart_type = "i",
+    agg_fun = "median"
+  )
+  expect_s3_class(result, "bfh_qic_result")
+})
+
+test_that("agg.fun = 'median' still works with deprecation warning", {
+  d <- make_alias_data()
+  expect_warning(
+    {
+      result <- bfh_qic(d,
+        x = month, y = value, chart_type = "i",
+        agg.fun = "median"
+      )
+    },
+    regexp = "agg\\.fun.*deprecated",
+    fixed = FALSE
+  )
+  expect_s3_class(result, "bfh_qic_result")
+})
+
+test_that("supplying both agg_fun and agg.fun errors", {
+  d <- make_alias_data()
+  expect_error(
+    bfh_qic(d,
+      x = month, y = value, chart_type = "i",
+      agg.fun = "median", agg_fun = "mean"
+    ),
+    regexp = "Supply only one of",
+    fixed = FALSE
+  )
+})
+
+test_that("agg_fun and agg.fun produce the same result", {
+  d <- make_alias_data()
+
+  result_dot <- suppressWarnings(
+    bfh_qic(d,
+      x = month, y = value, chart_type = "i",
+      agg.fun = "median", return_data = TRUE
+    )
+  )
+  result_snake <- bfh_qic(d,
+    x = month, y = value, chart_type = "i",
+    agg_fun = "median", return_data = TRUE
+  )
+
+  expect_equal(result_snake$cl, result_dot$cl)
+})


### PR DESCRIPTION
## Summary

- Add `agg_fun` and `return_data` as the preferred snake_case params to `bfh_qic()`, consistent with all other API params
- Keep `agg.fun` and `return.data` working for backwards compatibility, each emitting a `warning()` deprecation notice on use
- Guard against supplying both old and new form simultaneously (raises `stop()`)
- Update `@param` roxygen docs and examples 7 + 19 to use the snake_case names

## Implementation details

Resolution order in `bfh_qic()`:

1. Capture `!missing(agg.fun)` / `!missing(return.data)` before any reassignment
2. If both dot.case and snake_case supplied → `stop()`
3. If only dot.case supplied → emit `warning()` (deprecation)
4. If only snake_case supplied → assign into the dot.case internal variable (no warning)
5. Downstream code (`validate_bfh_qic_inputs`, `build_qic_args`, etc.) is unchanged — it continues to use `agg.fun`/`return.data` internally

The `agg_fun_supplied` flag (used to gate forwarding to qicharts2) is set to `TRUE` when either form is supplied.

## Test plan

- [x] `return_data = TRUE` returns a data.frame
- [x] `return_data = FALSE` returns `bfh_qic_result`
- [x] `return.data = TRUE` still works with deprecation warning
- [x] Supplying both `return_data` and `return.data` errors
- [x] `agg_fun = "median"` is accepted and returns `bfh_qic_result`
- [x] `agg.fun = "median"` still works with deprecation warning
- [x] Supplying both `agg_fun` and `agg.fun` errors
- [x] `agg_fun` and `agg.fun` produce identical numerical results
- [x] ASCII source check passes (all warning/error strings are ASCII)
- [x] Full pre-push test suite passes (5600+ tests)