### PR TITLE
ci: add vdiffr visual regression workflow (closes #433)

### DIFF
--- a/.github/workflows/vdiffr.yaml
+++ b/.github/workflows/vdiffr.yaml
@@ -1,0 +1,115 @@
+# vdiffr visual regression tracking for BFHcharts.
+#
+# Purpose:
+#   Run vdiffr snapshot tests on each push to develop/main using
+#   DejaVu/Liberation as Mari (proprietary) font substitutes. This
+#   detects layout regressions even though snapshots were originally
+#   generated on macOS with Mari -- font-metric diffs are expected
+#   and intentional (regression detection, not pixel-perfect matching).
+#
+# Failure semantics:
+#   continue-on-error: true -- failures are VISIBLE in the Actions UI but
+#   non-blocking. Every run will likely show diffs because snapshots are
+#   Mari-based. Watch for NEW failures (changed layout, broken geometry)
+#   vs baseline drift (font-metric only). .new.svg artifacts are uploaded
+#   on failure for visual inspection.
+#
+# Opt-in gating:
+#   BFHCHARTS_VDIFFR_CI=true bypasses the CI-proxy skip in
+#   skip_if_no_mari_font() (helper-skips.R). Without this flag all
+#   vdiffr tests skip silently on CI.
+#
+# Trigger:
+#   push to develop/main only -- non-blocking regression tracking, not
+#   a PR gate. workflow_dispatch for manual runs.
+#
+# Security: only safe inputs used (GITHUB_TOKEN, static strings).
+# No untrusted user input forwarded to run steps.
+
+name: vdiffr visual regression
+
+on:
+  push:
+    branches: [develop, main]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  vdiffr:
+    runs-on: ubuntu-latest
+    name: vdiffr (ubuntu-latest)
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+      # Activate the full + render test layers so test helpers do not short-
+      # circuit before reaching vdiffr::expect_doppelganger().
+      BFHCHARTS_TEST_FULL: "true"
+      BFHCHARTS_TEST_RENDER: "true"
+      # Opt-in override: bypass skip_if_no_mari_font() CI-proxy skip so that
+      # vdiffr tests run with substitute fonts installed below.
+      BFHCHARTS_VDIFFR_CI: "true"
+      # testthat honours NOT_CRAN when called directly (not via R CMD check).
+      NOT_CRAN: "true"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system fonts (DejaVu/Liberation as Mari substitutes)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            fonts-dejavu \
+            fonts-liberation \
+            fonts-liberation2 \
+            fonts-noto \
+            fonts-noto-core \
+            fonts-roboto \
+            fontconfig
+          fc-cache -f -v
+        shell: bash
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: "release"
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::vdiffr any::pkgload any::testthat
+          needs: check
+
+      - name: Run vdiffr visual regression tests
+        # Failures are expected (font-metric diffs vs Mari baselines).
+        # Non-blocking: watch for novel geometry/layout failures.
+        continue-on-error: true
+        run: |
+          options(crayon.enabled = TRUE)
+          pkgload::load_all(".", quiet = TRUE)
+          res <- testthat::test_dir(
+            "tests/testthat",
+            filter = "visual-regression",
+            reporter = c("progress", "fail")
+          )
+          summary_df <- as.data.frame(res)
+          cat("\n\n========== vdiffr visual regression summary ==========\n")
+          cat("Total files: ", nrow(summary_df), "\n", sep = "")
+          cat("Failed:      ", sum(summary_df$failed > 0, na.rm = TRUE), "\n", sep = "")
+          cat("Skipped:     ", sum(summary_df$skipped, na.rm = TRUE), "\n", sep = "")
+          cat("Passed:      ", sum(summary_df$passed, na.rm = TRUE), "\n", sep = "")
+          cat("======================================================\n")
+        shell: Rscript {0}
+
+      - name: Upload vdiffr diff artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vdiffr-diffs-${{ github.run_id }}
+          path: |
+            tests/testthat/_snaps/**/*.new.svg
+            tests/testthat/_snaps/**/*.svg
+          retention-days: 14
+          if-no-files-found: warn

--- a/tests/testthat/README.md
+++ b/tests/testthat/README.md
@@ -42,6 +42,7 @@ Workflows:
 - `.github/workflows/render-tests.yaml` — Ugentlig live render-test suite (cron)
 - `.github/workflows/test-coverage.yml` — covr::codecov() rapportering
 - `.github/workflows/lint.yaml` — lintr (advisory)
+- `.github/workflows/vdiffr.yaml` — vdiffr visuel regression-tracking, push til develop/main (non-blocking, se nedenfor)
 
 #### CI Font-fallback strategi
 
@@ -56,18 +57,24 @@ CI anvender to komplementære strategier:
 - `ignore_system_fonts=TRUE` (Typst 0.13+) sikrer Typst kun bruger leverede fonts
 
 **vdiffr snapshot-tests:**
-- `skip_if_no_mari_font()` per test — skipper på CI (ingen Mari) uden at blokere suite
+- `skip_if_no_mari_font()` per test — skipper på CI (ingen Mari) i R-CMD-check og andre
+  standard-workflows. `vdiffr.yaml` sætter `BFHCHARTS_VDIFFR_CI=true` for at
+  bypass dette og køre tests med substitute-fonts (regression-detektion).
 - Snapshots re-baselinet ved: BFHtheme version-bump (forventede font-metric ændringer),
   bevidst layout-ændring, regression-fix
 - Commit-beskeden skal dokumentere årsag ved re-baseline
 
 **Opsummering af skip-logik for font-afhængige tests:**
 
-| Test type | CI-adfærd | Lokal adfærd (med Mari) |
-|-----------|-----------|------------------------|
-| vdiffr snapshots | SKIP (skip_if_no_mari_font) | PASS mod baselines |
-| PDF smoke render | PASS (åbne fallback-fonts) | PASS (Mari) |
-| Render-tests (ugentlig) | PASS (åbne fallback-fonts) | PASS (Mari) |
+| Test type | R-CMD-check CI | vdiffr.yaml CI | Lokal (med Mari) |
+|-----------|----------------|----------------|-----------------|
+| vdiffr snapshots | SKIP | FAIL/PASS (font-diffs forventede) | PASS mod baselines |
+| PDF smoke render | PASS (åbne fallback-fonts) | ikke relevant | PASS (Mari) |
+| Render-tests (ugentlig) | PASS (åbne fallback-fonts) | ikke relevant | PASS (Mari) |
+
+**vdiffr.yaml er altid rød** pga. font-metric-forskelle mellem Mari-baselines og DejaVu/Liberation
+substitute-fonts på CI. Det er korrekt og forventet. Nyt at bekymre sig om: ændringer i
+geometri, layer-rækkefølge, label-placering — ikke font-diffs alene.
 
 ---
 
@@ -77,6 +84,7 @@ CI anvender to komplementære strategier:
 |----------|---------|--------|
 | `BFHCHARTS_TEST_FULL` | ikke sat | Kører integration-tests ud over unit-tests |
 | `BFHCHARTS_TEST_RENDER` | ikke sat | Kører live render-tests (Quarto, PDF, PNG) |
+| `BFHCHARTS_VDIFFR_CI` | ikke sat | Bypass CI-skip i `skip_if_no_mari_font()` — bruges kun af `vdiffr.yaml` |
 
 **Status (2026-04-24):** Alle render/PDF-tests er migreret til de kanoniske helpers (`skip_if_not_render_test()` + `skip_if_no_quarto()`). Nye helpers `skip_if_no_quarto()` og `skip_if_no_mari_font()` tilføjet til `helper-skips.R`. Miljøvariablerne er sat i CI.
 
@@ -170,7 +178,10 @@ covr::report(cov)
 Vdiffr-snapshots beskytter mod utilsigtede visuelle regressioner i BFHcharts' plot-output.
 Golden images er i `tests/testthat/_snaps/visual-regression/`.
 
-**Tests kræver Mari-fonts** — `skip_if_fonts_unavailable()` skipper hele filen på CI og maskiner uden Mari.
+**Tests kræver Mari-fonts lokalt.** I standard-CI-workflows (R-CMD-check, pdf-smoke osv.)
+skipper `skip_if_no_mari_font()` alle tests når `CI=true` (ingen Mari tilgængelig). Se
+CI Font-fallback strategi ovenfor for den dedikerede `vdiffr.yaml`-workflow der kører
+tests med substitute-fonts til regression-detektion.
 
 ### Snapshot-politik
 
@@ -216,4 +227,4 @@ Genuine warnings propageres stadig — kun den specifikke PostScript-lookup-adva
 - `openspec/changes/strengthen-test-infrastructure/design.md` — tekniske beslutninger (D1-D10)
 - `openspec/changes/strengthen-test-infrastructure/tasks.md` — opgaver og status
 
-**Sidst opdateret:** 2026-04-27
+**Sidst opdateret:** 2026-06-12

--- a/tests/testthat/helper-skips.R
+++ b/tests/testthat/helper-skips.R
@@ -134,15 +134,26 @@ skip_if_fonts_unavailable <- function(
 
 #' Skip test hvis Mari-fonts (BFHtheme) ikke er installeret
 #'
-#' Kanonisk erstatning for `skip_if_fonts_unavailable()`. Forsøger faktisk
+#' Kanonisk erstatning for `skip_if_fonts_unavailable()`. Forsoeger faktisk
 #' font-detektion via `systemfonts::system_fonts()` hvis pakken er installeret,
 #' falder ellers tilbage til CI-detektion.
+#'
+#' Opt-in CI override: saet `BFHCHARTS_VDIFFR_CI=true` for at tillade
+#' vdiffr-tests at koere paa CI med substitute-fonts (DejaVu/Liberation).
+#' Font-metric diffs er forventede og fanges som continue-on-error fejl i
+#' `.github/workflows/vdiffr.yaml` (regression-detektion, ikke pixel-perfect).
 #'
 #' @param msg Besked der vises ved skip
 #' @keywords internal
 skip_if_no_mari_font <- function(
   msg = "Skipping: Mari fonts (BFHtheme) not available"
 ) {
+  # Opt-in CI override for vdiffr regression workflow. Bypass CI-proxy skip
+  # and let tests run with substitute fonts installed on the runner.
+  if (.read_env_flag("BFHCHARTS_VDIFFR_CI")) {
+    return(invisible(TRUE))
+  }
+
   # Eksplicit CI-skip: vdiffr-snapshots er rebaseret pa macOS med Mari;
   # CI Ubuntu uden Mari producerer divergerende SVG selv hvis systemfonts
   # detekterer en font-rest med "Mari" i navnet.


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/vdiffr.yaml` — runs vdiffr snapshot tests on push to develop/main
- Uses DejaVu/Liberation as Mari font substitutes (regression detection, not pixel-perfect)
- `continue-on-error: true` — visible in Actions UI but non-blocking
- `BFHCHARTS_VDIFFR_CI=true` bypasses the CI-proxy skip in `skip_if_no_mari_font()`
- Uploads `.new.svg` artifacts on failure for visual inspection

## Test plan
- [ ] Workflow triggers on push to develop after merge
- [ ] Test run shows vdiffr tests executing (not all skipped)
- [ ] Failures upload artifact correctly