### PR TITLE
test(coverage): fix Rd-coverage matching, benchmark skip, panel_measurement tests (#458-#460)

### DIFF
--- a/tests/testthat/test-note-placement-perf.R
+++ b/tests/testthat/test-note-placement-perf.R
@@ -1,13 +1,15 @@
 # Performance benchmark for place_note_labels()
 #
-# Skipped by default to keep CI fast. To run locally:
+# This test always runs (skip_on_cran only) to catch signature drift and
+# runtime errors. The strict 100ms timing gate is opt-in via RUN_BENCH=true:
+#
 #   RUN_BENCH=true Rscript -e 'devtools::test(filter = "note-placement-perf")'
 #
 # Baseline (pre-vectorization): ~600 ms / call on the 10 comments x ~50
 # segments fixture below. Vectorized target: <100 ms / call.
 
 test_that("place_note_labels stays under 100ms on realistic fixture", {
-  skip_if_not(identical(Sys.getenv("RUN_BENCH"), "true"))
+  skip_on_cran()
   skip_if_not_installed("bench")
 
   set.seed(42)
@@ -42,5 +44,14 @@ test_that("place_note_labels stays under 100ms on realistic fixture", {
       median_seconds * 1000
     )
   )
-  expect_lt(median_seconds, 0.1) # < 100 ms
+
+  # Always verify the function returns a finite timing (smoke test: no crash,
+  # no infinite loop, no NULL return).
+  expect_true(is.finite(median_seconds))
+
+  # Strict timing gate: only enforced when RUN_BENCH=true (CI runners vary too
+  # much for a hard 100ms wall-clock assertion in default runs).
+  if (identical(Sys.getenv("RUN_BENCH"), "true")) {
+    expect_lt(median_seconds, 0.1) # < 100 ms
+  }
 })

--- a/tests/testthat/test-public-api-contract.R
+++ b/tests/testthat/test-public-api-contract.R
@@ -9,22 +9,51 @@
 
 test_that("all NAMESPACE exports have a corresponding Rd file", {
   pkg_exports <- getNamespaceExports("BFHcharts")
-  man_dir <- system.file("help", package = "BFHcharts")
 
-  # Alternativt: brug devtools::load_all-stiknown man/ i package root
-  # Fallback naar pakken er loadet via load_all (help-dir er tomt)
-  if (!nzchar(man_dir) || !dir.exists(man_dir)) {
-    skip("Package not installed — run devtools::install() to test Rd coverage")
+  # Load Rd database: prefer installed package (R CMD check); fall back to
+  # in-tree man/ when running via devtools::test() (load_all empties help/).
+  rd_db <- tryCatch(tools::Rd_db(package = "BFHcharts"), error = function(e) list())
+  if (length(rd_db) == 0) {
+    # In-tree fallback: tests/testthat/ is two levels below package root
+    pkg_root_candidate <- tryCatch(
+      normalizePath(file.path(test_path(), "..", ".."), mustWork = FALSE),
+      error = function(e) NULL
+    )
+    in_tree_man <- if (!is.null(pkg_root_candidate)) {
+      file.path(pkg_root_candidate, "man")
+    }
+    if (!is.null(in_tree_man) && dir.exists(in_tree_man)) {
+      rd_db <- tryCatch(
+        suppressWarnings(tools::Rd_db(dir = pkg_root_candidate)),
+        error = function(e) list()
+      )
+    }
+  }
+  if (length(rd_db) == 0) {
+    skip("No Rd database available -- run devtools::document() first")
   }
 
-  # Rd filnavne (uden .Rd extension)
-  rd_names <- tools::Rd_db(package = "BFHcharts")
-  documented <- names(rd_names)
+  # Extract \\alias{} values from all Rd pages. Each export must appear as an
+  # exact alias in at least one Rd page. Using aliases (not filenames) correctly
+  # handles @rdname/@describeIn groups where multiple exports share one .Rd file.
+  # Previously used grepl(fn, rd_names) which caused false positives: e.g.
+  # "bfh_qic" matched "bfh_qic_result.Rd", hiding undocumented exports (#458).
+  alias_tag <- paste0(rawToChar(as.raw(0x5c)), "alias")
+  documented <- unique(unlist(lapply(rd_db, function(rd) {
+    out <- character(0)
+    for (item in rd) {
+      if (!is.null(attr(item, "Rd_tag")) && attr(item, "Rd_tag") == alias_tag) {
+        val <- item[[1]]
+        if (is.character(val)) out <- c(out, val)
+      }
+    }
+    out
+  })))
 
   for (fn in pkg_exports) {
     expect_true(
-      any(grepl(fn, documented, fixed = TRUE)),
-      info = paste0("Export '", fn, "' has no Rd page")
+      fn %in% documented,
+      info = paste0("Export '", fn, "' has no \\alias{} in any Rd page")
     )
   }
 })

--- a/tests/testthat/test-utils-panel-measurement.R
+++ b/tests/testthat/test-utils-panel-measurement.R
@@ -1,0 +1,156 @@
+# Direct unit tests for R/utils_panel_measurement.R
+#
+# utils_panel_measurement.R contains measure_panel_height_from_gtable() and
+# with_temporary_device(). These functions were previously only covered
+# transitively (via add_right_labels_marquee integration tests).
+#
+# Device-dependent tests use skip_on_cran() because they open graphics
+# devices, which is not available in CRAN check environments.
+
+# Helper: build a minimal valid gtable via ggplotGrob
+make_minimal_gtable <- function() {
+  p <- ggplot2::ggplot(
+    data.frame(x = 1:5, y = 1:5),
+    ggplot2::aes(x = x, y = y)
+  ) +
+    ggplot2::geom_point()
+  ggplot2::ggplotGrob(p)
+}
+
+# Helper: build a gtable with the panel grob renamed so no row is named "panel"
+make_no_panel_gtable <- function() {
+  g <- make_minimal_gtable()
+  g$layout$name[g$layout$name == "panel"] <- "not_a_panel"
+  g
+}
+
+# -----------------------------------------------------------------------
+# Happy path: returns a positive numeric height
+# -----------------------------------------------------------------------
+
+test_that("measure_panel_height_from_gtable returns positive numeric on valid gtable", {
+  skip_on_cran()
+
+  g <- make_minimal_gtable()
+  result <- BFHcharts:::measure_panel_height_from_gtable(g, device_width = 7, device_height = 7)
+
+  expect_type(result, "double")
+  expect_true(is.finite(result))
+  expect_gt(result, 0)
+  expect_lte(result, 7) # cannot exceed device height
+})
+
+# -----------------------------------------------------------------------
+# Fallback floor: when fixed rows consume all height, result is >= 0.1
+# -----------------------------------------------------------------------
+
+test_that("measure_panel_height_from_gtable floor is 0.1 when device_height is near zero", {
+  skip_on_cran()
+
+  g <- make_minimal_gtable()
+
+  # Open a real device so device_ready = TRUE path works without trying to
+  # open a 0.001-inch device (cairo_pdf would error on that).
+  tmp <- tempfile(fileext = ".pdf")
+  grDevices::cairo_pdf(tmp, width = 7, height = 7)
+  on.exit({
+    tryCatch(grDevices::dev.off(), error = function(e) NULL)
+    unlink(tmp, force = TRUE)
+  })
+
+  # device_height = 0.001 means device_height - fixed_total is very negative,
+  # so max(0.1, ...) kicks in and returns the floor value.
+  result <- BFHcharts:::measure_panel_height_from_gtable(
+    g,
+    device_width = 7,
+    device_height = 0.001,
+    device_ready = TRUE
+  )
+
+  expect_type(result, "double")
+  expect_equal(result, 0.1)
+})
+
+# -----------------------------------------------------------------------
+# Error on no-panel gtable: stop() is the documented behaviour
+# -----------------------------------------------------------------------
+
+test_that("measure_panel_height_from_gtable errors when gtable has no panel row", {
+  skip_on_cran()
+
+  g <- make_no_panel_gtable()
+  expect_error(
+    BFHcharts:::measure_panel_height_from_gtable(g),
+    regexp = "panel"
+  )
+})
+
+# -----------------------------------------------------------------------
+# Error on out-of-range panel index
+# -----------------------------------------------------------------------
+
+test_that("measure_panel_height_from_gtable errors when panel index exceeds panel count", {
+  skip_on_cran()
+
+  g <- make_minimal_gtable()
+  expect_error(
+    BFHcharts:::measure_panel_height_from_gtable(g, panel = 99),
+    regexp = "panel"
+  )
+})
+
+# -----------------------------------------------------------------------
+# NULL input errors immediately (no partial gtable parsing)
+# -----------------------------------------------------------------------
+
+test_that("measure_panel_height_from_gtable errors on NULL input", {
+  expect_error(
+    BFHcharts:::measure_panel_height_from_gtable(NULL)
+  )
+})
+
+# -----------------------------------------------------------------------
+# with_temporary_device: opens a device, runs code, restores device
+# -----------------------------------------------------------------------
+
+test_that("with_temporary_device restores the active device after use", {
+  skip_on_cran()
+
+  dev_before <- grDevices::dev.cur()
+
+  result <- BFHcharts:::with_temporary_device(
+    width_in = 7,
+    height_in = 7,
+    code = grDevices::dev.cur()
+  )
+
+  dev_after <- grDevices::dev.cur()
+
+  # Device should be restored to pre-call state
+  expect_equal(dev_after, dev_before)
+
+  # The code block ran inside a different device
+  expect_false(identical(result, dev_before))
+})
+
+test_that("with_temporary_device cleans up even when code errors", {
+  skip_on_cran()
+
+  dev_before <- grDevices::dev.cur()
+  n_devices_before <- length(grDevices::dev.list())
+
+  expect_error(
+    BFHcharts:::with_temporary_device(
+      width_in = 7,
+      height_in = 7,
+      code = stop("intentional error")
+    )
+  )
+
+  dev_after <- grDevices::dev.cur()
+  n_devices_after <- length(grDevices::dev.list())
+
+  # No leaked device
+  expect_equal(n_devices_after, n_devices_before)
+  expect_equal(dev_after, dev_before)
+})


### PR DESCRIPTION
## Summary
- **#458**: Rd-coverage contract now uses exact alias matching (was `grepl` substring — masked undocumented exports). Now runs 47 tests with 0 skips under `devtools::test()`.
- **#459**: Benchmark removes over-restrictive `RUN_BENCH=true` gate; now runs as smoke test on every run (timing gate still opt-in via env var to avoid CI flakiness on slow runners). Median: ~25ms.
- **#460**: 14 new direct unit tests for `utils_panel_measurement.R` covering happy path, floor fallback, NULL input, device cleanup.

## Test plan
- [ ] 5803 pass (19 new), 70 skip
- [ ] Rd-coverage test runs 47 tests (not skipped)
- [ ] CI passes

closes #458, closes #459, closes #460