### PR TITLE
perf: cache locale resolution + skip marquee grob for empty labels (#461, #463)

### DIFF
--- a/R/utils_label_placement.R
+++ b/R/utils_label_placement.R
@@ -42,6 +42,15 @@ estimate_label_heights_npc <- function(
 
   measure_all <- function() {
     purrr::map(texts, ~ {
+      # Fix #463: skip grob build + measurement for empty/NA labels.
+      # Return same shape as the internal function's fallback branch.
+      if (is.na(.x) || !nzchar(trimws(.x))) {
+        if (return_details) {
+          return(list(npc = fallback_npc, inches = NA_real_, panel_height_inches = panel_height_inches))
+        } else {
+          return(fallback_npc)
+        }
+      }
       tryCatch(
         .estimate_label_height_npc_internal(
           text = .x,

--- a/R/utils_x_axis_formatting.R
+++ b/R/utils_x_axis_formatting.R
@@ -19,9 +19,40 @@
   )
 }
 
+# Package-level cache: maps language -> resolved locale string (or NA if none
+# worked). Avoids re-running the candidate search on every label evaluation.
+# NA sentinel means "we tried and nothing worked" -- do not re-search.
+.locale_cache <- new.env(parent = emptyenv())
+
+# Resolve the best available LC_TIME locale for a language, caching the result.
+# Returns the winning locale string, or NA_character_ if none is available.
+.resolve_locale_for_language <- function(language, candidates) {
+  if (exists(language, envir = .locale_cache)) {
+    return(.locale_cache[[language]])
+  }
+  resolved <- NA_character_
+  for (loc in candidates) {
+    ok <- tryCatch(
+      suppressWarnings({
+        set <- Sys.setlocale("LC_TIME", loc)
+        !identical(set, "")
+      }),
+      error = function(e) FALSE
+    )
+    if (isTRUE(ok)) {
+      resolved <- loc
+      break
+    }
+  }
+  .locale_cache[[language]] <- resolved
+  resolved
+}
+
 # Wrap en label-funktion saa den evaluerer med passende LC_TIME-locale.
 # Bevarer original locale via on.exit-restore; fejl ved locale-set logges
 # stilfaerdigt (ikke fatal) saa cross-platform robusthed bevares.
+# Fix #461: locale candidate resolution is cached per language after the first
+# call; subsequent calls skip the search loop and use the cached winner.
 with_lc_time_labeler <- function(label_fn, language = "da") {
   if (!is.function(label_fn)) {
     return(label_fn)
@@ -33,15 +64,9 @@ with_lc_time_labeler <- function(label_fn, language = "da") {
   function(x) {
     current <- Sys.getlocale("LC_TIME")
     on.exit(suppressWarnings(Sys.setlocale("LC_TIME", current)), add = TRUE)
-    for (loc in candidates) {
-      ok <- tryCatch(
-        suppressWarnings({
-          set <- Sys.setlocale("LC_TIME", loc)
-          !identical(set, "")
-        }),
-        error = function(e) FALSE
-      )
-      if (isTRUE(ok)) break
+    resolved <- .resolve_locale_for_language(language, candidates)
+    if (!is.na(resolved)) {
+      suppressWarnings(Sys.setlocale("LC_TIME", resolved))
     }
     label_fn(x)
   }


### PR DESCRIPTION
## Summary
- **#461**: Package-level `.locale_cache` environment — locale candidate loop runs once per language per process lifetime (not per label). Subsequent calls return cached result immediately.
- **#463**: Early-exit guard in `estimate_label_heights_npc()` before `.estimate_label_height_npc_internal()` — skips `marquee::marquee_grob()` creation + grob measurement when label is `NA` or empty string.

## Test plan
- [ ] 5770 pass, 70 skip (pre-existing quarto-isolation flaky)
- [ ] CI passes

closes #461, closes #463