### PR TITLE
fix(bugs): bfh_reset_caches() covers all caches + PDF export respects chart language (#419, #439)

### DIFF
--- a/R/analysis_core.R
+++ b/R/analysis_core.R
@@ -226,7 +226,9 @@ bfh_build_analysis_context <- function(x, metadata = list()) {
 #'   relative-to-target tolerance. Passing a non-default value emits a
 #'   deprecation warning. The parameter will be removed in the next major
 #'   release.
-#' @param language Character string specifying output language. One of \code{"da"} (Danish, default) or \code{"en"} (English). Default \code{"da"} preserves backward compatibility.
+#' @param language Character string specifying output language. One of \code{"da"} (Danish) or \code{"en"} (English).
+#'   Default \code{NULL} inherits the language stored in \code{x$config$language} (set via \code{bfh_qic(language=)}).
+#'   Falls back to \code{"da"} when the chart carries no language (pre-v0.26 objects).
 #' @param texts_loader Function that returns SPC analysis text templates.
 #'   Defaults to \code{load_spc_texts(language)}. Primarily intended for tests/mocking.
 #'
@@ -319,7 +321,7 @@ bfh_generate_analysis <- function(x,
                                   min_chars = 300,
                                   max_chars = 375,
                                   target_tolerance = 0.05,
-                                  language = "da",
+                                  language = NULL,
                                   texts_loader = NULL) {
   # target_tolerance er deprecated -- value-neutral at_target-klassifikation
   # bruger nu processens variation (sigma_hat / sd(y)) i stedet for relativ-
@@ -342,6 +344,13 @@ bfh_generate_analysis <- function(x,
   # Input validation
   if (!inherits(x, "bfh_qic_result")) {
     stop("x must be a bfh_qic_result object from bfh_qic()", call. = FALSE)
+  }
+
+  # Inherit language from chart's config when caller does not supply it.
+  # Falls back to "da" for backward compatibility (pre-#419 callers that
+  # did not pass language= relied on the "da" default).
+  if (is.null(language)) {
+    language <- x$config$language %||% "da"
   }
 
   validate_language(language)

--- a/R/cache_reset.R
+++ b/R/cache_reset.R
@@ -5,19 +5,24 @@
 #' - `.marquee_style_cache`: marquee style-objekter per lineheight
 #' - `.quarto_cache`: Quarto CLI tilgaengelighed og sti
 #' - `.i18n_cache`: i18n YAML-tekster per sprog
+#' - `.bfh_template_cache`: staged Typst template-mappe (zzz.R)
+#' - `.dep_guard_cache`: BFHtheme version-check resultater (utils_dep_guards.R)
 #'
 #' Bruges primaert i testmiljoe for at sikre reproducerbare resultater
-#' paa tvaers af tests der aendrer fonts eller Quarto-konfiguration.
+#' paa tvaers af tests der aendrer fonts, Quarto-konfiguration eller
+#' dependency-status.
 #'
 #' @return invisible(NULL)
 #' @keywords internal
 #' @noRd
 bfh_reset_caches <- function() {
   caches <- list(
-    .font_cache,
-    .marquee_style_cache,
-    .quarto_cache,
-    .i18n_cache
+    .font_cache, # utils_add_right_labels_marquee.R
+    .marquee_style_cache, # utils_label_helpers.R
+    .quarto_cache, # utils_quarto.R
+    .i18n_cache, # utils_i18n.R
+    .bfh_template_cache, # zzz.R
+    .dep_guard_cache # utils_dep_guards.R
   )
   for (cache in caches) {
     rm(list = ls(envir = cache), envir = cache)

--- a/tests/testthat/test-analysis_core.R
+++ b/tests/testthat/test-analysis_core.R
@@ -197,7 +197,8 @@ test_that("bfh_generate_analysis has correct default values", {
   expect_equal(fn_args$min_chars, 300)
   expect_equal(fn_args$max_chars, 375)
   expect_null(fn_args$texts_loader)
-  expect_equal(as.character(fn_args$language), "da")
+  # language=NULL: inherits from chart config (#419); falls back to "da"
+  expect_null(fn_args$language)
 })
 
 test_that("bfh_generate_analysis validates min_chars < max_chars", {
@@ -1262,4 +1263,47 @@ test_that("bfh_generate_analysis does NOT warn when target_tolerance omitted", {
     }
   )
   succeed("Default-kald fyrer ikke target_tolerance-deprecation")
+})
+
+# ==============================================================================
+# Issue 419: bfh_generate_analysis() inherits language from bfh_qic_result
+# ==============================================================================
+
+test_that("bfh_generate_analysis() inherits language='en' from chart config (#419)", {
+  d <- fixture_minimal_chart_data(n = 24)
+  result_en <- bfh_qic(d,
+    x = month, y = infections, chart_type = "run",
+    language = "en"
+  )
+
+  # When language= is omitted, analysis should be in English (inherited from chart)
+  analysis <- bfh_generate_analysis(result_en)
+
+  # English output contains English keywords, not Danish ones
+  expect_match(analysis,
+    "(stable|predictable|improvement|signal|process)",
+    ignore.case = TRUE
+  )
+  expect_no_match(analysis, "Processen", ignore.case = FALSE)
+})
+
+test_that("bfh_generate_analysis() explicit language= overrides chart config (#419)", {
+  d <- fixture_minimal_chart_data(n = 24)
+  result_en <- bfh_qic(d,
+    x = month, y = infections, chart_type = "run",
+    language = "en"
+  )
+
+  # Explicit language="da" must override chart config
+  analysis_da <- bfh_generate_analysis(result_en, language = "da")
+  expect_match(analysis_da, "Processen", ignore.case = FALSE)
+})
+
+test_that("bfh_generate_analysis() defaults to 'da' for charts without language (#419)", {
+  d <- fixture_minimal_chart_data(n = 24)
+  result <- bfh_qic(d, x = month, y = infections, chart_type = "run")
+
+  # No explicit language -> inherits "da" from config
+  analysis <- bfh_generate_analysis(result)
+  expect_match(analysis, "Processen", ignore.case = FALSE)
 })

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -19,10 +19,19 @@ test_that("font-cache: samme fontfamily giver cache hit (kun 1 entry)", {
   expect_equal(length(cache_keys), 1L)
 })
 
-test_that("bfh_reset_caches() tømmer alle caches", {
-  # Fyld caches
+test_that("bfh_reset_caches() tommer alle caches (#439)", {
+  # Fyld samtlige 6 caches foer reset.
+  # Caches er environments (reference semantics); hold en lokal reference
+  # og tildel via assign() saa testmiljoejet kan mutere package-state.
   BFHcharts:::.resolve_font_family("sans")
   BFHcharts:::get_right_aligned_marquee_style(0.9)
+  BFHcharts:::i18n_lookup("labels.misc.ukendt", "da")
+
+  dep_env <- BFHcharts:::.dep_guard_cache
+  assign("testkey", TRUE, envir = dep_env)
+
+  tpl_env <- BFHcharts:::.bfh_template_cache
+  assign("dir", "/tmp", envir = tpl_env)
 
   bfh_reset_caches()
 
@@ -30,6 +39,9 @@ test_that("bfh_reset_caches() tømmer alle caches", {
   expect_equal(length(ls(envir = BFHcharts:::.marquee_style_cache)), 0L)
   expect_equal(length(ls(envir = BFHcharts:::.quarto_cache)), 0L)
   expect_equal(length(ls(envir = BFHcharts:::.i18n_cache)), 0L)
+  # Previously missing from bfh_reset_caches():
+  expect_equal(length(ls(envir = BFHcharts:::.bfh_template_cache)), 0L)
+  expect_equal(length(ls(envir = BFHcharts:::.dep_guard_cache)), 0L)
 })
 
 test_that("marquee style-cache: identiske lineheights giver kun 1 entry", {


### PR DESCRIPTION
## Summary
- **#439**: `bfh_reset_caches()` now clears all 6 caches — was missing `.bfh_template_cache` (Typst template staging) and `.dep_guard_cache` (BFHtheme version-check). Added comments cross-referencing defining files to prevent future drift.
- **#419**: `bfh_generate_analysis()` default changed from `language = "da"` → `language = NULL`. When NULL, inherits from `x$config$language %||% "da"`. Charts created with `language = "en"` now produce English auto-analysis in PDF export.

## Test plan
- [ ] 3 new tests for language inheritance (en inherits, da override, da default)
- [ ] Extended cache test verifies all 6 caches are cleared
- [ ] 5776 pass, 70 skip
- [ ] CI passes

closes #419, closes #439