### PR TITLE
refactor: globalVariables cleanup, commonmark/xml2 to Suggests, deprecate return.data (#444, #448, #449)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,12 +35,12 @@ Imports:
     lemon,
     marquee (>= 0.1.0),
     grid,
-    commonmark (>= 1.9),
-    xml2,
     systemfonts,
     rlang,
     svglite
 Suggests:
+    commonmark (>= 1.9),
+    xml2,
     testthat (>= 3.1.7),
     vdiffr,
     covr,

--- a/R/bfh_qic.R
+++ b/R/bfh_qic.R
@@ -81,10 +81,12 @@ NULL
 #' @param xlab X-axis label (default: "" for blank)
 #' @param subtitle Plot subtitle text (default: NULL for no subtitle)
 #' @param caption Plot caption text (default: NULL for no caption)
-#' @param return_data Logical. If TRUE, return the raw qic data frame instead of bfh_qic_result
-#'   object. If FALSE (default), return bfh_qic_result S3 object. Preferred snake_case alias for
-#'   the legacy `return.data`.
-#' @param return.data Deprecated. Use `return_data` instead. Kept for backwards compatibility.
+#' @param return_data Logical. **Deprecated**: `TRUE` is type-unstable and will be removed in
+#'   a future version. Use [bfh_extract_spc_stats()] to access the underlying SPC data frame.
+#'   If TRUE, returns the raw qic data frame; if FALSE (default), returns a `bfh_qic_result`
+#'   S3 object. Preferred snake_case alias for the legacy `return.data`.
+#' @param return.data **Deprecated**. Use `return_data` instead. Kept for backwards
+#'   compatibility. Passing `TRUE` emits a deprecation warning.
 #' @param language Character string specifying output language. One of
 #'   \code{"da"} (Danish, default) or \code{"en"} (English). Controls
 #'   three independent aspects of output (since v0.12.0):
@@ -726,6 +728,15 @@ bfh_qic <- function(data,
   }
   if (snake_return_data_supplied) {
     return.data <- return_data
+  }
+  # Deprecation warning for type-unstable return value (return.data = TRUE).
+  # Separate from the spelling deprecation above (return.data vs return_data).
+  if (isTRUE(return.data)) {
+    warning(
+      "return.data = TRUE is deprecated and will be removed in a future version. ",
+      "Use bfh_extract_spc_stats(result) to access the underlying SPC data frame.",
+      call. = FALSE
+    )
   }
   base_size_supplied <- !missing(base_size)
   qic_envir <- parent.frame()

--- a/R/export_pdf.R
+++ b/R/export_pdf.R
@@ -313,6 +313,11 @@ bfh_export_pdf <- function(x,
                            inject_assets = NULL,
                            batch_session = NULL,
                            strict_baseline) {
+  rlang::check_installed(
+    c("commonmark", "xml2"),
+    reason = "for PDF/Typst export (markdown rendering in document fields)"
+  )
+
   # strict_baseline: per-call > session > default(TRUE).
   # missing()-flag fanges FOERST i orchestrator-scopet (NSE-sensitive).
   strict_baseline_supplied <- !missing(strict_baseline)

--- a/R/globals.R
+++ b/R/globals.R
@@ -4,16 +4,11 @@ NULL
 # Global variables for NSE in ggplot2/dplyr
 # Suppresses R CMD check NOTEs about "no visible binding"
 
-utils::globalVariables(c(
-  # ggplot2 aesthetics
-  "x", "y", "lcl", "ucl", "target", "cl",
-  "label", "color", "vjust",
-
-  # dplyr/qicharts2 columns
-  "part", "anhoej.signal",
-  "n.crossings", "n.crossings.min",
-  "part_n_cross", "part_n_cross_min"
-))
+# All ggplot2 aes() calls now use the .data pronoun (e.g. .data[["x"]]) so
+# no bare column names need to be declared here. Keep this block as a
+# reminder that globalVariables() should only list names that genuinely
+# cannot be expressed via .data or rlang::.data in NSE contexts.
+# utils::globalVariables(character(0))
 
 # ============================================================================
 # SIZING CONSTANTS

--- a/R/plot_core.R
+++ b/R/plot_core.R
@@ -154,7 +154,7 @@ bfh_spc_plot <- function(qic_data,
   comment_data <- extract_comment_data(qic_data, max_length = 100)
 
   # Build base plot ----
-  plot <- ggplot2::ggplot(qic_data, ggplot2::aes(x = x, y = y))
+  plot <- ggplot2::ggplot(qic_data, ggplot2::aes(x = .data[["x"]], y = .data[["y"]]))
 
   # Pre-compute layers for performance
   plot_layers <- list()
@@ -164,19 +164,19 @@ bfh_spc_plot <- function(qic_data,
     !is.null(qic_data$lcl) && !all(is.na(qic_data$lcl))) {
     plot_layers <- c(plot_layers, list(
       ggplot2::geom_ribbon(
-        ggplot2::aes(ymin = lcl, ymax = ucl, group = part),
+        ggplot2::aes(ymin = .data[["lcl"]], ymax = .data[["ucl"]], group = .data[["part"]]),
         fill = cols$very_light_blue,
         alpha = 0.5
       ),
       ggplot2::geom_line(
-        ggplot2::aes(y = ucl, x = x, group = part),
+        ggplot2::aes(y = .data[["ucl"]], x = .data[["x"]], group = .data[["part"]]),
         inherit.aes = FALSE,
         linewidth = ucl_linewidth,
         colour = cols$light_blue,
         na.rm = TRUE
       ),
       ggplot2::geom_line(
-        ggplot2::aes(y = lcl, x = x, group = part),
+        ggplot2::aes(y = .data[["lcl"]], x = .data[["x"]], group = .data[["part"]]),
         inherit.aes = FALSE,
         linewidth = ucl_linewidth,
         colour = cols$light_blue,
@@ -189,7 +189,7 @@ bfh_spc_plot <- function(qic_data,
   if (!suppress_targetline && !is.null(qic_data$target) && any(!is.na(qic_data$target))) {
     plot_layers <- c(plot_layers, list(
       ggplot2::geom_line(
-        ggplot2::aes(y = target, x = x),
+        ggplot2::aes(y = .data[["target"]], x = .data[["x"]]),
         inherit.aes = FALSE,
         linewidth = target_linewidth,
         colour = cols$dark_grey,
@@ -205,21 +205,21 @@ bfh_spc_plot <- function(qic_data,
       # Drop NA-y rows so the line connects across missing observations
       # within the same part; part boundaries still break the line via group.
       data = function(d) d[!is.na(d$y), ],
-      ggplot2::aes(y = y, group = part),
+      ggplot2::aes(y = .data[["y"]], group = .data[["part"]]),
       colour = cols$grey,
       linewidth = data_linewidth,
       na.rm = TRUE
     ),
     ggplot2::geom_point(
-      ggplot2::aes(y = y, group = part),
+      ggplot2::aes(y = .data[["y"]], group = .data[["part"]]),
       colour = qic_data$point_colour,
       size = point_size,
       na.rm = TRUE
     ),
     ggplot2::geom_line(
       ggplot2::aes(
-        y = cl, group = part,
-        linetype = anhoej.signal
+        y = .data[["cl"]], group = .data[["part"]],
+        linetype = .data[["anhoej.signal"]]
       ),
       color = cols$blue,
       linewidth = cl_linewidth

--- a/R/plot_enhancements.R
+++ b/R/plot_enhancements.R
@@ -124,7 +124,7 @@ add_plot_enhancements <- function(plot,
       plot <- plot +
         ggplot2::geom_line(
           data = cl_ext,
-          ggplot2::aes(x = x, y = y),
+          ggplot2::aes(x = .data[["x"]], y = .data[["y"]]),
           color = cols$blue,
           linewidth = cl_linewidth,
           linetype = cl_ext$linetype[1],
@@ -138,7 +138,7 @@ add_plot_enhancements <- function(plot,
       plot <- plot +
         ggplot2::geom_line(
           data = target_ext,
-          ggplot2::aes(x = x, y = y),
+          ggplot2::aes(x = .data[["x"]], y = .data[["y"]]),
           color = cols$dark_grey,
           linewidth = target_linewidth,
           linetype = "42",

--- a/R/utils_add_right_labels_marquee.R
+++ b/R/utils_add_right_labels_marquee.R
@@ -690,7 +690,7 @@ add_right_labels_marquee <- function(
     result <- result +
       marquee::geom_marquee(
         data = label_data,
-        ggplot2::aes(x = x, y = y, label = label, color = color, vjust = vjust),
+        ggplot2::aes(x = .data[["x"]], y = .data[["y"]], label = .data[["label"]], color = .data[["color"]], vjust = .data[["vjust"]]),
         hjust = 1,
         style = right_aligned_style,
         size = marquee_size,

--- a/R/utils_typst.R
+++ b/R/utils_typst.R
@@ -62,6 +62,11 @@ bfh_create_typst_document <- function(chart_image,
                                       template = "bfh-diagram",
                                       template_path = NULL,
                                       skip_template_copy = FALSE) {
+  rlang::check_installed(
+    c("commonmark", "xml2"),
+    reason = "for PDF/Typst export (markdown rendering in document fields)"
+  )
+
   # Validate output and chart_image paths to prevent traversal/injection
   validate_export_path(output)
   validate_export_path(chart_image)


### PR DESCRIPTION
## Summary
- **#449**: Removed 12 ultra-generic names from `globalVariables()`. Switched bare `aes(x, y, ...)` to `.data[["name"]]` pronouns in plot_core.R, plot_enhancements.R, utils_add_right_labels_marquee.R.
- **#448**: `commonmark` + `xml2` moved from `Imports:` to `Suggests:`. Added `rlang::check_installed()` guards at entry points `bfh_create_typst_document()` and `bfh_export_pdf()`.
- **#444**: `return.data = TRUE` emits deprecation warning pointing to `bfh_extract_spc_stats()`. Roxygen `@param` updated.

## Test plan
- [ ] 5770 pass, 70 skip (pre-existing quarto-isolation flaky)
- [ ] `devtools::check()` — no new NOTEs from removed globalVariables
- [ ] CI passes

closes #444, closes #448, closes #449