### PR TITLE
chore(release): bump version to 0.26.1 + add NEWS entry

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BFHcharts
 Title: SPC Visualization for Healthcare Quality Improvement
-Version: 0.26.0
+Version: 0.26.1
 Authors@R: c(
     person(
       "Johan", "Reventlow",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,58 @@
+# BFHcharts 0.26.1
+
+## Bugfixes
+
+* `bfh_reset_caches()` nulstiller nu alle caches (inkl. locale- og
+  panel-hoejde-cachen). Tidligere blev kun analyse-cachen ryddet.
+  (#499, closes #419)
+
+* PDF-eksport anvender nu korrekt sproget fra `bfh_qic(language =)` i stedet
+  for altid at bruge dansk. (#499, closes #439)
+
+* `bfh_qic()` beregner ikke laengere automatisk gennemsnit som centrallinje
+  ved ikke-run-diagrammer. Guard tilfoejet saa auto-mean-substitution kun
+  sker for `chart_type = "run"`. (#501, closes #462)
+
+* Validering: `chart_type` afviser nu vectors med laengde > 1, `target_value`
+  afviser ikke-numeriske vaerdier, og `width`/`height` afviser negative tal.
+  (`#494`, closes #454, #455, #456)
+
+* `bfh_export_pdf()` og `bfh_export_png()` anvender konsistent validering af
+  `output`-stien. (#494, closes #457)
+
+## Performance
+
+* Locale-opslag (`Sys.getlocale()`) caches nu per R-session -- eliminerer
+  gentagne systemkald ved seriel PDF-eksport. (#498, closes #461)
+
+* Marquee-grobs springes over for tomme labels -- sparer render-tid ved
+  diagrammer med faa annotationer. (#498, closes #463)
+
+## Interne aendringer
+
+* `R/utils_bfh_qic_helpers.R` omdoebt til `R/bfh_qic_core.R` for at afspejle
+  indholdet. (#501, closes #438)
+
+* CI-pipeline blokkerer nu ved WARNINGs (ikke kun ERRORs) under
+  `R CMD check --as-cran`. (#501, closes #152)
+
+* `commonmark` og `xml2` flyttet fra `Imports` til `Suggests` -- reducerer
+  obligatoriske afhaengigheder. (#500, closes #444)
+
+* `format_time_danish` og `format_time_english` (interne hjaelpere) fjernet --
+  erstattet af `format_duration_label()`. (#496, closes #440)
+
+* `return.data`-parameteren i `bfh_qic()` er nu deprekereret til fordel for
+  `return_data` (snake_case). Deprekerings-advarsel vises ved brug af
+  dot.case-formen. (#500, closes #449)
+
+* `validate_bfh_qic_inputs()` kraever nu named-only argumenter ud over `data`.
+  Forhindrer stille positionelle fejl ved fremtidig refaktorering. (#502,
+  closes #452)
+
+* `print.viewport_dims` viser ikke laengere fejlagtigt "px" som enhed --
+  objektet er enhedsagnostisk. (#502, closes #443)
+
 # BFHcharts 0.26.0
 
 ## Nye features


### PR DESCRIPTION
## Summary
- Bump `DESCRIPTION` Version: 0.26.0 → 0.26.1
- Add `# BFHcharts 0.26.1` entry to NEWS.md covering all Phase 4 changes

## Phase 4 indhold (10 PRs, #493–#502)
- Bug fixes: cache reset, PDF language, auto-mean guard, input validation (#419, #439, #454–#457, #462)
- Performance: locale caching, marquee skip (#461, #463)
- Refactoring: file rename, dead code, globalVariables, Suggests (#438, #440, #443, #444, #448, #449, #450, #452)
- CI: warning gate (#152)

## Checklist
- [x] `devtools::check()` ren på CI (alle 10 PRs grønne)
- [x] DESCRIPTION Version bumpet
- [x] NEWS.md entry tilføjet
- [x] Ingen nye exports → NAMESPACE uændret
- [ ] Merge til develop
- [ ] Derefter: develop → main via PR #503 (opdateret)
- [ ] Annoteret tag `v0.26.1` efter main-merge